### PR TITLE
feat: add RTK and Caveman token savers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage/
 .turbo/
 .cache/
 .claude
+_EXAMPLE/

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The next documentation step is a separate official docs site repository. Until t
 - **Model routing** - map Claude tiers like `opus`, `sonnet`, and `haiku` to different providers and models.
 - **All-providers mode** - aggregate enabled providers into one model catalog and choose by model in Claude Code.
 - **Built-in OAuth** - OpenAI Account uses PKCE OAuth. GitHub Copilot uses Device Flow. Tokens refresh automatically.
+- **Token savers** - Optional RTK-style tool-result compression and Caveman terse-response mode from Settings.
 - **Outbound proxy support** - Configure an HTTP/HTTPS proxy in Settings so the daemon routes external requests (OAuth, provider API calls) through your network proxy. Required for users in regions where providers restrict direct access.
 - **Local model support** - Ollama, LM Studio, and llama.cpp run through the same Claude Code flow.
 - **Request history** - see model, provider, prompt, response preview, input tokens, latency, errors, and session totals.
@@ -130,6 +131,19 @@ CCPG logs each request Claude Code sends through the gateway, including backgrou
 </p>
 
 This is useful for debugging cost, understanding why a model behaved a certain way, and seeing background housekeeping calls that otherwise feel invisible.
+
+## Token Savers
+
+CCPG includes two optional local token-saving features in **Settings -> Token Savers**:
+
+| Feature | What it does | Best for |
+|---|---|---|
+| RTK compression | Compacts large `tool_result` payloads before the request reaches the provider. | Big `rg`, `git diff`, `git status`, `find`, `ls`, `tree`, numbered file dumps, and repetitive logs. |
+| Caveman mode | Injects terse-response guidance into the system prompt. | Reducing response verbosity and output tokens. |
+
+RTK does not change normal chat messages or errored tool results. If a request has no large tool output, there may be nothing to compress. When RTK does compress something, the daemon log records a line with bytes saved and the filter used.
+
+Caveman is different: it does not reduce input tokens. It asks the model to answer more tersely, with levels `lite`, `full`, and `ultra`.
 
 ## How `ccpg --all` Works
 
@@ -289,9 +303,10 @@ Every request goes through the same basic flow:
 1. Claude Code sends `POST /v1/messages` to CCPG's local proxy.
 2. CCPG authenticates the local request with its generated gateway token.
 3. CCPG resolves the target provider and model from the selected launch mode, model prefix, or routing rules.
-4. CCPG converts Anthropic Messages to the provider's native format when needed.
-5. CCPG streams the response back as Anthropic-compatible SSE.
-6. CCPG records session metadata and request details locally.
+4. CCPG applies enabled token savers to the request.
+5. CCPG converts Anthropic Messages to the provider's native format when needed.
+6. CCPG streams the response back as Anthropic-compatible SSE.
+7. CCPG records session metadata and request details locally.
 
 ## Runtime Storage
 
@@ -302,7 +317,7 @@ Runtime files live in:
 
 | File | Purpose |
 |---|---|
-| `config.json` | Non-sensitive provider settings, routing rules, ports, and model mode. |
+| `config.json` | Non-sensitive provider settings, routing rules, token saver settings, ports, and model mode. |
 | `secrets.enc.json` | API keys, OAuth tokens, and auth token encrypted with AES-256-GCM. |
 | `secret.key` | Local master key, unless `CC_GATEWAY_MASTER_KEY` is provided. |
 | `current-session.json` | Active session checkpoint. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,6 +58,7 @@ claude-code-provider-gateway/
 │   │   │   │   ├── native-claude-routing.ts  # Passthrough routing logic
 │   │   │   │   ├── prompt-serializer.ts  # Request → human-readable text for session log
 │   │   │   │   └── stream-result.ts      # Stream wrapping + response capture helpers
+│   │   │   ├── token-savers/             # RTK compression + Caveman prompt injection
 │   │   │   └── providers/               # LLM provider implementations
 │   │   │       ├── copilot.ts            # GitHub Copilot (dual-transport)
 │   │   │       ├── copilot-chat-stream.ts  # OpenAI Chat stream → Anthropic SSE
@@ -135,15 +136,20 @@ In `all` mode, provider-discovered models are exposed to Claude Code with a gate
 **services/message-service.ts** — core orchestration:
 1. Receives Anthropic-format request
 2. Resolves the target provider via `model-router.ts`
-3. Counts input tokens (`js-tiktoken`)
-4. Calls `provider.streamResponse()` with the configured request
-5. Tracks session statistics
+3. Applies enabled token savers to a cloned request
+4. Counts input tokens after compression (`js-tiktoken`)
+5. Calls `provider.streamResponse()` with the configured request
+6. Tracks session statistics
 
 **services/native-claude-routing.ts** — decides whether a request should bypass the active provider and fall through to native Anthropic passthrough. Applied when the requested model is a hardcoded Claude tier name and no primary model has been established yet for this session.
 
 **services/prompt-serializer.ts** — converts `MessagesRequest` to a truncated human-readable string stored in the session request log. The first request in a session captures up to 80 KB of system prompt; subsequent requests cap at 4 KB.
 
 **services/stream-result.ts** — wraps provider `ReadableStream<string>` into the `MessageServiceResult` union. `streamResultWithCapture()` tees the stream and writes the truncated response text back to the session log entry when the stream completes or is cancelled.
+
+**token-savers/rtk.ts** — compresses large `tool_result` text blocks before provider dispatch. It auto-detects common developer-output shapes such as grep/rg results, find output, git diff/status, ls/tree output, numbered file dumps, and repetitive logs. It skips small payloads, oversized raw blobs, and `tool_result` blocks marked as errors. Compression is best-effort: if a filter fails or makes the payload larger, the original text is preserved.
+
+**token-savers/caveman.ts** — injects terse-response guidance into the Anthropic `system` field when enabled. The levels are `lite`, `full`, and `ultra`. Caveman targets output verbosity; it does not reduce input tokens.
 
 ### 3. Provider Layer (`packages/daemon/src/proxy/providers/`)
 
@@ -249,6 +255,7 @@ secret.key (32-byte hex master key) or CC_GATEWAY_MASTER_KEY env var
 - **Paths** (`paths.ts`) — centralized functions for all config directory paths: `getConfigDir()`, `getConfigPath()`, `getPidPath()`, `getLogPath()`, `getSecretsPath()`, `getMasterKeyPath()`, `getCurrentSessionPath()`, `getSessionArchivePath()`. Handles the Windows `%APPDATA%` path on Win32.
 - **Schema** (`schema.ts`) — TypeScript types, provider defaults (base URLs, labels), CLI flag mappings
 - **Validation** (`validation.ts`) — runtime normalization with default merging
+- **Token savers** (`Config.tokenSavers`) — non-secret toggles for RTK compression and Caveman level
 - **Secret splitting** (`secrets/config-splitter.ts`) — extracts API keys, OAuth tokens, and auth token from config JSON into encrypted store
 - **Encrypted store** (`secrets/encrypted-file-store.ts`) — AES-256-GCM with random IV per write
 - **Master key** (`secrets/master-key.ts`) — resolution order: env var → stored file → generate new
@@ -285,8 +292,9 @@ Hono-based REST API for the web panel. The panel module is composed of:
 **`middleware/auth.ts`** — `requirePanelAccess` middleware:
 - Allows requests from Tauri webview origins (`tauri://localhost`, `https://tauri.localhost`) and the Vite dev server in non-production mode
 - CORS headers are set for allowed origins
-- Sensitive endpoints (config write, session clear, shutdown, shell install, OAuth flows, launch commands) require a valid `Authorization: Bearer <token>` or `x-api-key` header even from loopback
+- Sensitive endpoints (config write, session clear, shutdown, shell install, OAuth flows, launch commands with auth tokens) require a valid `Authorization: Bearer <token>` or `x-api-key` header even from loopback
 - Requests from cross-site browser origins without a valid token are rejected with 403
+- `GET /api/quick-launch` is intentionally token-free because it returns only non-sensitive `ccpg` shortcuts for the dashboard.
 
 **`routes/`** — one file per route group:
 
@@ -296,7 +304,7 @@ Hono-based REST API for the web panel. The panel module is composed of:
 | `config-routes.ts` | `GET /api/config`, `PUT /api/config` |
 | `provider-routes.ts` | `GET /api/providers`, `POST /api/providers/:id/test`, `GET /api/models/:providerId`, `GET /api/routing/options` |
 | `session-routes.ts` | `GET /api/sessions`, `DELETE /api/sessions`, `POST /api/launch/end`, `POST /api/launch/heartbeat`, `POST /api/launch/attach` |
-| `shell-routes.ts` | `GET /api/launch-commands`, `GET /api/launch-command`, `GET /api/shell-setup`, `GET /api/shell-setup/snippet/:shell`, `POST /api/shell-setup/install`, `POST /api/launch/prepare` |
+| `shell-routes.ts` | `GET /api/quick-launch`, `GET /api/launch-commands`, `GET /api/launch-command`, `GET /api/shell-setup`, `GET /api/shell-setup/snippet/:shell`, `POST /api/shell-setup/install`, `POST /api/launch/prepare` |
 | `oauth-routes.ts` | `POST /api/providers/openai_account/oauth/start`, `GET /api/providers/openai_account/oauth/status/:state`, `POST /api/providers/openai_account/oauth/logout`, `POST /api/providers/copilot/oauth/start`, `GET /api/providers/copilot/oauth/status/:flowId`, `POST /api/providers/copilot/oauth/logout` |
 | `static-routes.ts` | React SPA static file serving |
 
@@ -310,7 +318,7 @@ React 19 SPA built with Vite 6 + Ant Design 5 + Zustand 5.
 - **Providers** — toggle providers, edit API keys, OAuth login, test connections, add extra models
 - **Routing** — tier-based model routing UI
 - **History** — session archive with per-request drill-down
-- **Settings** — daemon configuration
+- **Settings** — daemon configuration, outbound proxy, web tools, and token savers
 
 ### 9. Desktop Shell (`packages/desktop/`)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -174,6 +174,35 @@ src/proxy/services/message-service.test.ts
 
 The daemon has the broadest test suite. The desktop crate also has focused Rust unit tests for pure policy code. The panel package does not have a dedicated test suite yet.
 
+### Token saver development
+
+Token savers live in `packages/daemon/src/proxy/token-savers/` and are applied by `MessageService` before provider dispatch.
+
+| Module | Responsibility |
+|---|---|
+| `rtk.ts` | Compress large `tool_result` text blocks with auto-detected filters. |
+| `caveman.ts` | Inject terse-response guidance into the Anthropic `system` prompt. |
+
+RTK should only mutate safe tool-result payloads. Preserve errored tool results, skip tiny payloads, and keep the original text whenever compression fails or expands the content. Caveman should remain a config-driven system prompt injection; it should not touch message content.
+
+Useful checks:
+
+```bash
+cd packages/daemon
+node --import tsx --test src/proxy/token-savers/token-savers.test.ts
+npm run typecheck
+```
+
+Manual validation path:
+
+1. Start the app with `npm run dev:desk`.
+2. Enable **Settings -> Token Savers -> RTK compression**.
+3. Launch Claude Code through `ccpg --<provider>`.
+4. Ask Claude Code to run a command with large output, such as `rg` or `git diff`.
+5. Check daemon logs for an `rtk` line showing bytes saved.
+
+Caveman can be validated with a normal chat request after enabling **Caveman mode**. The session prompt should include the injected terse-response guidance, and responses should become shorter according to the selected level.
+
 ## Build Pipeline
 
 ### Production build

