### PR TITLE
fix(daemon): support proxied OpenAI OAuth exchange

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,5 +1,7 @@
 import { loadConfig } from './config/index.js'
+import { configureOutboundNetwork } from './runtime/network.js'
 import { startDaemon } from './runtime/daemon.js'
 
+configureOutboundNetwork()
 const config = loadConfig()
 startDaemon(config)

--- a/packages/daemon/src/proxy/providers/openai-account-auth.test.ts
+++ b/packages/daemon/src/proxy/providers/openai-account-auth.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { exchangeAuthorizationCode } from './openai-account-auth.js'
+
+test('exchangeAuthorizationCode explains OpenAI unsupported region token errors', async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    error: {
+      code: 'unsupported_country_region_territory',
+      message: 'Country, region, or territory not supported',
+      type: 'request_forbidden',
+    },
+  }), { status: 403 })) as typeof fetch
+
+  try {
+    await assert.rejects(
+      () => exchangeAuthorizationCode('code', 'verifier'),
+      /outbound network is in an unsupported country, region, or territory/,
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})

--- a/packages/daemon/src/proxy/providers/openai-account-auth.ts
+++ b/packages/daemon/src/proxy/providers/openai-account-auth.ts
@@ -6,6 +6,7 @@ export const OPENAI_ACCOUNT_AUTHORIZE_URL = 'https://auth.openai.com/oauth/autho
 export const OPENAI_ACCOUNT_TOKEN_URL = 'https://auth.openai.com/oauth/token'
 export const OPENAI_ACCOUNT_REDIRECT_URI = 'http://localhost:1455/auth/callback'
 export const OPENAI_ACCOUNT_SCOPE = 'openid profile email offline_access'
+const OPENAI_UNSUPPORTED_REGION_CODE = 'unsupported_country_region_territory'
 
 export interface PkcePair {
   verifier: string
@@ -90,7 +91,7 @@ async function exchangeToken(params: Record<string, string>): Promise<OAuthToken
 
   if (!response.ok) {
     const text = await response.text().catch(() => '')
-    throw new Error(`OpenAI OAuth token exchange failed: HTTP ${response.status} ${text.slice(0, 300)}`)
+    throw new Error(formatTokenExchangeError(response.status, text))
   }
 
   const json = await response.json() as {
@@ -108,6 +109,44 @@ async function exchangeToken(params: Record<string, string>): Promise<OAuthToken
     refreshToken: json.refresh_token,
     expiresAt: Date.now() + json.expires_in * 1000,
     ...claims,
+  }
+}
+
+function formatTokenExchangeError(status: number, body: string): string {
+  const openaiError = parseOpenAIError(body)
+  if (openaiError?.code === OPENAI_UNSUPPORTED_REGION_CODE) {
+    return [
+      'OpenAI OAuth token exchange failed:',
+      'OpenAI rejected the daemon token exchange because the outbound network is in an unsupported country, region, or territory.',
+      'Configure the daemon to use a supported outbound proxy/network and try logging in again.',
+      `(${OPENAI_UNSUPPORTED_REGION_CODE})`,
+    ].join(' ')
+  }
+
+  if (openaiError) {
+    const details = [
+      openaiError.code,
+      openaiError.type,
+      openaiError.message,
+    ].filter(Boolean).join(' ')
+    return `OpenAI OAuth token exchange failed: HTTP ${status} ${details}`.trim()
+  }
+
+  return `OpenAI OAuth token exchange failed: HTTP ${status} ${body.slice(0, 300)}`
+}
+
+function parseOpenAIError(body: string): { code?: string; message?: string; type?: string } | null {
+  try {
+    const parsed = JSON.parse(body) as { error?: { code?: unknown; message?: unknown; type?: unknown } }
+    const error = parsed.error
+    if (!error) return null
+    return {
+      code: typeof error.code === 'string' ? error.code : undefined,
+      message: typeof error.message === 'string' ? error.message : undefined,
+      type: typeof error.type === 'string' ? error.type : undefined,
+    }
+  } catch {
+    return null
   }
 }
 

