### PR TITLE
Fix block indexing and closure in OpenAI account stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Everything runs locally. There is no hosted CCPG service, no telemetry, no accou
 ccpg --<provider>
 ```
 
+> [!WARNING]
+> If your `.claude/settings.json` or `.claude/settings.local.json` has an `env` block with `ANTHROPIC_AUTH_TOKEN` or `ANTHROPIC_BASE_URL`, **remove those entries before launching via `ccpg`**. Those env vars override the gateway endpoint and prevent CCPG from routing requests correctly.
+
 After that, switch providers per session:
 
 ```bash
@@ -205,6 +208,9 @@ Then:
 ```bash
 ccpg --DeepSeek
 ```
+
+> [!WARNING]
+> If your `.claude/settings.json` or `.claude/settings.local.json` has an `env` block containing `ANTHROPIC_AUTH_TOKEN` or `ANTHROPIC_BASE_URL`, **remove those entries**. They override the gateway endpoint and prevent CCPG from intercepting Claude Code's requests.
 
 Any arguments after the provider flag are passed to Claude Code:
 

--- a/packages/daemon/src/proxy/providers/openai-account-stream.ts
+++ b/packages/daemon/src/proxy/providers/openai-account-stream.ts
@@ -17,10 +17,10 @@ export function transformOpenAIAccountResponsesStream(
   inputTokens: number,
 ): ReadableStream<string> {
   let buffer = ''
-  let textBlockStarted = false
+  let textBlockIndex = -1
+  let nextAvailableIndex = 0
   let outputTokens = 0
   let finished = false
-  let nextBlockIndex = 0
   const toolBlocks = new Map<string, { index: number; id: string; name: string }>()
   const decoder = new TextDecoder()
 
@@ -31,6 +31,11 @@ export function transformOpenAIAccountResponsesStream(
 
       enq(ssePing())
       enq(sseMessageStart(messageId, model, inputTokens))
+
+      const closeOpenBlocks = () => {
+        if (textBlockIndex !== -1) enq(sseContentBlockStop(textBlockIndex))
+        for (const tool of toolBlocks.values()) enq(sseContentBlockStop(tool.index))
+      }
 
       try {
         while (true) {
@@ -53,31 +58,31 @@ export function transformOpenAIAccountResponsesStream(
             if (type === 'response.output_text.delta') {
               const delta = typeof event['delta'] === 'string' ? event['delta'] : ''
               if (!delta) continue
-              if (!textBlockStarted) {
-                enq(sseContentBlockStart(nextBlockIndex, { type: 'text', text: '' }))
-                textBlockStarted = true
+              if (textBlockIndex === -1) {
+                textBlockIndex = nextAvailableIndex++
+                enq(sseContentBlockStart(textBlockIndex, { type: 'text', text: '' }))
               }
-              enq(sseContentBlockDelta(nextBlockIndex, { type: 'text_delta', text: delta }))
+              enq(sseContentBlockDelta(textBlockIndex, { type: 'text_delta', text: delta }))
             }
 
             if (type === 'response.output_item.added') {
               const item = event['item'] as Record<string, unknown> | undefined
               if (item?.['type'] === 'function_call') {
                 const callKey = String(item['id'] ?? item['call_id'] ?? randomUUID())
-                const blockIndex = textBlockStarted
-                  ? nextBlockIndex + 1 + toolBlocks.size
-                  : nextBlockIndex + toolBlocks.size
-                toolBlocks.set(callKey, {
-                  index: blockIndex,
-                  id: String(item['call_id'] ?? callKey),
-                  name: String(item['name'] ?? ''),
-                })
-                enq(sseContentBlockStart(blockIndex, {
-                  type: 'tool_use',
-                  id: String(item['call_id'] ?? callKey),
-                  name: String(item['name'] ?? ''),
-                  input: {},
-                }))
+                if (!toolBlocks.has(callKey)) {
+                  const blockIndex = nextAvailableIndex++
+                  toolBlocks.set(callKey, {
+                    index: blockIndex,
+                    id: String(item['call_id'] ?? callKey),
+                    name: String(item['name'] ?? ''),
+                  })
+                  enq(sseContentBlockStart(blockIndex, {
+                    type: 'tool_use',
+                    id: String(item['call_id'] ?? callKey),
+                    name: String(item['name'] ?? ''),
+                    input: {},
+                  }))
+                }
               }
             }
 
@@ -99,14 +104,14 @@ export function transformOpenAIAccountResponsesStream(
           }
         }
 
-        if (textBlockStarted) enq(sseContentBlockStop(nextBlockIndex))
-        for (const tool of toolBlocks.values()) enq(sseContentBlockStop(tool.index))
+        closeOpenBlocks()
         enq(sseMessageDelta(toolBlocks.size ? 'tool_use' : 'end_turn', outputTokens))
         enq(sseMessageStop())
       } catch (err) {
+        closeOpenBlocks()
         enq(sseError('api_error', String(err)))
       } finally {
-        if (!finished && !textBlockStarted && toolBlocks.size === 0) {
+        if (!finished && textBlockIndex === -1 && toolBlocks.size === 0) {
           enq(sseError('api_error', 'OpenAI Account stream ended without a completed response'))
         }
         controller.close()


### PR DESCRIPTION
## Description

This PR fixes how `openai-account-stream.ts` builds Anthropic-compatible SSE content blocks from the OpenAI Account stream.

  Previously, block indexes were derived from the current text/tool state instead of being assigned monotonically, which could produce inconsistent block ordering when text deltas and
  function_call items were interleaved. The stream also only closed open blocks on the success path, which meant failuresduring streaming could leave tool_use or text blocks unfinished.

  ## Issues Fixed

  - content_block indexes could become unstable when text and tool calls were interleaved in the same stream.
  - The same function_call could create duplicate tool_use blocks if the added event was observed more than once.
  - Errors raised mid-stream could leave previously opened blocks without a matching content_block_stop.
  - In practice, this could surface downstream as errors such as stream finished with incomplete tool_use block.

  ## Changes

  - Replace the text-start boolean with an explicit textBlockIndex.
  - Introduce a monotonic nextAvailableIndex so every new block gets a stable, unique index.
  - Only create each tool_use block once per callKey.
  - Centralize block cleanup in closeOpenBlocks() and call it on both normal completion and error paths.
  - Update the final incomplete-stream check to use the explicit text block state.

  ## Issues Fixed

  - content_block indexes could become unstable when text and tool calls were interleaved in the same stream.
  - The same function_call could create duplicate tool_use blocks if the added event was observed more than once.
  - Errors raised mid-stream could leave previously opened blocks without a matching content_block_stop.
  - In practice, this could surface downstream as errors such as stream finished with incomplete tool_use block.

  ## Changes

  - Replace the text-start boolean with an explicit textBlockIndex.
  - Introduce a monotonic nextAvailableIndex so every new block gets a stable, unique index.
  - Only create each tool_use block once per callKey.
  - Centralize block cleanup in closeOpenBlocks() and call it on both normal completion and error paths.
  - Update the final incomplete-stream check to use the explicit text block state.