--- a/packages/daemon/src/config/index.ts
+++ b/packages/daemon/src/config/index.ts
@@ -86,6 +86,11 @@ export function buildDefaultConfig(): Config {
       enabled: false,
       url: '',
     },
+    tokenSavers: {
+      rtkEnabled: false,
+      cavemanEnabled: false,
+      cavemanLevel: 'lite',
+    },
     activeProvider: 'nvidia_nim',
     modelMode: 'single',
   }

--- a/packages/daemon/src/config/schema.ts
+++ b/packages/daemon/src/config/schema.ts
@@ -40,6 +40,7 @@ export interface ProviderConfig {
 }
 
 export type ModelMode = 'single' | 'all'
+export type CavemanLevel = 'lite' | 'full' | 'ultra'
 
 export interface RoutingRule {
   enabled: boolean
@@ -70,6 +71,11 @@ export interface Config {
   proxy: {
     enabled: boolean
     url: string
+  }
+  tokenSavers: {
+    rtkEnabled: boolean
+    cavemanEnabled: boolean
+    cavemanLevel: CavemanLevel
   }
   activeProvider: ProviderId
   modelMode: ModelMode

--- a/packages/daemon/src/config/validation.test.ts
+++ b/packages/daemon/src/config/validation.test.ts
@@ -32,11 +32,15 @@ test('normalizeConfig uses proxy defaults when proxy field is absent (legacy con
   const defaults = buildDefaultConfig()
   const legacyConfig = { ...defaults } as Record<string, unknown>
   delete legacyConfig.proxy
+  delete legacyConfig.tokenSavers
 
   const normalized = normalizeConfig(legacyConfig as unknown as typeof defaults, defaults)
 
   assert.equal(normalized.proxy.enabled, false)
   assert.equal(normalized.proxy.url, '')
+  assert.equal(normalized.tokenSavers.rtkEnabled, false)
+  assert.equal(normalized.tokenSavers.cavemanEnabled, false)
+  assert.equal(normalized.tokenSavers.cavemanLevel, 'lite')
 })
 
 test('normalizeConfig preserves proxy config when present', () => {
@@ -86,4 +90,22 @@ test('normalizeConfig falls back for invalid runtime values', () => {
   assert.equal(normalized.modelMode, defaults.modelMode)
   assert.equal(normalized.providers.nvidia_nim.enabled, defaults.providers.nvidia_nim.enabled)
   assert.equal(normalized.providers.nvidia_nim.requestTimeoutMs, undefined)
+})
+
+test('normalizeConfig preserves valid token saver settings', () => {
+  const defaults = buildDefaultConfig()
+  const config = {
+    ...defaults,
+    tokenSavers: {
+      rtkEnabled: true,
+      cavemanEnabled: true,
+      cavemanLevel: 'ultra' as const,
+    },
+  }
+
+  const normalized = normalizeConfig(config, defaults)
+
+  assert.equal(normalized.tokenSavers.rtkEnabled, true)
+  assert.equal(normalized.tokenSavers.cavemanEnabled, true)
+  assert.equal(normalized.tokenSavers.cavemanLevel, 'ultra')
 })

--- a/packages/daemon/src/config/validation.ts
+++ b/packages/daemon/src/config/validation.ts
@@ -1,8 +1,9 @@
-import type { Config, ModelMode, ProviderConfig, ProviderId, RoutingRule } from './schema.js'
+import type { CavemanLevel, Config, ModelMode, ProviderConfig, ProviderId, RoutingRule } from './schema.js'
 import { PROVIDER_IDS } from './schema.js'
 
 const PROVIDER_ID_SET = new Set<string>(PROVIDER_IDS)
 const MODEL_MODES = new Set<ModelMode>(['single', 'all'])
+const CAVEMAN_LEVELS = new Set<CavemanLevel>(['lite', 'full', 'ultra'])
 
 export function normalizeConfig(config: Config, defaults: Config): Config {
   return {
@@ -34,6 +35,11 @@ export function normalizeConfig(config: Config, defaults: Config): Config {
     proxy: {
       enabled: booleanOrDefault(config.proxy?.enabled, defaults.proxy.enabled),
       url: stringOrDefault(config.proxy?.url, defaults.proxy.url) || '',
+    },
+    tokenSavers: {
+      rtkEnabled: booleanOrDefault(config.tokenSavers?.rtkEnabled, defaults.tokenSavers.rtkEnabled),
+      cavemanEnabled: booleanOrDefault(config.tokenSavers?.cavemanEnabled, defaults.tokenSavers.cavemanEnabled),
+      cavemanLevel: cavemanLevelOrDefault(config.tokenSavers?.cavemanLevel, defaults.tokenSavers.cavemanLevel),
     },
     activeProvider: providerIdOrDefault(config.activeProvider, defaults.activeProvider),
     modelMode: modelModeOrDefault(config.modelMode, defaults.modelMode),
@@ -152,4 +158,10 @@ function providerIdOrDefault(value: unknown, fallback: ProviderId): ProviderId {
 
 function modelModeOrDefault(value: unknown, fallback: ModelMode): ModelMode {
   return typeof value === 'string' && MODEL_MODES.has(value as ModelMode) ? value as ModelMode : fallback
+}
+
+function cavemanLevelOrDefault(value: unknown, fallback: CavemanLevel): CavemanLevel {
+  return typeof value === 'string' && CAVEMAN_LEVELS.has(value as CavemanLevel)
+    ? value as CavemanLevel
+    : fallback
 }

--- a/packages/daemon/src/panel/app.test.ts
+++ b/packages/daemon/src/panel/app.test.ts
@@ -2,11 +2,16 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { buildDefaultConfig } from '../config/index.js'
 import { createPanelApp } from './app.js'
+import type { Config } from '../config/schema.js'
+
+function testPanelApp(config: Config) {
+  return createPanelApp(config, { saveConfig: () => {} })
+}
 
 test('panel API rejects browser requests from untrusted origins', async () => {
   const config = buildDefaultConfig()
   config.server.authToken = 'secret'
-  const app = createPanelApp(config)
+  const app = testPanelApp(config)
 
   const response = await app.request('/api/launch-commands', {
     headers: {
@@ -25,7 +30,7 @@ test('panel API allows trusted Tauri origins in production', async () => {
   try {
     const config = buildDefaultConfig()
     config.server.authToken = 'secret'
-    const app = createPanelApp(config)
+    const app = testPanelApp(config)
 
     const response = await app.request('/api/status', {
       headers: { Origin: 'https://tauri.localhost' },
@@ -45,7 +50,7 @@ test('panel API allows vite dev origin only outside production', async () => {
   try {
     const config = buildDefaultConfig()
     config.server.authToken = 'secret'
-    const app = createPanelApp(config)
+    const app = testPanelApp(config)
 
     const response = await app.request('/api/status', {
       headers: { Origin: 'http://localhost:5173' },
@@ -65,7 +70,7 @@ test('panel API rejects vite dev origin in production', async () => {
   try {
     const config = buildDefaultConfig()
     config.server.authToken = 'secret'
-    const app = createPanelApp(config)
+    const app = testPanelApp(config)
 
     const response = await app.request('/api/status', {
       headers: { Origin: 'http://localhost:5173' },
@@ -81,7 +86,7 @@ test('panel API rejects vite dev origin in production', async () => {
 test('panel API accepts gateway token as explicit local bypass', async () => {
   const config = buildDefaultConfig()
   config.server.authToken = 'secret'
-  const app = createPanelApp(config)
+  const app = testPanelApp(config)
 
   const response = await app.request('/api/status', {
     headers: {
@@ -96,7 +101,7 @@ test('panel API accepts gateway token as explicit local bypass', async () => {
 test('panel API keeps local curl-style reads working without Origin', async () => {
   const config = buildDefaultConfig()
   config.server.authToken = 'secret'
-  const app = createPanelApp(config)
+  const app = testPanelApp(config)
 
   const response = await app.request('/api/status')
 
@@ -108,7 +113,7 @@ test('panel API keeps local curl-style reads working without Origin', async () =
 test('panel API requires token for sensitive local requests without Origin', async () => {
   const config = buildDefaultConfig()
   config.server.authToken = 'secret'
-  const app = createPanelApp(config)
+  const app = testPanelApp(config)
 
   const response = await app.request('/api/launch-commands')
 
@@ -116,10 +121,31 @@ test('panel API requires token for sensitive local requests without Origin', asy
   assert.deepEqual(await response.json(), { error: 'Authentication required' })
 })
 
+test('panel API exposes token-free quick launch commands without Origin', async () => {
+  const config = buildDefaultConfig()
+  config.server.authToken = 'secret'
+  config.providers.openrouter.enabled = true
+  const app = testPanelApp(config)
+
+  const response = await app.request('/api/quick-launch')
+
+  assert.equal(response.status, 200)
+  const body = await response.json() as {
+    all?: string
+    manual?: string
+    perProvider?: Array<{ id: string; cli: string }>
+  }
+  assert.equal(body.all, 'ccpg --all')
+  assert.equal(body.manual, undefined)
+  assert.deepEqual(body.perProvider, [
+    { id: 'openrouter', label: 'OpenRouter', cli: 'ccpg --OpenRouter' },
+  ])
+})
+
 test('panel API allows sensitive local requests with gateway token', async () => {
   const config = buildDefaultConfig()
   config.server.authToken = 'secret'
-  const app = createPanelApp(config)
+  const app = testPanelApp(config)
 
   const response = await app.request('/api/launch-commands', {
     headers: { Authorization: 'Bearer secret' },
@@ -133,7 +159,7 @@ test('panel API allows sensitive local requests with gateway token', async () =>
 test('panel API rejects sensitive local requests with wrong gateway token', async () => {
   const config = buildDefaultConfig()
   config.server.authToken = 'secret'
-  const app = createPanelApp(config)
+  const app = testPanelApp(config)
 
   const response = await app.request('/api/control/shutdown', {
     method: 'POST',
@@ -146,7 +172,7 @@ test('panel API rejects sensitive local requests with wrong gateway token', asyn
 test('panel API rejects unknown shell names before installing snippets', async () => {
   const config = buildDefaultConfig()
   config.server.authToken = 'secret'
-  const app = createPanelApp(config)
+  const app = testPanelApp(config)
 
   const response = await app.request('/api/shell-setup/install', {
     method: 'POST',
@@ -164,7 +190,7 @@ test('panel API rejects unknown shell names before installing snippets', async (
 test('PUT /api/config persists proxy settings and returns them on GET', async () => {
   const config = buildDefaultConfig()
   config.server.authToken = 'secret'
-  const app = createPanelApp(config)
+  const app = testPanelApp(config)
 
   const putResponse = await app.request('/api/config', {
     method: 'PUT',
@@ -184,10 +210,48 @@ test('PUT /api/config persists proxy settings and returns them on GET', async ()
   assert.equal(body.proxy?.url, 'http://127.0.0.1:7890')
 })
 
+test('PUT /api/config persists token saver settings and returns them on GET', async () => {
+  const config = buildDefaultConfig()
+  config.server.authToken = 'secret'
+  const app = testPanelApp(config)
+
+  const putResponse = await app.request('/api/config', {
+    method: 'PUT',
+    headers: {
+      Authorization: 'Bearer secret',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      tokenSavers: {
+        rtkEnabled: true,
+        cavemanEnabled: true,
+        cavemanLevel: 'full',
+      },
+    }),
+  })
+  assert.equal(putResponse.status, 200)
+
+  const getResponse = await app.request('/api/config', {
+    headers: { Authorization: 'Bearer secret' },
+  })
+  const body = await getResponse.json() as {
+    tokenSavers?: {
+      rtkEnabled: boolean
+      cavemanEnabled: boolean
+      cavemanLevel: string
+    }
+  }
+  assert.deepEqual(body.tokenSavers, {
+    rtkEnabled: true,
+    cavemanEnabled: true,
+    cavemanLevel: 'full',
+  })
+})
+
 test('PUT /api/config rejects invalid proxy URL when enabled', async () => {
   const config = buildDefaultConfig()
   config.server.authToken = 'secret'
-  const app = createPanelApp(config)
+  const app = testPanelApp(config)
 
   const response = await app.request('/api/config', {
     method: 'PUT',
@@ -205,7 +269,7 @@ test('PUT /api/config rejects invalid proxy URL when enabled', async () => {
 test('PUT /api/config rejects proxy URL with embedded credentials even when disabled', async () => {
   const config = buildDefaultConfig()
   config.server.authToken = 'secret'
-  const app = createPanelApp(config)
+  const app = testPanelApp(config)
 
   for (const enabled of [true, false]) {
     const response = await app.request('/api/config', {
@@ -225,7 +289,7 @@ test('PUT /api/config rejects proxy URL with embedded credentials even when disa
 test('PUT /api/config rejects enabling proxy when existing URL is empty', async () => {
   const config = buildDefaultConfig()
   config.server.authToken = 'secret'
-  const app = createPanelApp(config)
+  const app = testPanelApp(config)
 
   const response = await app.request('/api/config', {
     method: 'PUT',
@@ -242,7 +306,7 @@ test('PUT /api/config disabling proxy clears the enabled flag', async () => {
   const config = buildDefaultConfig()
   config.server.authToken = 'secret'
   config.proxy = { enabled: true, url: 'http://127.0.0.1:7890' }
-  const app = createPanelApp(config)
+  const app = testPanelApp(config)
 
   const putResponse = await app.request('/api/config', {
     method: 'PUT',

--- a/packages/daemon/src/panel/app.ts
+++ b/packages/daemon/src/panel/app.ts
@@ -10,9 +10,13 @@ import { registerStaticRoutes } from './routes/static-routes.js'
 import { registerStatusRoutes } from './routes/status-routes.js'
 import { PanelRuntime } from './runtime.js'
 
-export function createPanelApp(initialConfig: Config) {
+export type PanelAppOptions = {
+  saveConfig?: (config: Config) => void
+}
+
+export function createPanelApp(initialConfig: Config, options: PanelAppOptions = {}) {
   const app = new Hono()
-  const runtime = new PanelRuntime(initialConfig)
+  const runtime = new PanelRuntime(initialConfig, options.saveConfig)
 
   app.use('/api/*', requirePanelAccess(runtime))
 

--- a/packages/daemon/src/panel/contracts.ts
+++ b/packages/daemon/src/panel/contracts.ts
@@ -4,6 +4,7 @@ import type {
   SessionRecord,
   SessionRequestLogEntry,
   SessionModelStat,
+  TokenSaverStats,
 } from '../runtime/sessions.js'
 
 export type GatewayStatusResponse = {
@@ -44,6 +45,8 @@ export type LaunchCommandsResponse = {
   all: string
   perProvider: Array<{ id: string; label: string; cli: string }>
 }
+
+export type QuickLaunchResponse = Pick<LaunchCommandsResponse, 'all' | 'perProvider'>
 
 export type ShellName = 'zsh' | 'bash' | 'fish' | 'powershell'
 
@@ -129,7 +132,7 @@ export type RoutingOption = {
 }
 
 export type PanelConfigResponse = Config
-export type SettingsConfigResponse = Pick<Config, 'server' | 'webTools' | 'proxy'>
+export type SettingsConfigResponse = Pick<Config, 'server' | 'webTools' | 'proxy' | 'tokenSavers'>
 export type RoutingConfigResponse = Pick<Config, 'routing' | 'thinking'>
 
 export type SessionsResponse = {
@@ -141,4 +144,5 @@ export type {
   SessionRecord,
   SessionRequestLogEntry,
   SessionModelStat,
+  TokenSaverStats,
 }

--- a/packages/daemon/src/panel/routes/config-routes.ts
+++ b/packages/daemon/src/panel/routes/config-routes.ts
@@ -30,6 +30,7 @@ export function registerConfigRoutes(app: Hono, runtime: PanelRuntime): void {
     if (update.routing) Object.assign(merged.routing, update.routing)
     if (update.thinking) Object.assign(merged.thinking, update.thinking)
     if (update.webTools) Object.assign(merged.webTools, update.webTools)
+    if (update.tokenSavers) Object.assign(merged.tokenSavers, update.tokenSavers)
     if (update.proxy) {
       if (update.proxy.url !== undefined) {
         const urlError = validateProxyUrl(update.proxy.url)

--- a/packages/daemon/src/panel/routes/shell-routes.ts
+++ b/packages/daemon/src/panel/routes/shell-routes.ts
@@ -11,6 +11,7 @@ import { prepareLaunch } from '../launch-prepare.js'
 import type {
   InstallShellSetupResponse,
   LaunchCommandsResponse,
+  QuickLaunchResponse,
 } from '../contracts.js'
 import type { PanelRuntime } from '../runtime.js'
 
@@ -18,18 +19,19 @@ export function registerShellRoutes(app: Hono, runtime: PanelRuntime): void {
   app.get('/api/launch-commands', c => {
     const config = runtime.currentConfig()
     const env = `ANTHROPIC_AUTH_TOKEN=${config.server.authToken} ANTHROPIC_BASE_URL=http://localhost:${config.server.proxyPort} CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 claude`
-    const enabled = (Object.entries(config.providers) as [ProviderId, typeof config.providers[ProviderId]][])
-      .filter(([, pc]) => pc.enabled)
-      .map(([id]) => ({
-        id,
-        label: PROVIDER_LABELS[id] ?? id,
-        cli: `ccpg ${flagFor(id) ?? `--${id}`}`,
-      }))
     const response = {
       manual: env,
       all: 'ccpg --all',
-      perProvider: enabled,
+      perProvider: buildQuickLaunchProviders(config),
     } satisfies LaunchCommandsResponse
+    return c.json(response)
+  })
+
+  app.get('/api/quick-launch', c => {
+    const response = {
+      all: 'ccpg --all',
+      perProvider: buildQuickLaunchProviders(runtime.currentConfig()),
+    } satisfies QuickLaunchResponse
     return c.json(response)
   })
 
@@ -91,6 +93,16 @@ export function registerShellRoutes(app: Hono, runtime: PanelRuntime): void {
     ].join(' ')
     return c.json({ command: cmd })
   })
+}
+
+function buildQuickLaunchProviders(config: ReturnType<PanelRuntime['currentConfig']>) {
+  return (Object.entries(config.providers) as [ProviderId, typeof config.providers[ProviderId]][])
+    .filter(([, pc]) => pc.enabled)
+    .map(([id]) => ({
+      id,
+      label: PROVIDER_LABELS[id] ?? id,
+      cli: `ccpg ${flagFor(id) ?? `--${id}`}`,
+    }))
 }
 
 function flagFor(id: ProviderId): string | null {

--- a/packages/daemon/src/panel/runtime.ts
+++ b/packages/daemon/src/panel/runtime.ts
@@ -28,7 +28,10 @@ export class PanelRuntime {
   readonly oauthFlows = new Map<string, OAuthFlow>()
   readonly copilotFlows = new Map<string, CopilotFlow>()
 
-  constructor(initialConfig: Config) {
+  constructor(
+    initialConfig: Config,
+    private readonly persistConfig: (config: Config) => void = saveConfig,
+  ) {
     this.config = initialConfig
     this.registry = new ProviderRegistry(initialConfig)
   }
@@ -43,7 +46,7 @@ export class PanelRuntime {
   }
 
   saveAndUpdateConfig(config: Config): void {
-    saveConfig(config)
+    this.persistConfig(config)
     this.updateConfig(config)
   }
 

--- a/packages/daemon/src/proxy/routes/anthropic-routes.ts
+++ b/packages/daemon/src/proxy/routes/anthropic-routes.ts
@@ -1,5 +1,4 @@
 import type { Hono } from 'hono'
-import { countRequestTokens } from '../../core/anthropic/tokens.js'
 import type { CountTokensRequest, MessagesRequest } from '../../core/anthropic/types.js'
 import { requireAnthropicAuth } from '../middleware/auth.js'
 import type { ProxyRuntime } from '../runtime.js'
@@ -17,7 +16,7 @@ export function registerAnthropicRoutes(app: Hono, runtime: ProxyRuntime): void 
 
   app.post('/v1/messages/count_tokens', async c => {
     const req = await c.req.json<CountTokensRequest>()
-    const tokens = countRequestTokens(req as MessagesRequest)
+    const tokens = messages.countTokens(req as MessagesRequest)
     return c.json({ input_tokens: tokens })
   })
 

--- a/packages/daemon/src/proxy/services/message-service.ts
+++ b/packages/daemon/src/proxy/services/message-service.ts
@@ -23,6 +23,9 @@ import { tryOptimize } from "../optimizations.js";
 import type { ProxyRuntime } from "../runtime.js";
 import { serializePrompt } from "./prompt-serializer.js";
 import { streamResult, streamResultWithCapture } from "./stream-result.js";
+import { injectCaveman } from "../token-savers/caveman.js";
+import { cloneMessagesRequest, compressMessages, formatRtkLog } from "../token-savers/rtk.js";
+import type { TokenSaverStats } from "../../runtime/session-types.js";
 export { shouldUseNativeClaudePassthrough } from "./native-claude-routing.js";
 import { shouldUseNativeClaudePassthrough } from "./native-claude-routing.js";
 
@@ -131,8 +134,8 @@ export class MessageService {
       };
     }
 
-    const inputTokens = countRequestTokens(req);
-    const providerReq = { ...req, model: providerModel };
+    const { req: providerReq, stats: tokenSaverStats } = this.applyTokenSavers({ ...cloneMessagesRequest(req), model: providerModel });
+    const inputTokens = countRequestTokens(providerReq);
     const result = await provider.streamResponse(providerReq, inputTokens);
     const latency = Date.now() - started;
 
@@ -182,6 +185,7 @@ export class MessageService {
       status: "ok",
       error: null,
       prompt,
+      tokenSavers: tokenSaverStats,
     });
     return streamResultWithCapture(result.stream, logEntryId);
   }
@@ -190,8 +194,9 @@ export class MessageService {
     req: MessagesRequest,
     started: number,
   ): Promise<MessageServiceResult> {
-    const inputTokens = countRequestTokens(req);
-    const result = await streamAnthropicNative(req, req.model, undefined);
+    const { req: nativeReq, stats: tokenSaverStats } = this.applyTokenSavers(cloneMessagesRequest(req));
+    const inputTokens = countRequestTokens(nativeReq);
+    const result = await streamAnthropicNative(nativeReq, nativeReq.model, undefined);
     const latency = Date.now() - started;
     // Synthetic stats key so the dashboard can show native Claude usage separately
     // from configured third-party providers.
@@ -243,7 +248,31 @@ export class MessageService {
       status: "ok",
       error: null,
       prompt,
+      tokenSavers: tokenSaverStats,
     });
     return streamResultWithCapture(result.stream, logEntryId);
+  }
+
+  private applyTokenSavers(req: MessagesRequest): { req: MessagesRequest; stats: TokenSaverStats | undefined } {
+    const { tokenSavers } = this.runtime.currentConfig();
+    const rtkStats = compressMessages(req, tokenSavers.rtkEnabled);
+    const rtkLine = formatRtkLog(rtkStats);
+    if (rtkLine) logger.info("rtk", rtkLine);
+
+    injectCaveman(req, tokenSavers.cavemanEnabled, tokenSavers.cavemanLevel);
+    if (tokenSavers.cavemanEnabled) {
+      logger.info("caveman", `system prompt injected (${tokenSavers.cavemanLevel})`);
+    }
+
+    if (!rtkStats && !tokenSavers.cavemanEnabled) return { req, stats: undefined };
+
+    const stats: TokenSaverStats = {
+      rtkBytesBefore: rtkStats?.bytesBefore ?? 0,
+      rtkBytesAfter: rtkStats?.bytesAfter ?? 0,
+      rtkHits: rtkStats?.hits.length ?? 0,
+      rtkFilters: rtkStats ? Array.from(new Set(rtkStats.hits.map(hit => hit.filter))) : [],
+      cavemanLevel: tokenSavers.cavemanEnabled ? tokenSavers.cavemanLevel : null,
+    };
+    return { req, stats };
   }
 }

--- a/packages/daemon/src/proxy/services/message-service.ts
+++ b/packages/daemon/src/proxy/services/message-service.ts
@@ -175,7 +175,7 @@ export class MessageService {
       `→ ${providerId}/${providerModel} (${inputTokens} input tokens, ${latency}ms to first byte)`,
     );
     recordRequest(providerId, latency, null);
-    const prompt = serializePrompt(req, isFirstSessionRequest());
+    const prompt = serializePrompt(providerReq, isFirstSessionRequest());
     const logEntryId = recordSessionRequest({
       requestedModel: req.model,
       providerId,
@@ -238,7 +238,7 @@ export class MessageService {
       `→ ${providerId}/${req.model} (${inputTokens} input tokens, ${latency}ms to first byte)`,
     );
     recordRequest(providerId, latency, null);
-    const prompt = serializePrompt(req, isFirstSessionRequest());
+    const prompt = serializePrompt(nativeReq, isFirstSessionRequest());
     const logEntryId = recordSessionRequest({
       requestedModel: req.model,
       providerId,

--- a/packages/daemon/src/proxy/services/message-service.ts
+++ b/packages/daemon/src/proxy/services/message-service.ts
@@ -253,6 +253,11 @@ export class MessageService {
     return streamResultWithCapture(result.stream, logEntryId);
   }
 
+  countTokens(req: MessagesRequest): number {
+    const { req: transformed } = this.applyTokenSavers(cloneMessagesRequest(req));
+    return countRequestTokens(transformed);
+  }
+
   private applyTokenSavers(req: MessagesRequest): { req: MessagesRequest; stats: TokenSaverStats | undefined } {
     const { tokenSavers } = this.runtime.currentConfig();
     const rtkStats = compressMessages(req, tokenSavers.rtkEnabled);

--- a/packages/daemon/src/proxy/token-savers/caveman.ts
+++ b/packages/daemon/src/proxy/token-savers/caveman.ts
@@ -1,0 +1,59 @@
+import type { MessagesRequest } from '../../core/anthropic/types.js'
+import type { CavemanLevel } from '../../config/schema.js'
+
+const SEP = '\n\n'
+
+type SystemBlock = { type: 'text'; text: string; cache_control?: unknown }
+
+const SHARED_BOUNDARIES =
+  'Code blocks, file paths, commands, errors, URLs: keep exact. Security warnings, irreversible action confirmations, multi-step ordered sequences: write normal. Resume terse style after.'
+
+const CAVEMAN_PROMPTS: Record<CavemanLevel, string> = {
+  lite: [
+    'Respond tersely. Keep grammar and full sentences but drop filler, hedging and pleasantries.',
+    'Pattern: state the thing, the action, the reason. Then next step.',
+    SHARED_BOUNDARIES,
+    'Active every response until user asks for normal mode.',
+  ].join(' '),
+  full: [
+    'Respond like terse caveman. All technical substance stay exact, only fluff die.',
+    'Drop articles, filler, pleasantries, hedging. Fragments OK. Short synonyms.',
+    'Pattern: thing action reason. next step.',
+    SHARED_BOUNDARIES,
+    'Active every response until user asks for normal mode.',
+  ].join(' '),
+  ultra: [
+    'Respond ultra-terse. Maximum compression. Telegraphic.',
+    'Abbreviate DB/auth/config/req/res/fn/impl, strip conjunctions, use arrows for causality.',
+    'Pattern: thing -> result. fix.',
+    SHARED_BOUNDARIES,
+    'Active every response until user asks for normal mode.',
+  ].join(' '),
+}
+
+export function injectCaveman(req: MessagesRequest, enabled: boolean, level: CavemanLevel): void {
+  if (!enabled) return
+  const prompt = CAVEMAN_PROMPTS[level]
+  if (!prompt) return
+
+  if (typeof req.system === 'string') {
+    req.system = req.system ? `${req.system}${SEP}${prompt}` : prompt
+    return
+  }
+
+  if (Array.isArray(req.system)) {
+    const block: SystemBlock = { type: 'text', text: prompt }
+    let lastCacheIdx = -1
+    for (let i = req.system.length - 1; i >= 0; i -= 1) {
+      if ((req.system[i] as SystemBlock).cache_control !== undefined) {
+        lastCacheIdx = i
+        break
+      }
+    }
+    if (lastCacheIdx >= 0) req.system.splice(lastCacheIdx, 0, block)
+    else req.system.push(block)
+    return
+  }
+
+  req.system = prompt
+}

--- a/packages/daemon/src/proxy/token-savers/caveman.ts
+++ b/packages/daemon/src/proxy/token-savers/caveman.ts
@@ -50,7 +50,7 @@ export function injectCaveman(req: MessagesRequest, enabled: boolean, level: Cav
         break
       }
     }
-    if (lastCacheIdx >= 0) req.system.splice(lastCacheIdx + 1, 0, block)
+    if (lastCacheIdx >= 0) req.system.splice(lastCacheIdx, 0, block)
     else req.system.push(block)
     return
   }

--- a/packages/daemon/src/proxy/token-savers/caveman.ts
+++ b/packages/daemon/src/proxy/token-savers/caveman.ts
@@ -50,7 +50,7 @@ export function injectCaveman(req: MessagesRequest, enabled: boolean, level: Cav
         break
       }
     }
-    if (lastCacheIdx >= 0) req.system.splice(lastCacheIdx, 0, block)
+    if (lastCacheIdx >= 0) req.system.splice(lastCacheIdx + 1, 0, block)
     else req.system.push(block)
     return
   }

--- a/packages/daemon/src/proxy/token-savers/rtk.ts
+++ b/packages/daemon/src/proxy/token-savers/rtk.ts
@@ -106,16 +106,24 @@ function autoDetectFilter(text: string): Filter | null {
   if (/^On branch |^nothing to commit|^Changes (not |to be )|^Untracked files:/m.test(head) || isMostlyPorcelain(head)) return gitStatus
 
   const lines = head.split('\n')
+  const totalLines = text.split('\n').length
   const nonEmpty = lines.filter(line => line.trim().length > 0)
   if (nonEmpty.slice(0, 5).some(isGrepLine)) return grep
   if (nonEmpty.length >= 3 && nonEmpty.every(isPathLike)) return find
   if (/[├└]──|│  /.test(head)) return tree
   if (/^total \d+$/m.test(head) || countMatches(head, /^[-dlbcps][rwx-]{9}/m) >= 3) return ls
   if (SEARCH_LIST_HEADER_RE.test(head)) return searchList
-  if (lines.length >= SMART_TRUNCATE_MIN_LINES && isLineNumbered(lines)) return readNumbered
-  if (nonEmpty.length >= 5) return dedupLog
-  if (text.split('\n').length >= SMART_TRUNCATE_MIN_LINES) return smartTruncate
+  if (totalLines >= SMART_TRUNCATE_MIN_LINES && isLineNumbered(lines)) return readNumbered
+  if (nonEmpty.length >= 5 && hasDuplicateRun(nonEmpty)) return dedupLog
+  if (totalLines >= SMART_TRUNCATE_MIN_LINES) return smartTruncate
   return null
+}
+
+function hasDuplicateRun(lines: string[]): boolean {
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === lines[i - 1]) return true
+  }
+  return false
 }
 
 function isGrepLine(line: string): boolean {

--- a/packages/daemon/src/proxy/token-savers/rtk.ts
+++ b/packages/daemon/src/proxy/token-savers/rtk.ts
@@ -1,0 +1,498 @@
+import type { ContentBlock, MessagesRequest } from '../../core/anthropic/types.js'
+
+const RAW_CAP = 10 * 1024 * 1024
+const MIN_COMPRESS_SIZE = 500
+const DETECT_WINDOW = 1024
+const GIT_DIFF_HUNK_MAX_LINES = 100
+const GREP_PER_FILE_MAX = 10
+const FIND_PER_DIR_MAX = 10
+const FIND_TOTAL_DIR_MAX = 20
+const STATUS_MAX_FILES = 10
+const STATUS_MAX_UNTRACKED = 10
+const DEDUP_LINE_MAX = 2000
+const SMART_TRUNCATE_HEAD = 120
+const SMART_TRUNCATE_TAIL = 60
+const SMART_TRUNCATE_MIN_LINES = 250
+const READ_NUMBERED_MIN_HIT_RATIO = 0.7
+const SEARCH_LIST_PER_DIR_MAX = 10
+const SEARCH_LIST_TOTAL_DIR_MAX = 20
+const TREE_MAX_LINES = 200
+
+type Filter = ((input: string) => string) & { filterName?: string }
+
+export type RtkCompressionStats = {
+  bytesBefore: number
+  bytesAfter: number
+  hits: Array<{ shape: string; filter: string; saved: number }>
+}
+
+export function compressMessages(req: MessagesRequest, enabled: boolean): RtkCompressionStats | null {
+  if (!enabled) return null
+
+  const stats: RtkCompressionStats = { bytesBefore: 0, bytesAfter: 0, hits: [] }
+  try {
+    for (const message of req.messages) {
+      if (!Array.isArray(message.content)) continue
+      for (const block of message.content) {
+        if (block.type !== 'tool_result' || block.is_error === true) continue
+        if (typeof block.content === 'string') {
+          block.content = compressText(block.content, stats, 'claude-string')
+        } else if (Array.isArray(block.content)) {
+          for (const part of block.content) {
+            if (part.type === 'text') {
+              part.text = compressText(part.text, stats, 'claude-array')
+            }
+          }
+        }
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.warn(`[RTK] compressMessages error: ${message}`)
+    return null
+  }
+
+  return stats
+}
+
+export function formatRtkLog(stats: RtkCompressionStats | null): string | null {
+  if (!stats?.hits.length) return null
+  const saved = stats.bytesBefore - stats.bytesAfter
+  const pct = stats.bytesBefore > 0 ? ((saved / stats.bytesBefore) * 100).toFixed(1) : '0'
+  const filters = Array.from(new Set(stats.hits.map(hit => hit.filter))).join(',')
+  return `saved ${saved}B / ${stats.bytesBefore}B (${pct}%) via [${filters}] hits=${stats.hits.length}`
+}
+
+function compressText(text: string, stats: RtkCompressionStats, shape: string): string {
+  const bytesIn = text.length
+  stats.bytesBefore += bytesIn
+
+  if (bytesIn < MIN_COMPRESS_SIZE || bytesIn > RAW_CAP) {
+    stats.bytesAfter += bytesIn
+    return text
+  }
+
+  const filter = autoDetectFilter(text)
+  if (!filter) {
+    stats.bytesAfter += bytesIn
+    return text
+  }
+
+  const out = safeApply(filter, text)
+  if (!out || out.length === 0 || out.length >= bytesIn) {
+    stats.bytesAfter += bytesIn
+    return text
+  }
+
+  stats.bytesAfter += out.length
+  stats.hits.push({ shape, filter: filter.filterName ?? filter.name, saved: bytesIn - out.length })
+  return out
+}
+
+function safeApply(filter: Filter, text: string): string {
+  try {
+    const out = filter(text)
+    return typeof out === 'string' ? out : text
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.warn(`[rtk] warning: filter '${filter.filterName ?? filter.name}' failed; passing through raw output: ${message}`)
+    return text
+  }
+}
+
+function autoDetectFilter(text: string): Filter | null {
+  const head = text.length > DETECT_WINDOW ? text.slice(0, DETECT_WINDOW) : text
+  if (/^diff --git /m.test(head) || /^@@ /m.test(head)) return gitDiff
+  if (/^On branch |^nothing to commit|^Changes (not |to be )|^Untracked files:/m.test(head) || isMostlyPorcelain(head)) return gitStatus
+
+  const lines = head.split('\n')
+  const nonEmpty = lines.filter(line => line.trim().length > 0)
+  if (nonEmpty.slice(0, 5).some(isGrepLine)) return grep
+  if (nonEmpty.length >= 3 && nonEmpty.every(isPathLike)) return find
+  if (/[├└]──|│  /.test(head)) return tree
+  if (/^total \d+$/m.test(head) || countMatches(head, /^[-dlbcps][rwx-]{9}/m) >= 3) return ls
+  if (SEARCH_LIST_HEADER_RE.test(head)) return searchList
+  if (lines.length >= SMART_TRUNCATE_MIN_LINES && isLineNumbered(lines)) return readNumbered
+  if (nonEmpty.length >= 5) return dedupLog
+  if (text.split('\n').length >= SMART_TRUNCATE_MIN_LINES) return smartTruncate
+  return null
+}
+
+function isGrepLine(line: string): boolean {
+  const first = line.indexOf(':')
+  if (first === -1) return false
+  const second = line.indexOf(':', first + 1)
+  if (second === -1) return false
+  return /^\d+$/.test(line.slice(first + 1, second))
+}
+
+function isPathLike(line: string): boolean {
+  const t = line.trim()
+  if (!t || t.includes(':')) return false
+  return t.startsWith('.') || t.startsWith('/') || t.includes('/')
+}
+
+function isMostlyPorcelain(head: string): boolean {
+  const lines = head.split('\n').filter(line => line.trim())
+  if (lines.length < 3) return false
+  const hits = lines.filter(line => /^[ MADRCU?!][ MADRCU?!] \S/m.test(line)).length
+  return hits / lines.length >= 0.6
+}
+
+function isLineNumbered(lines: string[]): boolean {
+  let hits = 0
+  let nonEmpty = 0
+  for (const line of lines.slice(0, 100)) {
+    if (!line) continue
+    nonEmpty += 1
+    if (READ_NUMBERED_LINE_RE.test(line)) hits += 1
+  }
+  return nonEmpty >= 5 && hits / nonEmpty >= READ_NUMBERED_MIN_HIT_RATIO
+}
+
+function countMatches(text: string, re: RegExp): number {
+  return text.match(new RegExp(re.source, re.flags.includes('g') ? re.flags : `${re.flags}g`))?.length ?? 0
+}
+
+const gitDiff: Filter = (diff: string, maxLines = 500): string => {
+  const result: string[] = []
+  let currentFile = ''
+  let added = 0
+  let removed = 0
+  let inHunk = false
+  let hunkShown = 0
+  let hunkSkipped = 0
+  let wasTruncated = false
+
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('diff --git')) {
+      if (hunkSkipped > 0) {
+        result.push(`  ... (${hunkSkipped} lines truncated)`)
+        wasTruncated = true
+        hunkSkipped = 0
+      }
+      if (currentFile && (added > 0 || removed > 0)) result.push(`  +${added} -${removed}`)
+      currentFile = line.split(' b/').slice(1).join(' b/') || 'unknown'
+      result.push(`\n${currentFile}`)
+      added = 0
+      removed = 0
+      inHunk = false
+      hunkShown = 0
+    } else if (line.startsWith('@@')) {
+      if (hunkSkipped > 0) {
+        result.push(`  ... (${hunkSkipped} lines truncated)`)
+        wasTruncated = true
+        hunkSkipped = 0
+      }
+      inHunk = true
+      hunkShown = 0
+      result.push(`  ${line}`)
+    } else if (inHunk) {
+      if (line.startsWith('+') && !line.startsWith('+++')) {
+        added += 1
+        if (hunkShown < GIT_DIFF_HUNK_MAX_LINES) result.push(`  ${line}`)
+        else hunkSkipped += 1
+        hunkShown += 1
+      } else if (line.startsWith('-') && !line.startsWith('---')) {
+        removed += 1
+        if (hunkShown < GIT_DIFF_HUNK_MAX_LINES) result.push(`  ${line}`)
+        else hunkSkipped += 1
+        hunkShown += 1
+      } else if (hunkShown < GIT_DIFF_HUNK_MAX_LINES && !line.startsWith('\\') && hunkShown > 0) {
+        result.push(`  ${line}`)
+        hunkShown += 1
+      }
+    }
+    if (result.length >= maxLines) {
+      result.push('\n... (more changes truncated)')
+      wasTruncated = true
+      break
+    }
+  }
+
+  if (hunkSkipped > 0) {
+    result.push(`  ... (${hunkSkipped} lines truncated)`)
+    wasTruncated = true
+  }
+  if (currentFile && (added > 0 || removed > 0)) result.push(`  +${added} -${removed}`)
+  if (wasTruncated) result.push('[full diff: rtk git diff --no-compact]')
+  return result.join('\n')
+}
+gitDiff.filterName = 'git-diff'
+
+const gitStatus: Filter = (input: string): string => {
+  const stagedFiles: string[] = []
+  const modifiedFiles: string[] = []
+  const untrackedFiles: string[] = []
+  let branch = ''
+  let staged = 0
+  let modified = 0
+  let untracked = 0
+  let conflicts = 0
+
+  for (const raw of input.split('\n')) {
+    if (!raw.trim()) continue
+    const longBranch = raw.match(/^On branch (\S+)/)
+    if (longBranch) {
+      branch = longBranch[1] ?? ''
+      continue
+    }
+    if (raw.startsWith('##')) {
+      branch = raw.replace(/^##\s*/, '')
+      continue
+    }
+    if (/^[ MADRCU?!][ MADRCU?!] /.test(raw)) {
+      const x = raw[0]
+      const y = raw[1]
+      const file = raw.slice(3)
+      if (raw.slice(0, 2) === '??') {
+        untracked += 1
+        untrackedFiles.push(file)
+        continue
+      }
+      if ('MADRC'.includes(x)) {
+        staged += 1
+        stagedFiles.push(file)
+      } else if (x === 'U') conflicts += 1
+      if (y === 'M' || y === 'D') {
+        modified += 1
+        modifiedFiles.push(file)
+      }
+      continue
+    }
+    const longMatch = raw.match(/^\s*(modified|new file|deleted|renamed|both modified):\s+(.+)$/)
+    if (!longMatch) continue
+    const kind = longMatch[1]
+    const file = longMatch[2]?.trim() ?? ''
+    if (kind === 'both modified') conflicts += 1
+    else if (kind === 'modified' || kind === 'deleted') {
+      modified += 1
+      modifiedFiles.push(file)
+    } else {
+      staged += 1
+      stagedFiles.push(file)
+    }
+  }
+
+  let out = branch ? `* ${branch}\n` : ''
+  out += statusSection('+ Staged', staged, stagedFiles, STATUS_MAX_FILES)
+  out += statusSection('~ Modified', modified, modifiedFiles, STATUS_MAX_FILES)
+  out += statusSection('? Untracked', untracked, untrackedFiles, STATUS_MAX_UNTRACKED)
+  if (conflicts > 0) out += `conflicts: ${conflicts} files\n`
+  if (staged === 0 && modified === 0 && untracked === 0 && conflicts === 0) out += 'clean - nothing to commit\n'
+  return out.replace(/\n+$/, '')
+}
+gitStatus.filterName = 'git-status'
+
+function statusSection(title: string, count: number, files: string[], max: number): string {
+  if (count <= 0) return ''
+  let out = `${title}: ${count} files\n`
+  for (const file of files.slice(0, max)) out += `   ${file}\n`
+  if (files.length > max) out += `   ... +${files.length - max} more\n`
+  return out
+}
+
+const grep: Filter = (input: string): string => {
+  const byFile = new Map<string, Array<[string, string]>>()
+  let total = 0
+  for (const line of input.split('\n')) {
+    const first = line.indexOf(':')
+    const second = first === -1 ? -1 : line.indexOf(':', first + 1)
+    if (first === -1 || second === -1) continue
+    const lineNum = line.slice(first + 1, second)
+    if (!/^\d+$/.test(lineNum)) continue
+    const file = line.slice(0, first)
+    total += 1
+    const matches = byFile.get(file) ?? []
+    matches.push([lineNum, line.slice(second + 1)])
+    byFile.set(file, matches)
+  }
+  if (total === 0) return input
+  let out = `${total} matches in ${byFile.size}F:\n\n`
+  for (const file of Array.from(byFile.keys()).sort()) {
+    const matches = byFile.get(file) ?? []
+    out += `[file] ${file} (${matches.length}):\n`
+    for (const [lineNum, content] of matches.slice(0, GREP_PER_FILE_MAX)) out += `  ${lineNum.padStart(4)}: ${content.trim()}\n`
+    if (matches.length > GREP_PER_FILE_MAX) out += `  +${matches.length - GREP_PER_FILE_MAX}\n`
+    out += '\n'
+  }
+  return out
+}
+grep.filterName = 'grep'
+
+const find: Filter = (input: string): string => {
+  const lines = input.split('\n').filter(line => line.trim())
+  if (!lines.length) return input
+  const byDir = new Map<string, string[]>()
+  for (const p of lines) {
+    const slash = p.lastIndexOf('/')
+    const dir = slash === -1 ? '.' : p.slice(0, slash) || '/'
+    const basename = slash === -1 ? p : p.slice(slash + 1)
+    byDir.set(dir, [...(byDir.get(dir) ?? []), basename])
+  }
+  const dirs = Array.from(byDir.keys()).sort()
+  let out = `${lines.length} files in ${dirs.length} dirs:\n\n`
+  for (const dir of dirs.slice(0, FIND_TOTAL_DIR_MAX)) {
+    const files = byDir.get(dir) ?? []
+    out += `${dir}/ (${files.length}):\n`
+    for (const file of files.slice(0, FIND_PER_DIR_MAX)) out += `  ${file}\n`
+    if (files.length > FIND_PER_DIR_MAX) out += `  +${files.length - FIND_PER_DIR_MAX}\n`
+    out += '\n'
+  }
+  if (dirs.length > FIND_TOTAL_DIR_MAX) out += `+${dirs.length - FIND_TOTAL_DIR_MAX} more dirs\n`
+  return out
+}
+find.filterName = 'find'
+
+const dedupLog: Filter = (input: string): string => {
+  const out: string[] = []
+  let prev: string | null = null
+  let runCount = 0
+  let blankStreak = 0
+  const flushRun = () => {
+    if (prev !== null && runCount > 1) out.push(`  ... (${runCount - 1} duplicate lines)`)
+  }
+  for (const line of input.split('\n')) {
+    if (line.trim() === '') {
+      if (blankStreak < 1) out.push(line)
+      blankStreak += 1
+      flushRun()
+      prev = null
+      runCount = 0
+      continue
+    }
+    blankStreak = 0
+    if (line === prev) {
+      runCount += 1
+      continue
+    }
+    flushRun()
+    out.push(line)
+    prev = line
+    runCount = 1
+    if (out.length >= DEDUP_LINE_MAX) return `${out.join('\n')}\n... (truncated at ${DEDUP_LINE_MAX} lines)`
+  }
+  flushRun()
+  return out.join('\n')
+}
+dedupLog.filterName = 'dedup-log'
+
+const smartTruncate: Filter = (input: string): string => truncateLines(input, '... +{cut} lines truncated')
+smartTruncate.filterName = 'smart-truncate'
+
+const READ_NUMBERED_LINE_RE = /^\s*\d+\|/
+const readNumbered: Filter = (input: string): string => truncateLines(input, '... +{cut} lines truncated (file continues)')
+readNumbered.filterName = 'read-numbered'
+
+function truncateLines(input: string, marker: string): string {
+  const lines = input.split('\n')
+  if (lines.length < SMART_TRUNCATE_MIN_LINES) return input
+  const head = lines.slice(0, SMART_TRUNCATE_HEAD)
+  const tail = lines.slice(lines.length - SMART_TRUNCATE_TAIL)
+  const cut = lines.length - head.length - tail.length
+  return [...head, marker.replace('{cut}', String(cut)), ...tail].join('\n')
+}
+
+const tree: Filter = (input: string): string => {
+  const filtered = input
+    .split('\n')
+    .filter(line => !(line.includes('director') && line.includes('file')))
+  while (filtered.length > 0 && filtered[0]?.trim() === '') filtered.shift()
+  while (filtered.length > 0 && filtered[filtered.length - 1]?.trim() === '') filtered.pop()
+  if (filtered.length > TREE_MAX_LINES) return `${filtered.slice(0, TREE_MAX_LINES).join('\n')}\n... +${filtered.length - TREE_MAX_LINES} more lines`
+  return filtered.join('\n')
+}
+tree.filterName = 'tree'
+
+const SEARCH_LIST_HEADER_RE = /^Result of search in '[^']*' \(total (\d+) files?\):/
+const searchList: Filter = (input: string): string => {
+  const lines = input.split('\n')
+  const header = lines[0] ?? ''
+  const paths = lines.slice(1).map(line => line.trim()).filter(line => line.startsWith('- ')).map(line => line.slice(2))
+  if (!paths.length) return input
+  const byDir = new Map<string, string[]>()
+  for (const p of paths) {
+    const slash = p.lastIndexOf('/')
+    const dir = slash === -1 ? '.' : p.slice(0, slash) || '/'
+    const name = slash === -1 ? p : p.slice(slash + 1)
+    byDir.set(dir, [...(byDir.get(dir) ?? []), name])
+  }
+  const dirs = Array.from(byDir.keys()).sort()
+  let out = `${header}\n${paths.length} files in ${dirs.length} dirs:\n\n`
+  for (const dir of dirs.slice(0, SEARCH_LIST_TOTAL_DIR_MAX)) {
+    const names = byDir.get(dir) ?? []
+    out += `${dir}/ (${names.length}):\n`
+    for (const name of names.slice(0, SEARCH_LIST_PER_DIR_MAX)) out += `  ${name}\n`
+    if (names.length > SEARCH_LIST_PER_DIR_MAX) out += `  +${names.length - SEARCH_LIST_PER_DIR_MAX}\n`
+    out += '\n'
+  }
+  if (dirs.length > SEARCH_LIST_TOTAL_DIR_MAX) out += `+${dirs.length - SEARCH_LIST_TOTAL_DIR_MAX} more dirs\n`
+  return out.replace(/\n+$/, '')
+}
+searchList.filterName = 'search-list'
+
+const LS_DATE_RE = /\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+(\d{4}|\d{2}:\d{2})\s+/
+const LS_NOISE_DIRS = new Set(['node_modules', '.git', 'target', '__pycache__', '.next', 'dist', 'build', '.venv', 'venv', '.cache', '.idea', '.vscode', '.DS_Store'])
+
+const ls: Filter = (input: string): string => {
+  const dirs: string[] = []
+  const files: Array<[string, string]> = []
+  const byExt = new Map<string, number>()
+  for (const line of input.split('\n')) {
+    if (line.startsWith('total ') || !line) continue
+    const parsed = parseLsLine(line)
+    if (!parsed || parsed.name === '.' || parsed.name === '..' || LS_NOISE_DIRS.has(parsed.name)) continue
+    if (parsed.fileType === 'd') dirs.push(parsed.name)
+    else if (parsed.fileType === '-' || parsed.fileType === 'l') {
+      const dot = parsed.name.lastIndexOf('.')
+      const ext = dot > 0 ? parsed.name.slice(dot) : 'no ext'
+      byExt.set(ext, (byExt.get(ext) ?? 0) + 1)
+      files.push([parsed.name, humanSize(parsed.size)])
+    }
+  }
+  if (dirs.length === 0 && files.length === 0) return input
+  let out = ''
+  for (const dir of dirs) out += `${dir}/\n`
+  for (const [name, size] of files) out += `${name}  ${size}\n`
+  let summary = `\nSummary: ${files.length} files, ${dirs.length} dirs`
+  if (byExt.size > 0) {
+    const ext = Array.from(byExt.entries()).sort((a, b) => b[1] - a[1])
+    summary += ` (${ext.slice(0, 5).map(([e, c]) => `${c} ${e}`).join(', ')}`
+    if (ext.length > 5) summary += `, +${ext.length - 5} more`
+    summary += ')'
+  }
+  return out + summary
+}
+ls.filterName = 'ls'
+
+function parseLsLine(line: string): { fileType: string; size: number; name: string } | null {
+  const match = LS_DATE_RE.exec(line)
+  if (!match) return null
+  const beforeParts = line.slice(0, match.index).split(/\s+/).filter(Boolean)
+  if (beforeParts.length < 4) return null
+  const perms = beforeParts[0] ?? ''
+  let size = 0
+  for (let i = beforeParts.length - 1; i >= 0; i -= 1) {
+    const n = Number(beforeParts[i])
+    if (Number.isInteger(n) && String(n) === beforeParts[i]) {
+      size = n
+      break
+    }
+  }
+  return { fileType: perms.charAt(0), size, name: line.slice(match.index + match[0].length) }
+}
+
+function humanSize(bytes: number): string {
+  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)}M`
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)}K`
+  return `${bytes}B`
+}
+
+export function cloneMessagesRequest(req: MessagesRequest): MessagesRequest {
+  return structuredClone(req) as MessagesRequest
+}
+
+export function extractToolResultText(block: Extract<ContentBlock, { type: 'tool_result' }>): string {
+  if (typeof block.content === 'string') return block.content
+  return block.content.filter(part => part.type === 'text').map(part => part.text).join('\n')
+}

--- a/packages/daemon/src/proxy/token-savers/rtk.ts
+++ b/packages/daemon/src/proxy/token-savers/rtk.ts
@@ -229,6 +229,7 @@ const gitStatus: Filter = (input: string): string => {
   let modified = 0
   let untracked = 0
   let conflicts = 0
+  let inStagedSection = false
 
   for (const raw of input.split('\n')) {
     if (!raw.trim()) continue
@@ -239,6 +240,14 @@ const gitStatus: Filter = (input: string): string => {
     }
     if (raw.startsWith('##')) {
       branch = raw.replace(/^##\s*/, '')
+      continue
+    }
+    if (raw.includes('Changes to be committed:')) {
+      inStagedSection = true
+      continue
+    }
+    if (raw.includes('Changes not staged for commit:') || raw.includes('Untracked files:') || raw.includes('Unmerged paths:')) {
+      inStagedSection = false
       continue
     }
     if (/^[ MADRCU?!][ MADRCU?!] /.test(raw)) {
@@ -265,12 +274,12 @@ const gitStatus: Filter = (input: string): string => {
     const kind = longMatch[1]
     const file = longMatch[2]?.trim() ?? ''
     if (kind === 'both modified') conflicts += 1
-    else if (kind === 'modified' || kind === 'deleted') {
-      modified += 1
-      modifiedFiles.push(file)
-    } else {
+    else if (inStagedSection) {
       staged += 1
       stagedFiles.push(file)
+    } else {
+      modified += 1
+      modifiedFiles.push(file)
     }
   }
 

--- a/packages/daemon/src/proxy/token-savers/token-savers.test.ts
+++ b/packages/daemon/src/proxy/token-savers/token-savers.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import type { MessagesRequest } from '../../core/anthropic/types.js'
+import { injectCaveman } from './caveman.js'
+import { compressMessages } from './rtk.js'
+
+test('RTK compresses large tool_result grep output', () => {
+  const lines = Array.from({ length: 30 }, (_, i) => `src/file-${i % 3}.ts:${i + 1}:const value${i} = true`)
+  const req = baseRequest(lines.join('\n'))
+
+  const before = toolContent(req).length
+  const stats = compressMessages(req, true)
+  const after = toolContent(req).length
+
+  assert.ok(stats)
+  assert.ok(stats.hits.some(hit => hit.filter === 'grep'))
+  assert.ok(after < before)
+  assert.match(toolContent(req), /matches in 3F/)
+})
+
+test('RTK leaves errored tool_result content untouched', () => {
+  const req = baseRequest('src/a.ts:1:value\n'.repeat(80), true)
+
+  const before = toolContent(req)
+  const stats = compressMessages(req, true)
+
+  assert.equal(toolContent(req), before)
+  assert.equal(stats?.hits.length, 0)
+})
+
+test('caveman injects terse guidance into existing system prompt', () => {
+  const req = baseRequest('small')
+  req.system = 'Existing rules.'
+
+  injectCaveman(req, true, 'ultra')
+
+  assert.equal(typeof req.system, 'string')
+  assert.match(req.system as string, /Existing rules\./)
+  assert.match(req.system as string, /ultra-terse/)
+})
+
+test('caveman inserts before last cache_control block to preserve prompt cache', () => {
+  const req = baseRequest('small')
+  req.system = [
+    { type: 'text', text: 'rule A' },
+    { type: 'text', text: 'rule B', cache_control: { type: 'ephemeral' } } as { type: 'text'; text: string },
+    { type: 'text', text: 'rule C' },
+  ]
+
+  injectCaveman(req, true, 'full')
+
+  assert.ok(Array.isArray(req.system))
+  const texts = (req.system as Array<{ text: string }>).map(b => b.text)
+  const cavemanIdx = texts.findIndex(t => /terse caveman/.test(t))
+  const cachedIdx = texts.findIndex(t => t === 'rule B')
+  assert.ok(cavemanIdx >= 0 && cachedIdx >= 0)
+  assert.ok(cavemanIdx < cachedIdx, `caveman (${cavemanIdx}) must come before cached block (${cachedIdx})`)
+})
+
+test('caveman appends to system array when no cache_control present', () => {
+  const req = baseRequest('small')
+  req.system = [
+    { type: 'text', text: 'rule A' },
+    { type: 'text', text: 'rule B' },
+  ]
+
+  injectCaveman(req, true, 'lite')
+
+  assert.ok(Array.isArray(req.system))
+  const arr = req.system as Array<{ text: string }>
+  assert.equal(arr.length, 3)
+  assert.match(arr[2]!.text, /terse/)
+})
+
+function baseRequest(toolResult: string, isError = false): MessagesRequest {
+  return {
+    model: 'claude-sonnet-4-5',
+    max_tokens: 1024,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_123',
+            content: toolResult,
+            is_error: isError,
+          },
+        ],
+      },
+    ],
+  }
+}
+
+function toolContent(req: MessagesRequest): string {
+  const content = req.messages[0]?.content
+  assert.ok(Array.isArray(content))
+  const block = content[0]
+  assert.equal(block?.type, 'tool_result')
+  if (block.type !== 'tool_result' || typeof block.content !== 'string') {
+    throw new Error('expected string tool_result content')
+  }
+  return block.content
+}

--- a/packages/daemon/src/runtime/session-types.ts
+++ b/packages/daemon/src/runtime/session-types.ts
@@ -34,6 +34,15 @@ export interface SessionRequestLogEntry {
   error: string | null
   prompt?: string
   response?: string
+  tokenSavers?: TokenSaverStats
+}
+
+export interface TokenSaverStats {
+  rtkBytesBefore: number
+  rtkBytesAfter: number
+  rtkHits: number
+  rtkFilters: string[]
+  cavemanLevel: 'lite' | 'full' | 'ultra' | null
 }
 
 export interface SessionRecord {

--- a/packages/daemon/src/runtime/sessions.ts
+++ b/packages/daemon/src/runtime/sessions.ts
@@ -29,6 +29,7 @@ export type {
   SessionProviderStat,
   SessionRecord,
   SessionRequestLogEntry,
+  TokenSaverStats,
 } from './session-types.js'
 
 const HEARTBEAT_TIMEOUT_MS = 60_000

--- a/packages/panel/src/features/dashboard/components/DashboardPage.tsx
+++ b/packages/panel/src/features/dashboard/components/DashboardPage.tsx
@@ -15,7 +15,7 @@ const DISMISSED_SHELL_SETUP_KEY = "cc-provider-gtw:shell-setup-dismissed";
 export default function DashboardPage() {
   const { token } = theme.useToken();
   const { status, stats } = useGatewayStatus();
-  const { items } = useLaunchCommands();
+  const { items, error: launchError } = useLaunchCommands();
   const { setup, refresh } = useShellSetup();
   const { logs, paused, togglePaused, clear } = useLiveLogs();
   const [setupDismissed, setSetupDismissed] = useState(
@@ -47,7 +47,7 @@ export default function DashboardPage() {
       <StatusOverview status={status} />
       <EnabledProvidersCard stats={stats} />
       {!hasTerminalConfigured && shellSetupCard}
-      <QuickLaunchCard items={items} />
+      <QuickLaunchCard items={items} error={launchError} />
       {hasTerminalConfigured && shellSetupCard}
       <LiveLogsPanel
         logs={logs}

--- a/packages/panel/src/features/dashboard/components/ShellSetupCard.tsx
+++ b/packages/panel/src/features/dashboard/components/ShellSetupCard.tsx
@@ -137,14 +137,15 @@ export function ShellSetupCard({
 
 interface QuickLaunchCardProps {
   items: LaunchItem[];
+  error?: Error | null;
 }
 
-export function QuickLaunchCard({ items }: QuickLaunchCardProps) {
+export function QuickLaunchCard({ items, error }: QuickLaunchCardProps) {
   const { copiedKey, copy } = useCopyToClipboard();
 
   return (
     <Card title="Quick Launch">
-      <AvailableProviders items={items} onCopy={copy} copiedKey={copiedKey} />
+      <AvailableProviders items={items} error={error} onCopy={copy} copiedKey={copiedKey} />
     </Card>
   );
 }
@@ -166,14 +167,26 @@ function HeaderSummary({ shells }: { shells: ShellInfo[] }) {
 
 function AvailableProviders({
   items,
+  error,
   copiedKey,
   onCopy,
 }: {
   items: LaunchItem[];
+  error?: Error | null;
   copiedKey: string | null;
   onCopy: (key: string, value: string) => void;
 }) {
   const { token } = theme.useToken();
+  if (error) {
+    return (
+      <Empty
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+        description={`Quick Launch unavailable: ${error.message}`}
+        style={{ margin: 0 }}
+      />
+    );
+  }
+
   if (items.length === 0) {
     return (
       <Empty

--- a/packages/panel/src/features/dashboard/dashboardService.ts
+++ b/packages/panel/src/features/dashboard/dashboardService.ts
@@ -3,6 +3,7 @@ import type {
   GatewayStatus,
   InstallResponse,
   LaunchCommands,
+  QuickLaunch,
   ShellName,
   ShellSetup,
   StatsResponse,
@@ -12,6 +13,7 @@ export const dashboardService = {
   getStatus: () => http.get<GatewayStatus>("/status"),
   getStats: () => http.get<StatsResponse>("/stats"),
   getLaunchCommands: () => http.get<LaunchCommands>("/launch-commands"),
+  getQuickLaunch: () => http.get<QuickLaunch>("/quick-launch"),
   getShellSetup: () => http.get<ShellSetup>("/shell-setup"),
   installShellSetup: (shells: ShellName[]) =>
     http.post<InstallResponse>("/shell-setup/install", { shells }),

--- a/packages/panel/src/features/dashboard/hooks/useLaunchCommands.ts
+++ b/packages/panel/src/features/dashboard/hooks/useLaunchCommands.ts
@@ -1,12 +1,21 @@
 import { useEffect, useMemo, useState } from "react";
 import { dashboardService } from "../dashboardService.js";
-import type { LaunchCommands, LaunchItem } from "../types.js";
+import type { LaunchItem, QuickLaunch } from "../types.js";
 
 export function useLaunchCommands() {
-  const [launch, setLaunch] = useState<LaunchCommands | null>(null);
+  const [launch, setLaunch] = useState<QuickLaunch | null>(null);
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    dashboardService.getLaunchCommands().then(setLaunch).catch(() => {});
+    dashboardService
+      .getQuickLaunch()
+      .then((value) => {
+        setLaunch(value);
+        setError(null);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err : new Error("Quick Launch failed"));
+      });
   }, []);
 
   const items: LaunchItem[] = useMemo(() => {
@@ -22,5 +31,5 @@ export function useLaunchCommands() {
     ];
   }, [launch]);
 
-  return { launch, items };
+  return { launch, items, error };
 }

--- a/packages/panel/src/features/dashboard/types.ts
+++ b/packages/panel/src/features/dashboard/types.ts
@@ -4,6 +4,7 @@ import type {
   InstallResult,
   InstallShellSetupResponse,
   LaunchCommandsResponse,
+  QuickLaunchResponse,
   ShellInfo,
   ShellName,
   ShellSetupResponse,
@@ -15,6 +16,7 @@ export type StatsResponse = {
   providers: GatewayProviderStat[];
 };
 export type LaunchCommands = LaunchCommandsResponse;
+export type QuickLaunch = QuickLaunchResponse;
 
 export interface LaunchItem {
   id: string;

--- a/packages/panel/src/features/history/components/RequestLogTable.tsx
+++ b/packages/panel/src/features/history/components/RequestLogTable.tsx
@@ -99,6 +99,38 @@ export function RequestLogTable({ entries }: RequestLogTableProps) {
       ),
     },
     {
+      title: "Savers",
+      key: "tokenSavers",
+      width: 160,
+      render: (_, e) => {
+        const ts = e.tokenSavers;
+        if (!ts) return <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>—</Text>;
+        const saved = ts.rtkBytesBefore - ts.rtkBytesAfter;
+        const pct = ts.rtkBytesBefore > 0 ? ((saved / ts.rtkBytesBefore) * 100).toFixed(0) : "0";
+        return (
+          <Space size={4} wrap>
+            {ts.rtkHits > 0 && (
+              <Tooltip title={`RTK saved ${saved}B (${pct}%) via ${ts.rtkFilters.join(", ")}`}>
+                <Tag color="geekblue" style={{ margin: 0, fontFamily: "monospace", fontSize: token.fontSizeSM }}>
+                  RTK -{pct}%
+                </Tag>
+              </Tooltip>
+            )}
+            {ts.cavemanLevel && (
+              <Tooltip title={`Caveman ${ts.cavemanLevel} injected into system prompt`}>
+                <Tag color="orange" style={{ margin: 0, fontFamily: "monospace", fontSize: token.fontSizeSM }}>
+                  CAVE {ts.cavemanLevel}
+                </Tag>
+              </Tooltip>
+            )}
+            {ts.rtkHits === 0 && !ts.cavemanLevel && (
+              <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>—</Text>
+            )}
+          </Space>
+        );
+      },
+    },
+    {
       title: "Response",
       key: "has_resp",
       width: 90,

--- a/packages/panel/src/features/settings/components/SettingsPage.tsx
+++ b/packages/panel/src/features/settings/components/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { useSettings } from "../hooks/useSettings.js";
 import { ServerCard } from "./ServerCard.js";
 import { WebToolsCard } from "./WebToolsCard.js";
 import { ProxyCard } from "./ProxyCard.js";
+import { TokenSaversCard } from "./TokenSaversCard.js";
 
 export default function SettingsPage() {
   const { token } = theme.useToken();
@@ -15,6 +16,8 @@ export default function SettingsPage() {
     updateWebTools,
     proxy,
     updateProxy,
+    tokenSavers,
+    updateTokenSavers,
     loaded,
     saving,
     saved,
@@ -36,6 +39,9 @@ export default function SettingsPage() {
         </Col>
         <Col xs={24} lg={12}>
           <ProxyCard value={proxy} onChange={updateProxy} />
+        </Col>
+        <Col xs={24} lg={12}>
+          <TokenSaversCard value={tokenSavers} onChange={updateTokenSavers} />
         </Col>
       </Row>
 

--- a/packages/panel/src/features/settings/components/TokenSaversCard.tsx
+++ b/packages/panel/src/features/settings/components/TokenSaversCard.tsx
@@ -42,6 +42,7 @@ export function TokenSaversCard({ value, onChange }: TokenSaversCardProps) {
             Caveman level
           </Text>
           <Segmented
+            aria-label="Caveman mode level"
             disabled={!value.cavemanEnabled}
             value={value.cavemanLevel}
             options={[
@@ -71,7 +72,7 @@ function ToggleRow({ title, description, checked, onChange }: ToggleRowProps) {
         <Text strong>{title}</Text>
         <Text type="secondary">{description}</Text>
       </Flex>
-      <Switch checked={checked} onChange={onChange} />
+      <Switch aria-label={title} checked={checked} onChange={onChange} />
     </Flex>
   );
 }

--- a/packages/panel/src/features/settings/components/TokenSaversCard.tsx
+++ b/packages/panel/src/features/settings/components/TokenSaversCard.tsx
@@ -1,0 +1,77 @@
+import { Card, Divider, Flex, Segmented, Space, Switch, Typography, theme } from "antd";
+import { CompressOutlined } from "@ant-design/icons";
+import type { TokenSaversConfig } from "../types.js";
+
+const { Text } = Typography;
+
+interface TokenSaversCardProps {
+  value: TokenSaversConfig;
+  onChange: (patch: Partial<TokenSaversConfig>) => void;
+}
+
+export function TokenSaversCard({ value, onChange }: TokenSaversCardProps) {
+  const { token } = theme.useToken();
+  return (
+    <Card
+      title={
+        <Space>
+          <CompressOutlined />
+          Token Savers
+        </Space>
+      }
+    >
+      <Flex vertical gap={token.padding}>
+        <ToggleRow
+          title="RTK compression"
+          description="Compact large tool results before provider dispatch"
+          checked={value.rtkEnabled}
+          onChange={(v) => onChange({ rtkEnabled: v })}
+        />
+
+        <Divider style={{ margin: 0 }} />
+
+        <ToggleRow
+          title="Caveman mode"
+          description="Inject terse-response guidance into the system prompt"
+          checked={value.cavemanEnabled}
+          onChange={(v) => onChange({ cavemanEnabled: v })}
+        />
+
+        <Flex vertical gap={token.paddingXS}>
+          <Text strong style={{ opacity: value.cavemanEnabled ? 1 : 0.4 }}>
+            Caveman level
+          </Text>
+          <Segmented
+            disabled={!value.cavemanEnabled}
+            value={value.cavemanLevel}
+            options={[
+              { label: "Lite", value: "lite" },
+              { label: "Full", value: "full" },
+              { label: "Ultra", value: "ultra" },
+            ]}
+            onChange={(v) => onChange({ cavemanLevel: v as TokenSaversConfig["cavemanLevel"] })}
+          />
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}
+
+interface ToggleRowProps {
+  title: string;
+  description: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+}
+
+function ToggleRow({ title, description, checked, onChange }: ToggleRowProps) {
+  return (
+    <Flex justify="space-between" align="flex-start" gap="middle">
+      <Flex vertical>
+        <Text strong>{title}</Text>
+        <Text type="secondary">{description}</Text>
+      </Flex>
+      <Switch checked={checked} onChange={onChange} />
+    </Flex>
+  );
+}

--- a/packages/panel/src/features/settings/hooks/useSettings.ts
+++ b/packages/panel/src/features/settings/hooks/useSettings.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Form } from "antd";
 import { useSaveFeedback } from "../../../shared/hooks/useSaveFeedback.js";
 import { settingsService } from "../settingsService.js";
-import type { ServerConfig, WebToolsConfig, ProxyConfig } from "../types.js";
+import type { ServerConfig, WebToolsConfig, ProxyConfig, TokenSaversConfig } from "../types.js";
 
 const DEFAULT_WEB_TOOLS: WebToolsConfig = {
   enabled: true,
@@ -14,11 +14,18 @@ const DEFAULT_PROXY: ProxyConfig = {
   url: "",
 };
 
+const DEFAULT_TOKEN_SAVERS: TokenSaversConfig = {
+  rtkEnabled: false,
+  cavemanEnabled: false,
+  cavemanLevel: "lite",
+};
+
 export function useSettings() {
   const [serverForm] = Form.useForm<ServerConfig>();
   const [serverConfig, setServerConfig] = useState<ServerConfig | null>(null);
   const [webTools, setWebTools] = useState<WebToolsConfig>(DEFAULT_WEB_TOOLS);
   const [proxy, setProxy] = useState<ProxyConfig>(DEFAULT_PROXY);
+  const [tokenSavers, setTokenSavers] = useState<TokenSaversConfig>(DEFAULT_TOKEN_SAVERS);
   const [loaded, setLoaded] = useState(false);
   const { saving, saved, wrap } = useSaveFeedback();
 
@@ -30,6 +37,7 @@ export function useSettings() {
         serverForm.setFieldsValue(c.server);
         setWebTools(c.webTools);
         setProxy(c.proxy);
+        setTokenSavers(c.tokenSavers);
       })
       .finally(() => setLoaded(true));
   }, [serverForm]);
@@ -40,9 +48,12 @@ export function useSettings() {
   const updateProxy = (patch: Partial<ProxyConfig>) =>
     setProxy((p) => ({ ...p, ...patch }));
 
+  const updateTokenSavers = (patch: Partial<TokenSaversConfig>) =>
+    setTokenSavers((t) => ({ ...t, ...patch }));
+
   const save = () => {
     const nextServer = serverForm.getFieldsValue();
-    return wrap(() => settingsService.save(nextServer, webTools, proxy)).then(() => {
+    return wrap(() => settingsService.save(nextServer, webTools, proxy, tokenSavers)).then(() => {
       setServerConfig((current) => ({ ...(current ?? serverForm.getFieldsValue(true)), ...nextServer }));
     });
   };
@@ -53,6 +64,8 @@ export function useSettings() {
     updateWebTools,
     proxy,
     updateProxy,
+    tokenSavers,
+    updateTokenSavers,
     loaded,
     saving,
     saved,

--- a/packages/panel/src/features/settings/settingsService.ts
+++ b/packages/panel/src/features/settings/settingsService.ts
@@ -1,8 +1,13 @@
 import { http } from "../../shared/api/http.js";
-import type { SettingsConfig, ServerConfig, WebToolsConfig, ProxyConfig } from "./types.js";
+import type { SettingsConfig, ServerConfig, WebToolsConfig, ProxyConfig, TokenSaversConfig } from "./types.js";
 
 export const settingsService = {
   get: () => http.get<SettingsConfig>("/config"),
-  save: (server: Partial<ServerConfig>, webTools: WebToolsConfig, proxy: ProxyConfig) =>
-    http.put<unknown>("/config", { server, webTools, proxy }),
+  save: (
+    server: Partial<ServerConfig>,
+    webTools: WebToolsConfig,
+    proxy: ProxyConfig,
+    tokenSavers: TokenSaversConfig,
+  ) =>
+    http.put<unknown>("/config", { server, webTools, proxy, tokenSavers }),
 };

--- a/packages/panel/src/features/settings/types.ts
+++ b/packages/panel/src/features/settings/types.ts
@@ -6,4 +6,5 @@ import type { Config } from "../../../../daemon/src/config/schema.js";
 export type ServerConfig = Partial<Config["server"]>;
 export type WebToolsConfig = Config["webTools"];
 export type ProxyConfig = Config["proxy"];
+export type TokenSaversConfig = Config["tokenSavers"];
 export type SettingsConfig = SettingsConfigResponse;


### PR DESCRIPTION
## Summary

Adds optional token-saving controls to CCPG:

- RTK-style compression for large `tool_result` payloads before provider dispatch
- Caveman terse-response mode with `lite`, `full`, and `ultra` levels
- Settings UI for enabling/disabling both features
- Dashboard Quick Launch fix using a token-free `/api/quick-launch` endpoint
- Documentation for usage, architecture, and development validation

## What Changed

### Daemon

- Added `Config.tokenSavers`:
  - `rtkEnabled`
  - `cavemanEnabled`
  - `cavemanLevel`
- Added runtime config normalization and defaults.
- Added RTK compression module under `proxy/token-savers/`.
- Added Caveman system prompt injection module.
- Applied token savers in `MessageService` before provider/native Claude dispatch.
- Recomputed input token count after compression.
- Added token-saver tests.
- Made `PanelRuntime` persistence injectable for tests.
- Added `/api/quick-launch` for non-sensitive dashboard launch commands.

### Panel

- Added **Settings -> Token Savers** card.
- Wired token saver settings through `useSettings`, `settingsService`, and shared types.
- Updated Quick Launch to use `/api/quick-launch`.
- Added Quick Launch error display instead of silently rendering an empty state.

### Docs

- Documented Token Savers in `README.md`.
- Updated architecture docs with token-saver modules, request flow, config, and API details.
- Added development/testing guidance for RTK and Caveman.

## Behavior Notes

RTK only compresses large tool-result payloads. It does not alter normal chat messages or errored tool results. If compression fails or produces larger output, the original text is preserved.

Caveman mode does not reduce input tokens. It injects terse-response guidance into the system prompt to reduce response verbosity/output tokens.

## Validation

- `npm run typecheck`
- `npm test --workspace @claude-code-provider-gateway/daemon`
- `npm run build`

`npm run lint` was not available locally because `eslint` was not installed/resolvable in the workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Token Savers settings now available in Settings page, with optional toggles for RTK compression and Caveman mode at multiple intensity levels
- Request history view displays token compression statistics in new "Savers" column with bytes saved and filter details
- Improved error handling for Quick Launch commands on dashboard

**Documentation**
- Updated README, architecture, and development documentation for Token Savers setup and implementation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danielalves96/claude-code-provider-gateway/pull/6)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->