--- a/packages/daemon/src/runtime/network.test.ts
+++ b/packages/daemon/src/runtime/network.test.ts
@@ -1,0 +1,35 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mergeLocalNoProxy, resolveOutboundProxyConfig } from './network.js'
+
+test('resolveOutboundProxyConfig maps HTTPS proxy env and protects local hosts', () => {
+  const config = resolveOutboundProxyConfig({
+    HTTPS_PROXY: 'http://127.0.0.1:7890',
+  } as NodeJS.ProcessEnv)
+
+  assert.deepEqual(config, {
+    httpProxy: undefined,
+    httpsProxy: 'http://127.0.0.1:7890',
+    noProxy: 'localhost,127.0.0.1,::1',
+  })
+})
+
+test('resolveOutboundProxyConfig uses ALL_PROXY as fallback for both schemes', () => {
+  const config = resolveOutboundProxyConfig({
+    ALL_PROXY: 'http://127.0.0.1:7890',
+  } as NodeJS.ProcessEnv)
+
+  assert.deepEqual(config, {
+    httpProxy: 'http://127.0.0.1:7890',
+    httpsProxy: 'http://127.0.0.1:7890',
+    noProxy: 'localhost,127.0.0.1,::1',
+  })
+})
+
+test('resolveOutboundProxyConfig returns null when no proxy env is set', () => {
+  assert.equal(resolveOutboundProxyConfig({} as NodeJS.ProcessEnv), null)
+})
+
+test('mergeLocalNoProxy preserves existing entries and appends missing local hosts', () => {
+  assert.equal(mergeLocalNoProxy('example.com, localhost'), 'example.com,localhost,127.0.0.1,::1')
+})

--- a/packages/daemon/src/runtime/network.ts
+++ b/packages/daemon/src/runtime/network.ts
@@ -12,6 +12,11 @@ export function configureOutboundNetwork(env: NodeJS.ProcessEnv = process.env): 
   const proxyConfig = resolveOutboundProxyConfig(env)
   if (!proxyConfig) return false
 
+  env.NO_PROXY = proxyConfig.noProxy
+  env.no_proxy = proxyConfig.noProxy
+  process.env.NO_PROXY = proxyConfig.noProxy
+  process.env.no_proxy = proxyConfig.noProxy
+
   setGlobalDispatcher(new EnvHttpProxyAgent(proxyConfig))
   globalThis.fetch = undiciFetch as unknown as typeof globalThis.fetch
   return true

--- a/packages/daemon/src/runtime/network.ts
+++ b/packages/daemon/src/runtime/network.ts
@@ -1,0 +1,46 @@
+import { EnvHttpProxyAgent, fetch as undiciFetch, setGlobalDispatcher } from 'undici'
+
+const LOCAL_NO_PROXY_HOSTS = ['localhost', '127.0.0.1', '::1']
+
+export interface OutboundProxyConfig {
+  httpProxy?: string
+  httpsProxy?: string
+  noProxy: string
+}
+
+export function configureOutboundNetwork(env: NodeJS.ProcessEnv = process.env): boolean {
+  const proxyConfig = resolveOutboundProxyConfig(env)
+  if (!proxyConfig) return false
+
+  setGlobalDispatcher(new EnvHttpProxyAgent(proxyConfig))
+  globalThis.fetch = undiciFetch as unknown as typeof globalThis.fetch
+  return true
+}
+
+export function resolveOutboundProxyConfig(env: NodeJS.ProcessEnv): OutboundProxyConfig | null {
+  const fallbackProxy = env.ALL_PROXY ?? env.all_proxy
+  const httpProxy = env.HTTP_PROXY ?? env.http_proxy ?? fallbackProxy
+  const httpsProxy = env.HTTPS_PROXY ?? env.https_proxy ?? fallbackProxy
+
+  if (!httpProxy && !httpsProxy) return null
+
+  return {
+    httpProxy,
+    httpsProxy,
+    noProxy: mergeLocalNoProxy(env.NO_PROXY ?? env.no_proxy),
+  }
+}
+
+export function mergeLocalNoProxy(value: string | undefined): string {
+  const entries = (value ?? '')
+    .split(/[,\s]+/)
+    .map(entry => entry.trim())
+    .filter(Boolean)
+
+  const seen = new Set(entries.map(entry => entry.toLowerCase()))
+  for (const host of LOCAL_NO_PROXY_HOSTS) {
+    if (!seen.has(host.toLowerCase())) entries.push(host)
+  }
+
+  return entries.join(',')
+}


### PR DESCRIPTION
Symptom: after the OpenAI Account OAuth browser authorization succeeds and redirects back locally, the daemon may fail while exchanging the authorization code at https://auth.openai.com/oauth/token with HTTP 403 unsupported_country_region_territory. The callback page previously surfaced the raw token exchange JSON. A common case is that the browser uses a proxy while the local daemon process does not inherit the same outbound network configuration.

Fix: initialize daemon outbound networking on startup from HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, and NO_PROXY. When proxy settings are present, configure Undici EnvHttpProxyAgent as the global fetch dispatcher and merge localhost, 127.0.0.1, and ::1 into NO_PROXY so local services are not proxied. Also parse OpenAI token error JSON and convert unsupported_country_region_territory into an actionable error message.

Impact: behavior is unchanged when no proxy environment variables are set. When a proxy is configured, daemon outbound OpenAI OAuth token exchange, token refresh, model catalog fetches, and external provider requests use that proxy. Local callback, panel, Ollama, LM Studio, and llama.cpp requests remain direct by default. Unit tests cover proxy environment parsing and the OpenAI unsupported-region error message.