### PR TITLE
chore: centralize formatting and linting with Biome

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,6 +10,7 @@ on:
       - "package.json"
       - "package-lock.json"
       - "tsconfig.json"
+      - "biome.jsonc"
       - ".github/workflows/quality.yml"
   workflow_dispatch:
 
@@ -20,6 +21,23 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  biome:
+    name: Biome format and lint
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting, lint, and imports
+        run: npm run quality:ci -- --reporter=github --diagnostic-level=error
+
   typescript:
     name: TypeScript build and daemon tests
     runs-on: ubuntu-22.04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ This starts the desktop app, panel dev server, and hot-reload daemon. See [docs/
 
 ## Pull Request Checklist
 
+- Run `npm run quality:ci`.
 - Run `npm test`.
 - Run `npm run build` when touching daemon, panel, types, or shared build config.
 - Update docs when changing setup, provider behavior, routing, storage, or release behavior.
@@ -48,6 +49,7 @@ This starts the desktop app, panel dev server, and hot-reload daemon. See [docs/
 
 ## Code Style
 
+- **Biome** - centralized formatter, linter, and import organizer via `biome.jsonc`
 - **TypeScript** - strict mode, ES2022 target
 - **ES Modules** - relative imports must include `.js`
 - **Errors** - throw `Error` objects, not strings
@@ -56,10 +58,10 @@ This starts the desktop app, panel dev server, and hot-reload daemon. See [docs/
 
 ```typescript
 // Correct
-import { loadConfig } from './config/index.js'
+import { loadConfig } from "./config/index.js";
 
 // Incorrect
-import { loadConfig } from './config/index'
+import { loadConfig } from "./config/index";
 ```
 
 ## Testing

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "root": true,
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+    "defaultBranch": "main"
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!!**/dist",
+      "!!**/dist-bin",
+      "!!**/build",
+      "!!**/coverage",
+      "!!**/node_modules",
+      "!!package-lock.json",
+      "!!packages/daemon/src/panel/static/assets",
+      "!!packages/desktop/src-tauri/binaries",
+      "!!packages/desktop/src-tauri/target",
+      "!!packages/desktop/src-tauri/Cargo.lock"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error",
+        "useExhaustiveDependencies": "warn"
+      },
+      "security": {
+        "noDangerouslySetInnerHtml": "error",
+        "noGlobalEval": "error"
+      },
+      "style": {
+        "useConst": "error",
+        "useTemplate": "warn"
+      },
+      "suspicious": {
+        "noConsole": "warn",
+        "noDebugger": "error",
+        "noExplicitAny": "warn"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "arrowParentheses": "always",
+      "jsxQuoteStyle": "double",
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.test.ts", "**/*.test.tsx"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["scripts/**", "packages/desktop/src-tauri/scripts/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -158,6 +158,9 @@ The desktop crate has focused unit tests for security-sensitive pure functions s
 ## Testing
 
 ```bash
+npm run quality:ci # Biome format + lint + import ordering, CI mode
+npm run quality    # Biome check for local feedback
+npm run quality:fix # Biome safe fixes and formatting
 npm test          # Node built-in test runner (all daemon tests)
 npm run typecheck # tsc --noEmit across daemon + panel (no emit, just type errors)
 ```
@@ -241,7 +244,11 @@ There are two GitHub Actions workflows:
 
 Runs on every PR touching `packages/daemon`, `packages/panel`, `packages/desktop`, or `docs`. Also available via manual dispatch.
 
-Two parallel jobs:
+Three parallel jobs:
+
+**Biome** (`ubuntu-22.04`):
+1. `npm ci`
+2. `npm run quality:ci -- --reporter=github --diagnostic-level=error` — format, lint, and import-order validation
 
 **TypeScript** (`ubuntu-22.04`):
 1. `npm ci`

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "packages/desktop"
       ],
       "devDependencies": {
+        "@biomejs/biome": "2.4.15",
         "@tauri-apps/cli": "^2.11.1",
         "concurrently": "^9.2.1",
         "nodemon": "^3.1.14",
@@ -409,6 +410,181 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.15.tgz",
+      "integrity": "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.15",
+        "@biomejs/cli-darwin-x64": "2.4.15",
+        "@biomejs/cli-linux-arm64": "2.4.15",
+        "@biomejs/cli-linux-arm64-musl": "2.4.15",
+        "@biomejs/cli-linux-x64": "2.4.15",
+        "@biomejs/cli-linux-x64-musl": "2.4.15",
+        "@biomejs/cli-win32-arm64": "2.4.15",
+        "@biomejs/cli-win32-x64": "2.4.15"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.15.tgz",
+      "integrity": "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.15.tgz",
+      "integrity": "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.15.tgz",
+      "integrity": "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.15.tgz",
+      "integrity": "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.15.tgz",
+      "integrity": "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.15.tgz",
+      "integrity": "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.15.tgz",
+      "integrity": "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.15.tgz",
+      "integrity": "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@claude-code-provider-gateway/daemon": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,13 @@
     "dev:desk": "bash -lc 'source \"$HOME/.cargo/env\" 2>/dev/null || true; CC_GATEWAY_EXTERNAL_DAEMON=1 VITE_CC_GATEWAY_EXTERNAL_DAEMON=1 concurrently --kill-others --names daemon,desktop --prefix-colors cyan,green \"bun run dev:daemon\" \"cd packages/desktop && bun run dev\"'",
     "dev:daemon": "nodemon --exec tsx packages/daemon/src/index.ts --ext ts --watch packages/daemon/src",
     "dev:panel": "vite packages/panel",
-    "lint": "eslint packages/*/src --ext .ts,.tsx",
+    "format": "biome format --write .",
+    "format:check": "biome format .",
+    "lint": "biome lint .",
+    "lint:fix": "biome lint --write .",
+    "quality": "biome check .",
+    "quality:fix": "biome check --write .",
+    "quality:ci": "biome ci .",
     "test": "npm test --workspace @claude-code-provider-gateway/daemon",
     "typecheck": "npm run typecheck -w @claude-code-provider-gateway/daemon && npm run typecheck -w @claude-code-provider-gateway/panel"
   },
@@ -23,6 +29,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@biomejs/biome": "2.4.15",
     "@tauri-apps/cli": "^2.11.1",
     "concurrently": "^9.2.1",
     "nodemon": "^3.1.14",

--- a/packages/daemon/src/config/index.ts
+++ b/packages/daemon/src/config/index.ts
@@ -1,22 +1,15 @@
-import { randomBytes } from 'node:crypto'
-import { existsSync, readFileSync } from 'node:fs'
-import { writePrivateFile } from '../core/files/private-file.js'
-import type { Config, ProviderId, ProviderConfig } from './schema.js'
-import { PROVIDER_DEFAULTS, PROVIDER_IDS } from './schema.js'
-import { normalizeConfig } from './validation.js'
-import { EncryptedFileSecretStore } from './secrets/encrypted-file-store.js'
-import { resolveMasterKey } from './secrets/master-key.js'
-import type { SecretStore } from './secrets/store.js'
-import {
-  extractSecretsToStore,
-  hydrateSecretsFromStore,
-} from './secrets/config-splitter.js'
-import { SECRET_KEYS } from './secrets/store.js'
-import {
-  getConfigPath,
-  getMasterKeyPath,
-  getSecretsPath,
-} from './paths.js'
+import { randomBytes } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { writePrivateFile } from "../core/files/private-file.js";
+import { getConfigPath, getMasterKeyPath, getSecretsPath } from "./paths.js";
+import type { Config, ProviderConfig, ProviderId } from "./schema.js";
+import { PROVIDER_DEFAULTS, PROVIDER_IDS } from "./schema.js";
+import { extractSecretsToStore, hydrateSecretsFromStore } from "./secrets/config-splitter.js";
+import { EncryptedFileSecretStore } from "./secrets/encrypted-file-store.js";
+import { resolveMasterKey } from "./secrets/master-key.js";
+import type { SecretStore } from "./secrets/store.js";
+import { SECRET_KEYS } from "./secrets/store.js";
+import { normalizeConfig } from "./validation.js";
 
 export {
   getConfigDir,
@@ -27,35 +20,38 @@ export {
   getPidPath,
   getSecretsPath,
   getSessionArchivePath,
-} from './paths.js'
+} from "./paths.js";
 
-let cachedSecretStore: SecretStore | null = null
+let cachedSecretStore: SecretStore | null = null;
 
 export function getSecretStore(): SecretStore {
-  if (cachedSecretStore) return cachedSecretStore
-  const { key } = resolveMasterKey(getMasterKeyPath())
-  cachedSecretStore = new EncryptedFileSecretStore(getSecretsPath(), key)
-  return cachedSecretStore
+  if (cachedSecretStore) return cachedSecretStore;
+  const { key } = resolveMasterKey(getMasterKeyPath());
+  cachedSecretStore = new EncryptedFileSecretStore(getSecretsPath(), key);
+  return cachedSecretStore;
 }
 
 function buildDefaultProviderConfig(id: ProviderId): ProviderConfig {
   return {
     enabled: false,
-    apiKey: '',
-    authType: id === 'openai_account' || id === 'copilot' ? 'oauth' : 'api_key',
-    oauth: id === 'openai_account' || id === 'copilot' ? {} : undefined,
+    apiKey: "",
+    authType: id === "openai_account" || id === "copilot" ? "oauth" : "api_key",
+    oauth: id === "openai_account" || id === "copilot" ? {} : undefined,
     baseUrl: PROVIDER_DEFAULTS[id]?.baseUrl,
     rateLimit: 40,
     rateWindow: 60,
     maxConcurrency: 5,
-  }
+  };
 }
 
 function buildDefaultProviders(): Record<ProviderId, ProviderConfig> {
-  return PROVIDER_IDS.reduce((providers, id) => {
-    providers[id] = buildDefaultProviderConfig(id)
-    return providers
-  }, {} as Record<ProviderId, ProviderConfig>)
+  return PROVIDER_IDS.reduce(
+    (providers, id) => {
+      providers[id] = buildDefaultProviderConfig(id);
+      return providers;
+    },
+    {} as Record<ProviderId, ProviderConfig>,
+  );
 }
 
 export function buildDefaultConfig(): Config {
@@ -63,20 +59,20 @@ export function buildDefaultConfig(): Config {
     server: {
       proxyPort: 49250,
       panelPort: 6767,
-      authToken: `sk_${randomBytes(16).toString('hex')}`,
+      authToken: `sk_${randomBytes(16).toString("hex")}`,
     },
     providers: buildDefaultProviders(),
     routing: {
-      default: { enabled: false, providerId: '', model: '' },
-      opus:    { enabled: false, providerId: '', model: '' },
-      sonnet:  { enabled: false, providerId: '', model: '' },
-      haiku:   { enabled: false, providerId: '', model: '' },
+      default: { enabled: false, providerId: "", model: "" },
+      opus: { enabled: false, providerId: "", model: "" },
+      sonnet: { enabled: false, providerId: "", model: "" },
+      haiku: { enabled: false, providerId: "", model: "" },
     },
     thinking: {
       enabled: true,
-      opus:    null,
-      sonnet:  null,
-      haiku:   null,
+      opus: null,
+      sonnet: null,
+      haiku: null,
     },
     webTools: {
       enabled: true,
@@ -84,83 +80,84 @@ export function buildDefaultConfig(): Config {
     },
     proxy: {
       enabled: false,
-      url: '',
+      url: "",
     },
     tokenSavers: {
       rtkEnabled: false,
       cavemanEnabled: false,
-      cavemanLevel: 'lite',
+      cavemanLevel: "lite",
     },
-    activeProvider: 'nvidia_nim',
-    modelMode: 'single',
-  }
+    activeProvider: "nvidia_nim",
+    modelMode: "single",
+  };
 }
 
 export function loadConfig(): Config {
-  const path = getConfigPath()
-  const store = getSecretStore()
+  const path = getConfigPath();
+  const store = getSecretStore();
 
   if (!existsSync(path)) {
-    const fresh = buildDefaultConfig()
-    saveConfig(fresh)
-    return fresh
+    const fresh = buildDefaultConfig();
+    saveConfig(fresh);
+    return fresh;
   }
 
   try {
-    const raw = readFileSync(path, 'utf-8')
-    const parsed = JSON.parse(raw) as Partial<Config>
-    const defaults = buildDefaultConfig()
-    const merged = normalizeConfig(deepMerge(defaults, parsed) as Config, defaults)
-    const hasStoredAuthToken = store.get(SECRET_KEYS.serverAuthToken) !== null
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<Config>;
+    const defaults = buildDefaultConfig();
+    const merged = normalizeConfig(deepMerge(defaults, parsed) as Config, defaults);
+    const hasStoredAuthToken = store.get(SECRET_KEYS.serverAuthToken) !== null;
 
     // One-shot migration: legacy JSON has secrets inline → move them into the store.
     if (parsedJsonStillHasSecrets(parsed)) {
-      extractSecretsToStore(merged, store)
-      writePrivateFile(path, JSON.stringify(merged, null, 2))
+      extractSecretsToStore(merged, store);
+      writePrivateFile(path, JSON.stringify(merged, null, 2));
     }
 
-    hydrateSecretsFromStore(merged, store)
-    if (!hasStoredAuthToken) saveConfig(merged)
-    return merged
+    hydrateSecretsFromStore(merged, store);
+    if (!hasStoredAuthToken) saveConfig(merged);
+    return merged;
   } catch {
-    return buildDefaultConfig()
+    return buildDefaultConfig();
   }
 }
 
 export function saveConfig(config: Config): void {
   // Splitter mutates the clone, leaving the caller's object intact with its
   // secrets still populated for in-process use.
-  const onDisk = structuredClone(config)
-  extractSecretsToStore(onDisk, getSecretStore())
-  writePrivateFile(getConfigPath(), JSON.stringify(onDisk, null, 2))
+  const onDisk = structuredClone(config);
+  extractSecretsToStore(onDisk, getSecretStore());
+  writePrivateFile(getConfigPath(), JSON.stringify(onDisk, null, 2));
 }
 
 export function isFirstRun(): boolean {
-  return !existsSync(getConfigPath())
+  return !existsSync(getConfigPath());
 }
 
 function parsedJsonStillHasSecrets(config: Partial<Config>): boolean {
-  if (config.server?.authToken) return true
-  const providers = config.providers ?? {}
+  if (config.server?.authToken) return true;
+  const providers = config.providers ?? {};
   for (const provider of Object.values(providers) as Partial<ProviderConfig>[]) {
-    if (!provider) continue
-    if (provider.apiKey) return true
-    if (provider.oauth?.accessToken || provider.oauth?.refreshToken || provider.oauth?.copilotToken) return true
+    if (!provider) continue;
+    if (provider.apiKey) return true;
+    if (provider.oauth?.accessToken || provider.oauth?.refreshToken || provider.oauth?.copilotToken)
+      return true;
   }
-  return false
+  return false;
 }
 
 // Simple deep merge: values from `override` win, but missing keys fall back to `base`
 function deepMerge(base: unknown, override: unknown): unknown {
-  if (override === null || override === undefined) return base
-  if (typeof base !== 'object' || typeof override !== 'object') return override
-  if (Array.isArray(base) || Array.isArray(override)) return override
+  if (override === null || override === undefined) return base;
+  if (typeof base !== "object" || typeof override !== "object") return override;
+  if (Array.isArray(base) || Array.isArray(override)) return override;
 
-  const result = { ...(base as Record<string, unknown>) }
+  const result = { ...(base as Record<string, unknown>) };
   for (const key of Object.keys(override as Record<string, unknown>)) {
-    const overrideVal = (override as Record<string, unknown>)[key]
-    const baseVal = (base as Record<string, unknown>)[key]
-    result[key] = deepMerge(baseVal, overrideVal)
+    const overrideVal = (override as Record<string, unknown>)[key];
+    const baseVal = (base as Record<string, unknown>)[key];
+    result[key] = deepMerge(baseVal, overrideVal);
   }
-  return result
+  return result;
 }

--- a/packages/daemon/src/config/paths.ts
+++ b/packages/daemon/src/config/paths.ts
@@ -1,37 +1,37 @@
-import { homedir, platform } from 'node:os'
-import { join } from 'node:path'
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
 
 export function getConfigDir(): string {
-  if (platform() === 'win32') {
-    return join(process.env['APPDATA'] ?? homedir(), 'claude-code-provider-gateway')
+  if (platform() === "win32") {
+    return join(process.env["APPDATA"] ?? homedir(), "claude-code-provider-gateway");
   }
-  return join(homedir(), '.config', 'claude-code-provider-gateway')
+  return join(homedir(), ".config", "claude-code-provider-gateway");
 }
 
 export function getConfigPath(): string {
-  return join(getConfigDir(), 'config.json')
+  return join(getConfigDir(), "config.json");
 }
 
 export function getPidPath(): string {
-  return join(getConfigDir(), 'daemon.pid')
+  return join(getConfigDir(), "daemon.pid");
 }
 
 export function getLogPath(): string {
-  return join(getConfigDir(), 'daemon.log')
+  return join(getConfigDir(), "daemon.log");
 }
 
 export function getSecretsPath(): string {
-  return join(getConfigDir(), 'secrets.enc.json')
+  return join(getConfigDir(), "secrets.enc.json");
 }
 
 export function getMasterKeyPath(): string {
-  return join(getConfigDir(), 'secret.key')
+  return join(getConfigDir(), "secret.key");
 }
 
 export function getCurrentSessionPath(): string {
-  return join(getConfigDir(), 'current-session.json')
+  return join(getConfigDir(), "current-session.json");
 }
 
 export function getSessionArchivePath(): string {
-  return join(getConfigDir(), 'sessions.jsonl')
+  return join(getConfigDir(), "sessions.jsonl");
 }

--- a/packages/daemon/src/config/schema.ts
+++ b/packages/daemon/src/config/schema.ts
@@ -1,123 +1,124 @@
 export const PROVIDER_IDS = [
-  'openai_account',
-  'copilot',
-  'nvidia_nim',
-  'openrouter',
-  'deepseek',
-  'kimi',
-  'google',
-  'ollama',
-  'lmstudio',
-  'llamacpp',
-] as const
+  "openai_account",
+  "copilot",
+  "nvidia_nim",
+  "openrouter",
+  "deepseek",
+  "kimi",
+  "google",
+  "ollama",
+  "lmstudio",
+  "llamacpp",
+] as const;
 
-export type ProviderId = typeof PROVIDER_IDS[number]
+export type ProviderId = (typeof PROVIDER_IDS)[number];
 
 export interface ProviderOAuthConfig {
-  accessToken?: string
-  refreshToken?: string
-  expiresAt?: number
-  accountId?: string
-  planType?: string
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  accountId?: string;
+  planType?: string;
   // Copilot-specific: short-lived token derived from accessToken (the GH OAuth token)
-  copilotToken?: string
-  copilotExpiresAt?: number
-  copilotEndpoint?: string
+  copilotToken?: string;
+  copilotExpiresAt?: number;
+  copilotEndpoint?: string;
 }
 
 export interface ProviderConfig {
-  enabled: boolean
-  apiKey?: string
-  authType?: 'api_key' | 'oauth'
-  oauth?: ProviderOAuthConfig
-  models?: string[]
-  disabledModels?: string[]
-  baseUrl?: string
-  rateLimit: number
-  rateWindow: number
-  maxConcurrency: number
-  requestTimeoutMs?: number
+  enabled: boolean;
+  apiKey?: string;
+  authType?: "api_key" | "oauth";
+  oauth?: ProviderOAuthConfig;
+  models?: string[];
+  disabledModels?: string[];
+  baseUrl?: string;
+  rateLimit: number;
+  rateWindow: number;
+  maxConcurrency: number;
+  requestTimeoutMs?: number;
 }
 
-export type ModelMode = 'single' | 'all'
-export type CavemanLevel = 'lite' | 'full' | 'ultra'
+export type ModelMode = "single" | "all";
+export type CavemanLevel = "lite" | "full" | "ultra";
 
 export interface RoutingRule {
-  enabled: boolean
-  providerId: ProviderId | ''
-  model: string
+  enabled: boolean;
+  providerId: ProviderId | "";
+  model: string;
 }
 
-export type RoutingTier = 'default' | 'opus' | 'sonnet' | 'haiku'
+export type RoutingTier = "default" | "opus" | "sonnet" | "haiku";
 
 export interface Config {
   server: {
-    proxyPort: number
-    panelPort: number
-    authToken: string
-  }
-  providers: Record<ProviderId, ProviderConfig>
-  routing: Record<RoutingTier, RoutingRule>
+    proxyPort: number;
+    panelPort: number;
+    authToken: string;
+  };
+  providers: Record<ProviderId, ProviderConfig>;
+  routing: Record<RoutingTier, RoutingRule>;
   thinking: {
-    enabled: boolean
-    opus: boolean | null
-    sonnet: boolean | null
-    haiku: boolean | null
-  }
+    enabled: boolean;
+    opus: boolean | null;
+    sonnet: boolean | null;
+    haiku: boolean | null;
+  };
   webTools: {
-    enabled: boolean
-    allowPrivateNetworks: boolean
-  }
+    enabled: boolean;
+    allowPrivateNetworks: boolean;
+  };
   proxy: {
-    enabled: boolean
-    url: string
-  }
+    enabled: boolean;
+    url: string;
+  };
   tokenSavers: {
-    rtkEnabled: boolean
-    cavemanEnabled: boolean
-    cavemanLevel: CavemanLevel
-  }
-  activeProvider: ProviderId
-  modelMode: ModelMode
+    rtkEnabled: boolean;
+    cavemanEnabled: boolean;
+    cavemanLevel: CavemanLevel;
+  };
+  activeProvider: ProviderId;
+  modelMode: ModelMode;
 }
 
-export const PROVIDER_DEFAULTS: Record<ProviderId, Partial<ProviderConfig> & { baseUrl?: string }> = {
-  openai_account: { baseUrl: 'https://chatgpt.com/backend-api', models: [] },
-  copilot: { baseUrl: 'https://api.individual.githubcopilot.com', models: [] },
-  nvidia_nim: { baseUrl: 'https://integrate.api.nvidia.com/v1' },
-  openrouter:  { baseUrl: 'https://openrouter.ai/api/v1' },
-  deepseek:    { baseUrl: 'https://api.deepseek.com/anthropic' },
-  kimi:        { baseUrl: 'https://api.moonshot.ai/v1' },
-  google:      { baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai' },
-  ollama:      { baseUrl: 'http://localhost:11434' },
-  lmstudio:    { baseUrl: 'http://localhost:1234/v1' },
-  llamacpp:    { baseUrl: 'http://localhost:8080/v1' },
-}
+export const PROVIDER_DEFAULTS: Record<ProviderId, Partial<ProviderConfig> & { baseUrl?: string }> =
+  {
+    openai_account: { baseUrl: "https://chatgpt.com/backend-api", models: [] },
+    copilot: { baseUrl: "https://api.individual.githubcopilot.com", models: [] },
+    nvidia_nim: { baseUrl: "https://integrate.api.nvidia.com/v1" },
+    openrouter: { baseUrl: "https://openrouter.ai/api/v1" },
+    deepseek: { baseUrl: "https://api.deepseek.com/anthropic" },
+    kimi: { baseUrl: "https://api.moonshot.ai/v1" },
+    google: { baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai" },
+    ollama: { baseUrl: "http://localhost:11434" },
+    lmstudio: { baseUrl: "http://localhost:1234/v1" },
+    llamacpp: { baseUrl: "http://localhost:8080/v1" },
+  };
 
 export const PROVIDER_LABELS: Record<ProviderId, string> = {
-  openai_account: 'OpenAI Account',
-  copilot: 'GitHub Copilot',
-  nvidia_nim: 'NVIDIA NIM',
-  openrouter:  'OpenRouter',
-  deepseek:    'DeepSeek',
-  kimi:        'Kimi (Moonshot)',
-  google:      'Google AI',
-  ollama:      'Ollama',
-  lmstudio:    'LM Studio',
-  llamacpp:    'llama.cpp',
-}
+  openai_account: "OpenAI Account",
+  copilot: "GitHub Copilot",
+  nvidia_nim: "NVIDIA NIM",
+  openrouter: "OpenRouter",
+  deepseek: "DeepSeek",
+  kimi: "Kimi (Moonshot)",
+  google: "Google AI",
+  ollama: "Ollama",
+  lmstudio: "LM Studio",
+  llamacpp: "llama.cpp",
+};
 
 export const CLI_FLAGS: Record<string, ProviderId> = {
-  '--OpenAIAccount': 'openai_account',
-  '--Copilot':    'copilot',
-  '--GitHubCopilot': 'copilot',
-  '--NvidiaNim':  'nvidia_nim',
-  '--OpenRouter': 'openrouter',
-  '--DeepSeek':   'deepseek',
-  '--Kimi':       'kimi',
-  '--Google':     'google',
-  '--GoogleAI':   'google',
-  '--Ollama':     'ollama',
-  '--LMStudio':   'lmstudio',
-  '--LlamaCpp':   'llamacpp',
-}
+  "--OpenAIAccount": "openai_account",
+  "--Copilot": "copilot",
+  "--GitHubCopilot": "copilot",
+  "--NvidiaNim": "nvidia_nim",
+  "--OpenRouter": "openrouter",
+  "--DeepSeek": "deepseek",
+  "--Kimi": "kimi",
+  "--Google": "google",
+  "--GoogleAI": "google",
+  "--Ollama": "ollama",
+  "--LMStudio": "lmstudio",
+  "--LlamaCpp": "llamacpp",
+};

--- a/packages/daemon/src/config/secrets/config-splitter.test.ts
+++ b/packages/daemon/src/config/secrets/config-splitter.test.ts
@@ -1,60 +1,69 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { buildDefaultConfig } from '../index.js'
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildDefaultConfig } from "../index.js";
 import {
   extractSecretsToStore,
   hydrateSecretsFromStore,
   jsonStillHasSecrets,
-} from './config-splitter.js'
-import type { SecretStore } from './store.js'
+} from "./config-splitter.js";
+import type { SecretStore } from "./store.js";
 
 class MemoryStore implements SecretStore {
-  private map = new Map<string, string>()
-  get(k: string) { return this.map.get(k) ?? null }
-  set(k: string, v: string) { if (v) this.map.set(k, v); else this.map.delete(k) }
-  delete(k: string) { this.map.delete(k) }
-  keys() { return Array.from(this.map.keys()) }
+  private map = new Map<string, string>();
+  get(k: string) {
+    return this.map.get(k) ?? null;
+  }
+  set(k: string, v: string) {
+    if (v) this.map.set(k, v);
+    else this.map.delete(k);
+  }
+  delete(k: string) {
+    this.map.delete(k);
+  }
+  keys() {
+    return Array.from(this.map.keys());
+  }
 }
 
-test('extracts all secret fields out of config and blanks them', () => {
-  const store = new MemoryStore()
-  const cfg = buildDefaultConfig()
-  cfg.providers.openrouter.apiKey = 'sk-or-secret'
-  cfg.providers.openai_account.oauth = { accessToken: 'at', refreshToken: 'rt' }
+test("extracts all secret fields out of config and blanks them", () => {
+  const store = new MemoryStore();
+  const cfg = buildDefaultConfig();
+  cfg.providers.openrouter.apiKey = "sk-or-secret";
+  cfg.providers.openai_account.oauth = { accessToken: "at", refreshToken: "rt" };
 
-  extractSecretsToStore(cfg, store)
+  extractSecretsToStore(cfg, store);
 
-  assert.equal(cfg.server.authToken, '')
-  assert.equal(cfg.providers.openrouter.apiKey, '')
-  assert.equal(cfg.providers.openai_account.oauth?.accessToken, undefined)
-  assert.equal(cfg.providers.openai_account.oauth?.refreshToken, undefined)
+  assert.equal(cfg.server.authToken, "");
+  assert.equal(cfg.providers.openrouter.apiKey, "");
+  assert.equal(cfg.providers.openai_account.oauth?.accessToken, undefined);
+  assert.equal(cfg.providers.openai_account.oauth?.refreshToken, undefined);
 
-  assert.ok(store.get('server.authToken'))
-  assert.equal(store.get('provider.openrouter.apiKey'), 'sk-or-secret')
-  assert.equal(store.get('provider.openai_account.oauth.accessToken'), 'at')
-  assert.equal(store.get('provider.openai_account.oauth.refreshToken'), 'rt')
-})
+  assert.ok(store.get("server.authToken"));
+  assert.equal(store.get("provider.openrouter.apiKey"), "sk-or-secret");
+  assert.equal(store.get("provider.openai_account.oauth.accessToken"), "at");
+  assert.equal(store.get("provider.openai_account.oauth.refreshToken"), "rt");
+});
 
-test('hydrate restores secrets back into config from store', () => {
-  const store = new MemoryStore()
-  const cfg = buildDefaultConfig()
-  cfg.providers.openrouter.apiKey = 'sk-or-secret'
-  extractSecretsToStore(cfg, store)
+test("hydrate restores secrets back into config from store", () => {
+  const store = new MemoryStore();
+  const cfg = buildDefaultConfig();
+  cfg.providers.openrouter.apiKey = "sk-or-secret";
+  extractSecretsToStore(cfg, store);
 
-  const fresh = buildDefaultConfig()
-  fresh.server.authToken = ''
-  fresh.providers.openrouter.apiKey = ''
-  hydrateSecretsFromStore(fresh, store)
+  const fresh = buildDefaultConfig();
+  fresh.server.authToken = "";
+  fresh.providers.openrouter.apiKey = "";
+  hydrateSecretsFromStore(fresh, store);
 
-  assert.equal(fresh.providers.openrouter.apiKey, 'sk-or-secret')
-  assert.ok(fresh.server.authToken.length > 0)
-})
+  assert.equal(fresh.providers.openrouter.apiKey, "sk-or-secret");
+  assert.ok(fresh.server.authToken.length > 0);
+});
 
-test('jsonStillHasSecrets detects unmigrated config', () => {
-  const cfg = buildDefaultConfig()
-  assert.ok(jsonStillHasSecrets(cfg), 'fresh config has generated tokens')
+test("jsonStillHasSecrets detects unmigrated config", () => {
+  const cfg = buildDefaultConfig();
+  assert.ok(jsonStillHasSecrets(cfg), "fresh config has generated tokens");
 
-  const store = new MemoryStore()
-  extractSecretsToStore(cfg, store)
-  assert.equal(jsonStillHasSecrets(cfg), false)
-})
+  const store = new MemoryStore();
+  extractSecretsToStore(cfg, store);
+  assert.equal(jsonStillHasSecrets(cfg), false);
+});

--- a/packages/daemon/src/config/secrets/config-splitter.ts
+++ b/packages/daemon/src/config/secrets/config-splitter.ts
@@ -1,27 +1,27 @@
-import type { Config } from '../schema.js'
-import { PROVIDER_IDS } from '../schema.js'
-import { SECRET_KEYS, type SecretStore } from './store.js'
+import type { Config } from "../schema.js";
+import { PROVIDER_IDS } from "../schema.js";
+import { SECRET_KEYS, type SecretStore } from "./store.js";
 
 // Drains secrets *out of* `config` into `store`, leaving the config object
 // safe to persist as plain JSON. Mutates `config` in place.
 export function extractSecretsToStore(config: Config, store: SecretStore): void {
-  writeIfPresent(store, SECRET_KEYS.serverAuthToken, config.server.authToken)
-  config.server.authToken = ''
+  writeIfPresent(store, SECRET_KEYS.serverAuthToken, config.server.authToken);
+  config.server.authToken = "";
 
   for (const id of PROVIDER_IDS) {
-    const provider = config.providers[id]
-    if (!provider) continue
+    const provider = config.providers[id];
+    if (!provider) continue;
 
-    writeIfPresent(store, SECRET_KEYS.providerApiKey(id), provider.apiKey)
-    provider.apiKey = ''
+    writeIfPresent(store, SECRET_KEYS.providerApiKey(id), provider.apiKey);
+    provider.apiKey = "";
 
     if (provider.oauth) {
-      writeIfPresent(store, SECRET_KEYS.providerOAuthAccessToken(id), provider.oauth.accessToken)
-      writeIfPresent(store, SECRET_KEYS.providerOAuthRefreshToken(id), provider.oauth.refreshToken)
-      writeIfPresent(store, SECRET_KEYS.providerOAuthCopilotToken(id), provider.oauth.copilotToken)
-      provider.oauth.accessToken = undefined
-      provider.oauth.refreshToken = undefined
-      provider.oauth.copilotToken = undefined
+      writeIfPresent(store, SECRET_KEYS.providerOAuthAccessToken(id), provider.oauth.accessToken);
+      writeIfPresent(store, SECRET_KEYS.providerOAuthRefreshToken(id), provider.oauth.refreshToken);
+      writeIfPresent(store, SECRET_KEYS.providerOAuthCopilotToken(id), provider.oauth.copilotToken);
+      provider.oauth.accessToken = undefined;
+      provider.oauth.refreshToken = undefined;
+      provider.oauth.copilotToken = undefined;
     }
   }
 }
@@ -29,39 +29,39 @@ export function extractSecretsToStore(config: Config, store: SecretStore): void 
 // Hydrates secrets *from* `store` back into `config`. Used by loadConfig after
 // reading the JSON skeleton from disk.
 export function hydrateSecretsFromStore(config: Config, store: SecretStore): void {
-  config.server.authToken = store.get(SECRET_KEYS.serverAuthToken) ?? config.server.authToken
+  config.server.authToken = store.get(SECRET_KEYS.serverAuthToken) ?? config.server.authToken;
 
   for (const id of PROVIDER_IDS) {
-    const provider = config.providers[id]
-    if (!provider) continue
+    const provider = config.providers[id];
+    if (!provider) continue;
 
-    provider.apiKey = store.get(SECRET_KEYS.providerApiKey(id)) ?? provider.apiKey
+    provider.apiKey = store.get(SECRET_KEYS.providerApiKey(id)) ?? provider.apiKey;
 
     if (provider.oauth) {
-      const access = store.get(SECRET_KEYS.providerOAuthAccessToken(id))
-      const refresh = store.get(SECRET_KEYS.providerOAuthRefreshToken(id))
-      const copilot = store.get(SECRET_KEYS.providerOAuthCopilotToken(id))
-      if (access !== null) provider.oauth.accessToken = access
-      if (refresh !== null) provider.oauth.refreshToken = refresh
-      if (copilot !== null) provider.oauth.copilotToken = copilot
+      const access = store.get(SECRET_KEYS.providerOAuthAccessToken(id));
+      const refresh = store.get(SECRET_KEYS.providerOAuthRefreshToken(id));
+      const copilot = store.get(SECRET_KEYS.providerOAuthCopilotToken(id));
+      if (access !== null) provider.oauth.accessToken = access;
+      if (refresh !== null) provider.oauth.refreshToken = refresh;
+      if (copilot !== null) provider.oauth.copilotToken = copilot;
     }
   }
 }
 
 function writeIfPresent(store: SecretStore, key: string, value: string | undefined | null): void {
-  if (!value) return
-  store.set(key, value)
+  if (!value) return;
+  store.set(key, value);
 }
 
 // True iff the on-disk JSON still carries any secret field. Drives the
 // one-shot migration that moves secrets into the SecretStore.
 export function jsonStillHasSecrets(config: Config): boolean {
-  if (config.server.authToken) return true
+  if (config.server.authToken) return true;
   for (const id of PROVIDER_IDS) {
-    const p = config.providers[id]
-    if (!p) continue
-    if (p.apiKey) return true
-    if (p.oauth?.accessToken || p.oauth?.refreshToken || p.oauth?.copilotToken) return true
+    const p = config.providers[id];
+    if (!p) continue;
+    if (p.apiKey) return true;
+    if (p.oauth?.accessToken || p.oauth?.refreshToken || p.oauth?.copilotToken) return true;
   }
-  return false
+  return false;
 }

--- a/packages/daemon/src/config/secrets/encrypted-file-store.test.ts
+++ b/packages/daemon/src/config/secrets/encrypted-file-store.test.ts
@@ -1,88 +1,88 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { randomBytes } from 'node:crypto'
-import { EncryptedFileSecretStore } from './encrypted-file-store.js'
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { EncryptedFileSecretStore } from "./encrypted-file-store.js";
 
 function withTempDir(fn: (dir: string) => void): void {
-  const dir = mkdtempSync(join(tmpdir(), 'secret-store-'))
+  const dir = mkdtempSync(join(tmpdir(), "secret-store-"));
   try {
-    fn(dir)
+    fn(dir);
   } finally {
-    rmSync(dir, { recursive: true, force: true })
+    rmSync(dir, { recursive: true, force: true });
   }
 }
 
-test('round-trips a secret through encrypt/decrypt', () => {
-  withTempDir(dir => {
-    const store = new EncryptedFileSecretStore(join(dir, 'secrets.json'), randomBytes(32))
-    store.set('provider.openrouter.apiKey', 'sk-or-v1-test')
-    assert.equal(store.get('provider.openrouter.apiKey'), 'sk-or-v1-test')
-  })
-})
+test("round-trips a secret through encrypt/decrypt", () => {
+  withTempDir((dir) => {
+    const store = new EncryptedFileSecretStore(join(dir, "secrets.json"), randomBytes(32));
+    store.set("provider.openrouter.apiKey", "sk-or-v1-test");
+    assert.equal(store.get("provider.openrouter.apiKey"), "sk-or-v1-test");
+  });
+});
 
-test('returns null for missing keys', () => {
-  withTempDir(dir => {
-    const store = new EncryptedFileSecretStore(join(dir, 'secrets.json'), randomBytes(32))
-    assert.equal(store.get('does.not.exist'), null)
-  })
-})
+test("returns null for missing keys", () => {
+  withTempDir((dir) => {
+    const store = new EncryptedFileSecretStore(join(dir, "secrets.json"), randomBytes(32));
+    assert.equal(store.get("does.not.exist"), null);
+  });
+});
 
-test('persists across instances when master key matches', () => {
-  withTempDir(dir => {
-    const file = join(dir, 'secrets.json')
-    const key = randomBytes(32)
-    new EncryptedFileSecretStore(file, key).set('a', 'one')
-    const reopened = new EncryptedFileSecretStore(file, key)
-    assert.equal(reopened.get('a'), 'one')
-  })
-})
+test("persists across instances when master key matches", () => {
+  withTempDir((dir) => {
+    const file = join(dir, "secrets.json");
+    const key = randomBytes(32);
+    new EncryptedFileSecretStore(file, key).set("a", "one");
+    const reopened = new EncryptedFileSecretStore(file, key);
+    assert.equal(reopened.get("a"), "one");
+  });
+});
 
-test('wrong master key treats the entry as missing', () => {
-  withTempDir(dir => {
-    const file = join(dir, 'secrets.json')
-    new EncryptedFileSecretStore(file, randomBytes(32)).set('a', 'one')
-    const wrong = new EncryptedFileSecretStore(file, randomBytes(32))
-    assert.equal(wrong.get('a'), null)
-  })
-})
+test("wrong master key treats the entry as missing", () => {
+  withTempDir((dir) => {
+    const file = join(dir, "secrets.json");
+    new EncryptedFileSecretStore(file, randomBytes(32)).set("a", "one");
+    const wrong = new EncryptedFileSecretStore(file, randomBytes(32));
+    assert.equal(wrong.get("a"), null);
+  });
+});
 
-test('set with empty value deletes the entry', () => {
-  withTempDir(dir => {
-    const store = new EncryptedFileSecretStore(join(dir, 'secrets.json'), randomBytes(32))
-    store.set('a', 'one')
-    store.set('a', '')
-    assert.equal(store.get('a'), null)
-    assert.deepEqual(store.keys(), [])
-  })
-})
+test("set with empty value deletes the entry", () => {
+  withTempDir((dir) => {
+    const store = new EncryptedFileSecretStore(join(dir, "secrets.json"), randomBytes(32));
+    store.set("a", "one");
+    store.set("a", "");
+    assert.equal(store.get("a"), null);
+    assert.deepEqual(store.keys(), []);
+  });
+});
 
-test('on-disk file never contains plaintext', () => {
-  withTempDir(dir => {
-    const file = join(dir, 'secrets.json')
-    const store = new EncryptedFileSecretStore(file, randomBytes(32))
-    store.set('provider.openrouter.apiKey', 'plaintext-sentinel')
-    const raw = readFileSync(file, 'utf-8')
-    assert.ok(!raw.includes('plaintext-sentinel'), 'plaintext leaked into JSON')
-  })
-})
+test("on-disk file never contains plaintext", () => {
+  withTempDir((dir) => {
+    const file = join(dir, "secrets.json");
+    const store = new EncryptedFileSecretStore(file, randomBytes(32));
+    store.set("provider.openrouter.apiKey", "plaintext-sentinel");
+    const raw = readFileSync(file, "utf-8");
+    assert.ok(!raw.includes("plaintext-sentinel"), "plaintext leaked into JSON");
+  });
+});
 
-test('rejects 32-byte requirement on construction', () => {
-  withTempDir(dir => {
+test("rejects 32-byte requirement on construction", () => {
+  withTempDir((dir) => {
     assert.throws(
-      () => new EncryptedFileSecretStore(join(dir, 'secrets.json'), randomBytes(16)),
+      () => new EncryptedFileSecretStore(join(dir, "secrets.json"), randomBytes(16)),
       /32 bytes/,
-    )
-  })
-})
+    );
+  });
+});
 
-test('tolerates a corrupt secrets file by treating it as empty', () => {
-  withTempDir(dir => {
-    const file = join(dir, 'secrets.json')
-    writeFileSync(file, 'not json at all', 'utf-8')
-    const store = new EncryptedFileSecretStore(file, randomBytes(32))
-    assert.deepEqual(store.keys(), [])
-  })
-})
+test("tolerates a corrupt secrets file by treating it as empty", () => {
+  withTempDir((dir) => {
+    const file = join(dir, "secrets.json");
+    writeFileSync(file, "not json at all", "utf-8");
+    const store = new EncryptedFileSecretStore(file, randomBytes(32));
+    assert.deepEqual(store.keys(), []);
+  });
+});

--- a/packages/daemon/src/config/secrets/encrypted-file-store.ts
+++ b/packages/daemon/src/config/secrets/encrypted-file-store.ts
@@ -1,94 +1,97 @@
-import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname } from 'node:path'
-import type { SecretStore } from './store.js'
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { SecretStore } from "./store.js";
 
 interface EncryptedEntry {
-  nonce: string       // hex, 12 bytes
-  ciphertext: string  // hex
-  tag: string         // hex, 16 bytes
+  nonce: string; // hex, 12 bytes
+  ciphertext: string; // hex
+  tag: string; // hex, 16 bytes
 }
 
-type Cache = Record<string, EncryptedEntry>
+type Cache = Record<string, EncryptedEntry>;
 
-const ALGORITHM = 'aes-256-gcm'
-const NONCE_BYTES = 12
+const ALGORITHM = "aes-256-gcm";
+const NONCE_BYTES = 12;
 
 export class EncryptedFileSecretStore implements SecretStore {
-  private cache: Cache
+  private cache: Cache;
 
-  constructor(private readonly filePath: string, private readonly masterKey: Buffer) {
+  constructor(
+    private readonly filePath: string,
+    private readonly masterKey: Buffer,
+  ) {
     if (masterKey.length !== 32) {
-      throw new Error(`Master key must be 32 bytes (got ${masterKey.length})`)
+      throw new Error(`Master key must be 32 bytes (got ${masterKey.length})`);
     }
-    this.cache = this.readFromDisk()
+    this.cache = this.readFromDisk();
   }
 
   get(key: string): string | null {
-    const entry = this.cache[key]
-    if (!entry) return null
+    const entry = this.cache[key];
+    if (!entry) return null;
     try {
-      return this.decrypt(entry)
+      return this.decrypt(entry);
     } catch {
       // Corrupt or wrongly-keyed entry (e.g. left over from a previous master
       // key). Treat as missing so a single bad secret can't take down config
       // load — the user re-enters that one credential via the UI.
-      return null
+      return null;
     }
   }
 
   set(key: string, value: string): void {
-    if (value === '' || value == null) {
-      this.delete(key)
-      return
+    if (value === "" || value == null) {
+      this.delete(key);
+      return;
     }
-    this.cache[key] = this.encrypt(value)
-    this.flush()
+    this.cache[key] = this.encrypt(value);
+    this.flush();
   }
 
   delete(key: string): void {
-    if (!(key in this.cache)) return
-    delete this.cache[key]
-    this.flush()
+    if (!(key in this.cache)) return;
+    delete this.cache[key];
+    this.flush();
   }
 
   keys(): string[] {
-    return Object.keys(this.cache)
+    return Object.keys(this.cache);
   }
 
   private encrypt(plaintext: string): EncryptedEntry {
-    const nonce = randomBytes(NONCE_BYTES)
-    const cipher = createCipheriv(ALGORITHM, this.masterKey, nonce)
-    const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()])
-    const tag = cipher.getAuthTag()
+    const nonce = randomBytes(NONCE_BYTES);
+    const cipher = createCipheriv(ALGORITHM, this.masterKey, nonce);
+    const ciphertext = Buffer.concat([cipher.update(plaintext, "utf-8"), cipher.final()]);
+    const tag = cipher.getAuthTag();
     return {
-      nonce: nonce.toString('hex'),
-      ciphertext: ciphertext.toString('hex'),
-      tag: tag.toString('hex'),
-    }
+      nonce: nonce.toString("hex"),
+      ciphertext: ciphertext.toString("hex"),
+      tag: tag.toString("hex"),
+    };
   }
 
   private decrypt(entry: EncryptedEntry): string {
-    const nonce = Buffer.from(entry.nonce, 'hex')
-    const ciphertext = Buffer.from(entry.ciphertext, 'hex')
-    const tag = Buffer.from(entry.tag, 'hex')
-    const decipher = createDecipheriv(ALGORITHM, this.masterKey, nonce)
-    decipher.setAuthTag(tag)
-    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()])
-    return plaintext.toString('utf-8')
+    const nonce = Buffer.from(entry.nonce, "hex");
+    const ciphertext = Buffer.from(entry.ciphertext, "hex");
+    const tag = Buffer.from(entry.tag, "hex");
+    const decipher = createDecipheriv(ALGORITHM, this.masterKey, nonce);
+    decipher.setAuthTag(tag);
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return plaintext.toString("utf-8");
   }
 
   private readFromDisk(): Cache {
-    if (!existsSync(this.filePath)) return {}
+    if (!existsSync(this.filePath)) return {};
     try {
-      return JSON.parse(readFileSync(this.filePath, 'utf-8')) as Cache
+      return JSON.parse(readFileSync(this.filePath, "utf-8")) as Cache;
     } catch {
-      return {}
+      return {};
     }
   }
 
   private flush(): void {
-    mkdirSync(dirname(this.filePath), { recursive: true })
-    writeFileSync(this.filePath, JSON.stringify(this.cache, null, 2), { mode: 0o600 })
+    mkdirSync(dirname(this.filePath), { recursive: true });
+    writeFileSync(this.filePath, JSON.stringify(this.cache, null, 2), { mode: 0o600 });
   }
 }

--- a/packages/daemon/src/config/secrets/master-key.test.ts
+++ b/packages/daemon/src/config/secrets/master-key.test.ts
@@ -1,75 +1,75 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { mkdtempSync, existsSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
-import { tmpdir, platform } from 'node:os'
-import { join } from 'node:path'
-import { randomBytes } from 'node:crypto'
-import { resolveMasterKey } from './master-key.js'
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { platform, tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { resolveMasterKey } from "./master-key.js";
 
-const ENV_VAR = 'CC_GATEWAY_SECRET_KEY'
+const ENV_VAR = "CC_GATEWAY_SECRET_KEY";
 
 function withTempFile(fn: (file: string) => void): void {
-  const dir = mkdtempSync(join(tmpdir(), 'master-key-'))
-  const previousEnv = process.env[ENV_VAR]
-  delete process.env[ENV_VAR]
+  const dir = mkdtempSync(join(tmpdir(), "master-key-"));
+  const previousEnv = process.env[ENV_VAR];
+  delete process.env[ENV_VAR];
   try {
-    fn(join(dir, 'secret.key'))
+    fn(join(dir, "secret.key"));
   } finally {
-    if (previousEnv !== undefined) process.env[ENV_VAR] = previousEnv
-    rmSync(dir, { recursive: true, force: true })
+    if (previousEnv !== undefined) process.env[ENV_VAR] = previousEnv;
+    rmSync(dir, { recursive: true, force: true });
   }
 }
 
-test('generates and persists a 32-byte key on first call', () => {
-  withTempFile(file => {
-    const { origin, key } = resolveMasterKey(file)
-    assert.equal(origin, 'file-generated')
-    assert.equal(key.length, 32)
-    assert.ok(existsSync(file))
-    const fromDisk = Buffer.from(readFileSync(file, 'utf-8').trim(), 'hex')
-    assert.deepEqual(fromDisk, key)
-  })
-})
+test("generates and persists a 32-byte key on first call", () => {
+  withTempFile((file) => {
+    const { origin, key } = resolveMasterKey(file);
+    assert.equal(origin, "file-generated");
+    assert.equal(key.length, 32);
+    assert.ok(existsSync(file));
+    const fromDisk = Buffer.from(readFileSync(file, "utf-8").trim(), "hex");
+    assert.deepEqual(fromDisk, key);
+  });
+});
 
-test('returns the same key on subsequent calls', () => {
-  withTempFile(file => {
-    const first = resolveMasterKey(file)
-    const second = resolveMasterKey(file)
-    assert.equal(second.origin, 'file-existing')
-    assert.deepEqual(second.key, first.key)
-  })
-})
+test("returns the same key on subsequent calls", () => {
+  withTempFile((file) => {
+    const first = resolveMasterKey(file);
+    const second = resolveMasterKey(file);
+    assert.equal(second.origin, "file-existing");
+    assert.deepEqual(second.key, first.key);
+  });
+});
 
-test('env var takes precedence over file', () => {
-  withTempFile(file => {
-    const envKey = randomBytes(32)
-    process.env[ENV_VAR] = envKey.toString('hex')
-    const { origin, key } = resolveMasterKey(file)
-    assert.equal(origin, 'env')
-    assert.deepEqual(key, envKey)
-    assert.ok(!existsSync(file), 'should not create key file when env is set')
-  })
-})
+test("env var takes precedence over file", () => {
+  withTempFile((file) => {
+    const envKey = randomBytes(32);
+    process.env[ENV_VAR] = envKey.toString("hex");
+    const { origin, key } = resolveMasterKey(file);
+    assert.equal(origin, "env");
+    assert.deepEqual(key, envKey);
+    assert.ok(!existsSync(file), "should not create key file when env is set");
+  });
+});
 
-test('rejects env var with wrong byte length', () => {
-  withTempFile(file => {
-    process.env[ENV_VAR] = '00'.repeat(16)
-    assert.throws(() => resolveMasterKey(file), /32-byte/)
-  })
-})
+test("rejects env var with wrong byte length", () => {
+  withTempFile((file) => {
+    process.env[ENV_VAR] = "00".repeat(16);
+    assert.throws(() => resolveMasterKey(file), /32-byte/);
+  });
+});
 
-test('rejects corrupt key file', () => {
-  withTempFile(file => {
-    writeFileSync(file, 'not hex')
-    assert.throws(() => resolveMasterKey(file), /corrupt/)
-  })
-})
+test("rejects corrupt key file", () => {
+  withTempFile((file) => {
+    writeFileSync(file, "not hex");
+    assert.throws(() => resolveMasterKey(file), /corrupt/);
+  });
+});
 
-test('persists key file with 0600 perms on POSIX', t => {
-  if (platform() === 'win32') return t.skip('POSIX-only')
-  withTempFile(file => {
-    resolveMasterKey(file)
-    const mode = statSync(file).mode & 0o777
-    assert.equal(mode, 0o600)
-  })
-})
+test("persists key file with 0600 perms on POSIX", (t) => {
+  if (platform() === "win32") return t.skip("POSIX-only");
+  withTempFile((file) => {
+    resolveMasterKey(file);
+    const mode = statSync(file).mode & 0o777;
+    assert.equal(mode, 0o600);
+  });
+});

--- a/packages/daemon/src/config/secrets/master-key.ts
+++ b/packages/daemon/src/config/secrets/master-key.ts
@@ -1,13 +1,13 @@
-import { randomBytes } from 'node:crypto'
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname } from 'node:path'
+import { randomBytes } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 
-const MASTER_KEY_ENV = 'CC_GATEWAY_SECRET_KEY'
-const KEY_BYTES = 32
+const MASTER_KEY_ENV = "CC_GATEWAY_SECRET_KEY";
+const KEY_BYTES = 32;
 
 export interface MasterKeySource {
-  origin: 'env' | 'file-existing' | 'file-generated'
-  key: Buffer
+  origin: "env" | "file-existing" | "file-generated";
+  key: Buffer;
 }
 
 // Resolution order:
@@ -15,41 +15,41 @@ export interface MasterKeySource {
 //   2. Existing key file at `filePath`
 //   3. Generate fresh key, persist with 0600 perms (dev fallback)
 export function resolveMasterKey(filePath: string): MasterKeySource {
-  const fromEnv = readEnvKey()
-  if (fromEnv) return { origin: 'env', key: fromEnv }
+  const fromEnv = readEnvKey();
+  if (fromEnv) return { origin: "env", key: fromEnv };
 
   if (existsSync(filePath)) {
-    return { origin: 'file-existing', key: readKeyFile(filePath) }
+    return { origin: "file-existing", key: readKeyFile(filePath) };
   }
 
-  const generated = randomBytes(KEY_BYTES)
-  persistKeyFile(filePath, generated)
-  return { origin: 'file-generated', key: generated }
+  const generated = randomBytes(KEY_BYTES);
+  persistKeyFile(filePath, generated);
+  return { origin: "file-generated", key: generated };
 }
 
 function readEnvKey(): Buffer | null {
-  const raw = process.env[MASTER_KEY_ENV]
-  if (!raw) return null
-  const buf = Buffer.from(raw.trim(), 'hex')
+  const raw = process.env[MASTER_KEY_ENV];
+  if (!raw) return null;
+  const buf = Buffer.from(raw.trim(), "hex");
   if (buf.length !== KEY_BYTES) {
-    throw new Error(`${MASTER_KEY_ENV} must be ${KEY_BYTES}-byte hex (got ${buf.length} bytes)`)
+    throw new Error(`${MASTER_KEY_ENV} must be ${KEY_BYTES}-byte hex (got ${buf.length} bytes)`);
   }
-  return buf
+  return buf;
 }
 
 function readKeyFile(filePath: string): Buffer {
-  const buf = Buffer.from(readFileSync(filePath, 'utf-8').trim(), 'hex')
+  const buf = Buffer.from(readFileSync(filePath, "utf-8").trim(), "hex");
   if (buf.length !== KEY_BYTES) {
-    throw new Error(`Master key file at ${filePath} is corrupt (expected ${KEY_BYTES} bytes hex)`)
+    throw new Error(`Master key file at ${filePath} is corrupt (expected ${KEY_BYTES} bytes hex)`);
   }
-  return buf
+  return buf;
 }
 
 function persistKeyFile(filePath: string, key: Buffer): void {
-  mkdirSync(dirname(filePath), { recursive: true })
-  writeFileSync(filePath, key.toString('hex'), { encoding: 'utf-8', mode: 0o600 })
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, key.toString("hex"), { encoding: "utf-8", mode: 0o600 });
   try {
-    chmodSync(filePath, 0o600)
+    chmodSync(filePath, 0o600);
   } catch {
     // Best-effort on platforms without POSIX perms (Windows)
   }

--- a/packages/daemon/src/config/secrets/store.ts
+++ b/packages/daemon/src/config/secrets/store.ts
@@ -1,8 +1,8 @@
 export interface SecretStore {
-  get(key: string): string | null
-  set(key: string, value: string): void
-  delete(key: string): void
-  keys(): string[]
+  get(key: string): string | null;
+  set(key: string, value: string): void;
+  delete(key: string): void;
+  keys(): string[];
 }
 
 // Dotted paths used as keys, scoped by domain so collisions are impossible.
@@ -11,9 +11,9 @@ export interface SecretStore {
 //   provider.openrouter.apiKey
 //   provider.openai_account.oauth.accessToken
 export const SECRET_KEYS = {
-  serverAuthToken: 'server.authToken',
+  serverAuthToken: "server.authToken",
   providerApiKey: (id: string) => `provider.${id}.apiKey`,
   providerOAuthAccessToken: (id: string) => `provider.${id}.oauth.accessToken`,
   providerOAuthRefreshToken: (id: string) => `provider.${id}.oauth.refreshToken`,
   providerOAuthCopilotToken: (id: string) => `provider.${id}.oauth.copilotToken`,
-} as const
+} as const;

--- a/packages/daemon/src/config/validation.test.ts
+++ b/packages/daemon/src/config/validation.test.ts
@@ -1,15 +1,15 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { buildDefaultConfig } from './index.js'
-import { normalizeConfig } from './validation.js'
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildDefaultConfig } from "./index.js";
+import { normalizeConfig } from "./validation.js";
 
-test('normalizeConfig preserves valid config values', () => {
-  const defaults = buildDefaultConfig()
+test("normalizeConfig preserves valid config values", () => {
+  const defaults = buildDefaultConfig();
   const config = {
     ...defaults,
     server: { ...defaults.server, proxyPort: 5000 },
-    activeProvider: 'ollama' as const,
-    modelMode: 'all' as const,
+    activeProvider: "ollama" as const,
+    modelMode: "all" as const,
     providers: {
       ...defaults.providers,
       ollama: {
@@ -18,94 +18,94 @@ test('normalizeConfig preserves valid config values', () => {
         requestTimeoutMs: 1200,
       },
     },
-  }
+  };
 
-  const normalized = normalizeConfig(config, defaults)
+  const normalized = normalizeConfig(config, defaults);
 
-  assert.equal(normalized.server.proxyPort, 5000)
-  assert.equal(normalized.activeProvider, 'ollama')
-  assert.equal(normalized.modelMode, 'all')
-  assert.equal(normalized.providers.ollama.requestTimeoutMs, 1200)
-})
+  assert.equal(normalized.server.proxyPort, 5000);
+  assert.equal(normalized.activeProvider, "ollama");
+  assert.equal(normalized.modelMode, "all");
+  assert.equal(normalized.providers.ollama.requestTimeoutMs, 1200);
+});
 
-test('normalizeConfig uses proxy defaults when proxy field is absent (legacy config)', () => {
-  const defaults = buildDefaultConfig()
-  const legacyConfig = { ...defaults } as Record<string, unknown>
-  delete legacyConfig.proxy
-  delete legacyConfig.tokenSavers
+test("normalizeConfig uses proxy defaults when proxy field is absent (legacy config)", () => {
+  const defaults = buildDefaultConfig();
+  const legacyConfig = { ...defaults } as Record<string, unknown>;
+  delete legacyConfig.proxy;
+  delete legacyConfig.tokenSavers;
 
-  const normalized = normalizeConfig(legacyConfig as unknown as typeof defaults, defaults)
+  const normalized = normalizeConfig(legacyConfig as unknown as typeof defaults, defaults);
 
-  assert.equal(normalized.proxy.enabled, false)
-  assert.equal(normalized.proxy.url, '')
-  assert.equal(normalized.tokenSavers.rtkEnabled, false)
-  assert.equal(normalized.tokenSavers.cavemanEnabled, false)
-  assert.equal(normalized.tokenSavers.cavemanLevel, 'lite')
-})
+  assert.equal(normalized.proxy.enabled, false);
+  assert.equal(normalized.proxy.url, "");
+  assert.equal(normalized.tokenSavers.rtkEnabled, false);
+  assert.equal(normalized.tokenSavers.cavemanEnabled, false);
+  assert.equal(normalized.tokenSavers.cavemanLevel, "lite");
+});
 
-test('normalizeConfig preserves proxy config when present', () => {
-  const defaults = buildDefaultConfig()
-  const config = { ...defaults, proxy: { enabled: true, url: 'http://127.0.0.1:7890' } }
+test("normalizeConfig preserves proxy config when present", () => {
+  const defaults = buildDefaultConfig();
+  const config = { ...defaults, proxy: { enabled: true, url: "http://127.0.0.1:7890" } };
 
-  const normalized = normalizeConfig(config, defaults)
+  const normalized = normalizeConfig(config, defaults);
 
-  assert.equal(normalized.proxy.enabled, true)
-  assert.equal(normalized.proxy.url, 'http://127.0.0.1:7890')
-})
+  assert.equal(normalized.proxy.enabled, true);
+  assert.equal(normalized.proxy.url, "http://127.0.0.1:7890");
+});
 
-test('normalizeConfig falls back to defaults for invalid proxy values', () => {
-  const defaults = buildDefaultConfig()
+test("normalizeConfig falls back to defaults for invalid proxy values", () => {
+  const defaults = buildDefaultConfig();
   const config = {
     ...defaults,
-    proxy: { enabled: 'yes' as unknown as boolean, url: 123 as unknown as string },
-  }
+    proxy: { enabled: "yes" as unknown as boolean, url: 123 as unknown as string },
+  };
 
-  const normalized = normalizeConfig(config, defaults)
+  const normalized = normalizeConfig(config, defaults);
 
-  assert.equal(normalized.proxy.enabled, false)
-  assert.equal(normalized.proxy.url, '')
-})
+  assert.equal(normalized.proxy.enabled, false);
+  assert.equal(normalized.proxy.url, "");
+});
 
-test('normalizeConfig falls back for invalid runtime values', () => {
-  const defaults = buildDefaultConfig()
+test("normalizeConfig falls back for invalid runtime values", () => {
+  const defaults = buildDefaultConfig();
   const config = {
     ...defaults,
-    server: { ...defaults.server, proxyPort: 'bad' as unknown as number },
-    activeProvider: 'missing' as typeof defaults.activeProvider,
-    modelMode: 'many' as typeof defaults.modelMode,
+    server: { ...defaults.server, proxyPort: "bad" as unknown as number },
+    activeProvider: "missing" as typeof defaults.activeProvider,
+    modelMode: "many" as typeof defaults.modelMode,
     providers: {
       ...defaults.providers,
       nvidia_nim: {
         ...defaults.providers.nvidia_nim,
-        enabled: 'yes' as unknown as boolean,
+        enabled: "yes" as unknown as boolean,
         requestTimeoutMs: -1,
       },
     },
-  }
+  };
 
-  const normalized = normalizeConfig(config, defaults)
+  const normalized = normalizeConfig(config, defaults);
 
-  assert.equal(normalized.server.proxyPort, defaults.server.proxyPort)
-  assert.equal(normalized.activeProvider, defaults.activeProvider)
-  assert.equal(normalized.modelMode, defaults.modelMode)
-  assert.equal(normalized.providers.nvidia_nim.enabled, defaults.providers.nvidia_nim.enabled)
-  assert.equal(normalized.providers.nvidia_nim.requestTimeoutMs, undefined)
-})
+  assert.equal(normalized.server.proxyPort, defaults.server.proxyPort);
+  assert.equal(normalized.activeProvider, defaults.activeProvider);
+  assert.equal(normalized.modelMode, defaults.modelMode);
+  assert.equal(normalized.providers.nvidia_nim.enabled, defaults.providers.nvidia_nim.enabled);
+  assert.equal(normalized.providers.nvidia_nim.requestTimeoutMs, undefined);
+});
 
-test('normalizeConfig preserves valid token saver settings', () => {
-  const defaults = buildDefaultConfig()
+test("normalizeConfig preserves valid token saver settings", () => {
+  const defaults = buildDefaultConfig();
   const config = {
     ...defaults,
     tokenSavers: {
       rtkEnabled: true,
       cavemanEnabled: true,
-      cavemanLevel: 'ultra' as const,
+      cavemanLevel: "ultra" as const,
     },
-  }
+  };
 
-  const normalized = normalizeConfig(config, defaults)
+  const normalized = normalizeConfig(config, defaults);
 
-  assert.equal(normalized.tokenSavers.rtkEnabled, true)
-  assert.equal(normalized.tokenSavers.cavemanEnabled, true)
-  assert.equal(normalized.tokenSavers.cavemanLevel, 'ultra')
-})
+  assert.equal(normalized.tokenSavers.rtkEnabled, true);
+  assert.equal(normalized.tokenSavers.cavemanEnabled, true);
+  assert.equal(normalized.tokenSavers.cavemanLevel, "ultra");
+});

--- a/packages/daemon/src/config/validation.ts
+++ b/packages/daemon/src/config/validation.ts
@@ -1,9 +1,16 @@
-import type { CavemanLevel, Config, ModelMode, ProviderConfig, ProviderId, RoutingRule } from './schema.js'
-import { PROVIDER_IDS } from './schema.js'
+import type {
+  CavemanLevel,
+  Config,
+  ModelMode,
+  ProviderConfig,
+  ProviderId,
+  RoutingRule,
+} from "./schema.js";
+import { PROVIDER_IDS } from "./schema.js";
 
-const PROVIDER_ID_SET = new Set<string>(PROVIDER_IDS)
-const MODEL_MODES = new Set<ModelMode>(['single', 'all'])
-const CAVEMAN_LEVELS = new Set<CavemanLevel>(['lite', 'full', 'ultra'])
+const PROVIDER_ID_SET = new Set<string>(PROVIDER_IDS);
+const MODEL_MODES = new Set<ModelMode>(["single", "all"]);
+const CAVEMAN_LEVELS = new Set<CavemanLevel>(["lite", "full", "ultra"]);
 
 export function normalizeConfig(config: Config, defaults: Config): Config {
   return {
@@ -34,134 +41,148 @@ export function normalizeConfig(config: Config, defaults: Config): Config {
     },
     proxy: {
       enabled: booleanOrDefault(config.proxy?.enabled, defaults.proxy.enabled),
-      url: stringOrDefault(config.proxy?.url, defaults.proxy.url) || '',
+      url: stringOrDefault(config.proxy?.url, defaults.proxy.url) || "",
     },
     tokenSavers: {
       rtkEnabled: booleanOrDefault(config.tokenSavers?.rtkEnabled, defaults.tokenSavers.rtkEnabled),
-      cavemanEnabled: booleanOrDefault(config.tokenSavers?.cavemanEnabled, defaults.tokenSavers.cavemanEnabled),
-      cavemanLevel: cavemanLevelOrDefault(config.tokenSavers?.cavemanLevel, defaults.tokenSavers.cavemanLevel),
+      cavemanEnabled: booleanOrDefault(
+        config.tokenSavers?.cavemanEnabled,
+        defaults.tokenSavers.cavemanEnabled,
+      ),
+      cavemanLevel: cavemanLevelOrDefault(
+        config.tokenSavers?.cavemanLevel,
+        defaults.tokenSavers.cavemanLevel,
+      ),
     },
     activeProvider: providerIdOrDefault(config.activeProvider, defaults.activeProvider),
     modelMode: modelModeOrDefault(config.modelMode, defaults.modelMode),
-  }
+  };
 }
 
 function normalizeProviders(
   providers: Record<ProviderId, ProviderConfig>,
   defaults: Record<ProviderId, ProviderConfig>,
 ): Record<ProviderId, ProviderConfig> {
-  return PROVIDER_IDS.reduce((out, id) => {
-    const provider = providers[id]
-    const fallback = defaults[id]
-    out[id] = {
-      enabled: booleanOrDefault(provider.enabled, fallback.enabled),
-      apiKey: optionalString(provider.apiKey),
-      authType: authTypeOrDefault(provider.authType, fallback.authType),
-      oauth: normalizeOAuth(provider.oauth, fallback.oauth),
-      models: normalizeStringList(provider.models, fallback.models),
-      disabledModels: normalizeStringList(provider.disabledModels, fallback.disabledModels),
-      baseUrl: optionalString(provider.baseUrl) ?? fallback.baseUrl,
-      rateLimit: numberOrDefault(provider.rateLimit, fallback.rateLimit),
-      rateWindow: numberOrDefault(provider.rateWindow, fallback.rateWindow),
-      maxConcurrency: numberOrDefault(provider.maxConcurrency, fallback.maxConcurrency),
-      requestTimeoutMs: optionalPositiveNumber(provider.requestTimeoutMs),
-    }
-    return out
-  }, {} as Record<ProviderId, ProviderConfig>)
+  return PROVIDER_IDS.reduce(
+    (out, id) => {
+      const provider = providers[id];
+      const fallback = defaults[id];
+      out[id] = {
+        enabled: booleanOrDefault(provider.enabled, fallback.enabled),
+        apiKey: optionalString(provider.apiKey),
+        authType: authTypeOrDefault(provider.authType, fallback.authType),
+        oauth: normalizeOAuth(provider.oauth, fallback.oauth),
+        models: normalizeStringList(provider.models, fallback.models),
+        disabledModels: normalizeStringList(provider.disabledModels, fallback.disabledModels),
+        baseUrl: optionalString(provider.baseUrl) ?? fallback.baseUrl,
+        rateLimit: numberOrDefault(provider.rateLimit, fallback.rateLimit),
+        rateWindow: numberOrDefault(provider.rateWindow, fallback.rateWindow),
+        maxConcurrency: numberOrDefault(provider.maxConcurrency, fallback.maxConcurrency),
+        requestTimeoutMs: optionalPositiveNumber(provider.requestTimeoutMs),
+      };
+      return out;
+    },
+    {} as Record<ProviderId, ProviderConfig>,
+  );
 }
 
 function normalizeOAuth(
-  value: ProviderConfig['oauth'],
-  fallback: ProviderConfig['oauth'],
-): ProviderConfig['oauth'] {
-  if (!value || typeof value !== 'object') return fallback
+  value: ProviderConfig["oauth"],
+  fallback: ProviderConfig["oauth"],
+): ProviderConfig["oauth"] {
+  if (!value || typeof value !== "object") return fallback;
   return {
     accessToken: optionalString(value.accessToken),
     refreshToken: optionalString(value.refreshToken),
     expiresAt: optionalPositiveNumber(value.expiresAt),
     accountId: optionalString(value.accountId),
     planType: optionalString(value.planType),
-  }
+  };
 }
 
 function normalizeRoutingRule(value: unknown, fallback: RoutingRule): RoutingRule {
   // Legacy migration: string "provider_id/model-name"
-  if (typeof value === 'string') {
-    const slash = value.indexOf('/')
+  if (typeof value === "string") {
+    const slash = value.indexOf("/");
     if (slash > 0) {
-      const pid = value.slice(0, slash)
-      const model = value.slice(slash + 1)
+      const pid = value.slice(0, slash);
+      const model = value.slice(slash + 1);
       if (PROVIDER_ID_SET.has(pid) && model) {
-        return { enabled: true, providerId: pid as ProviderId, model }
+        return { enabled: true, providerId: pid as ProviderId, model };
       }
     }
-    return { enabled: false, providerId: '', model: '' }
+    return { enabled: false, providerId: "", model: "" };
   }
-  if (!value || typeof value !== 'object') return fallback
-  const v = value as Partial<RoutingRule>
+  if (!value || typeof value !== "object") return fallback;
+  const v = value as Partial<RoutingRule>;
   const providerId =
-    typeof v.providerId === 'string' && (v.providerId === '' || PROVIDER_ID_SET.has(v.providerId))
-      ? (v.providerId as ProviderId | '')
-      : ''
-  const model = typeof v.model === 'string' ? v.model : ''
-  const enabledRaw = typeof v.enabled === 'boolean' ? v.enabled : false
+    typeof v.providerId === "string" && (v.providerId === "" || PROVIDER_ID_SET.has(v.providerId))
+      ? (v.providerId as ProviderId | "")
+      : "";
+  const model = typeof v.model === "string" ? v.model : "";
+  const enabledRaw = typeof v.enabled === "boolean" ? v.enabled : false;
   // A rule can only be considered enabled if it has both a provider and a model
-  const enabled = enabledRaw && !!providerId && !!model
-  return { enabled, providerId, model }
+  const enabled = enabledRaw && !!providerId && !!model;
+  return { enabled, providerId, model };
 }
 
 function stringOrDefault(value: unknown, fallback: string): string {
-  return typeof value === 'string' && value.length > 0 ? value : fallback
+  return typeof value === "string" && value.length > 0 ? value : fallback;
 }
 
 function optionalString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined
+  return typeof value === "string" ? value : undefined;
 }
 
 function normalizeStringList(value: unknown, fallback: string[] | undefined): string[] | undefined {
-  if (!Array.isArray(value)) return fallback
-  const seen = new Set<string>()
-  const out: string[] = []
+  if (!Array.isArray(value)) return fallback;
+  const seen = new Set<string>();
+  const out: string[] = [];
   for (const item of value) {
-    if (typeof item !== 'string') continue
-    const model = item.trim()
-    if (!model || seen.has(model)) continue
-    seen.add(model)
-    out.push(model)
+    if (typeof item !== "string") continue;
+    const model = item.trim();
+    if (!model || seen.has(model)) continue;
+    seen.add(model);
+    out.push(model);
   }
-  return out
+  return out;
 }
 
 function numberOrDefault(value: unknown, fallback: number): number {
-  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 
 function optionalPositiveNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
 function booleanOrDefault(value: unknown, fallback: boolean): boolean {
-  return typeof value === 'boolean' ? value : fallback
+  return typeof value === "boolean" ? value : fallback;
 }
 
 function nullableBooleanOrDefault(value: unknown, fallback: boolean | null): boolean | null {
-  return value === null || typeof value === 'boolean' ? value : fallback
+  return value === null || typeof value === "boolean" ? value : fallback;
 }
 
-function authTypeOrDefault(value: unknown, fallback: ProviderConfig['authType']): ProviderConfig['authType'] {
-  return value === 'oauth' || value === 'api_key' ? value : fallback
+function authTypeOrDefault(
+  value: unknown,
+  fallback: ProviderConfig["authType"],
+): ProviderConfig["authType"] {
+  return value === "oauth" || value === "api_key" ? value : fallback;
 }
 
 function providerIdOrDefault(value: unknown, fallback: ProviderId): ProviderId {
-  return typeof value === 'string' && PROVIDER_ID_SET.has(value) ? value as ProviderId : fallback
+  return typeof value === "string" && PROVIDER_ID_SET.has(value) ? (value as ProviderId) : fallback;
 }
 
 function modelModeOrDefault(value: unknown, fallback: ModelMode): ModelMode {
-  return typeof value === 'string' && MODEL_MODES.has(value as ModelMode) ? value as ModelMode : fallback
+  return typeof value === "string" && MODEL_MODES.has(value as ModelMode)
+    ? (value as ModelMode)
+    : fallback;
 }
 
 function cavemanLevelOrDefault(value: unknown, fallback: CavemanLevel): CavemanLevel {
-  return typeof value === 'string' && CAVEMAN_LEVELS.has(value as CavemanLevel)
-    ? value as CavemanLevel
-    : fallback
+  return typeof value === "string" && CAVEMAN_LEVELS.has(value as CavemanLevel)
+    ? (value as CavemanLevel)
+    : fallback;
 }

--- a/packages/daemon/src/core/anthropic/conversion.ts
+++ b/packages/daemon/src/core/anthropic/conversion.ts
@@ -1,136 +1,142 @@
 // Anthropic Messages ↔ OpenAI Chat Completions conversion
 
-import type { MessagesRequest, Message, ContentBlock } from './types.js'
+import type { ContentBlock, Message, MessagesRequest } from "./types.js";
 
 export interface OpenAIMessage {
-  role: 'system' | 'user' | 'assistant' | 'tool'
-  content: string | OpenAIContentPart[]
-  tool_calls?: OpenAIToolCall[]
-  tool_call_id?: string
-  name?: string
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | OpenAIContentPart[];
+  tool_calls?: OpenAIToolCall[];
+  tool_call_id?: string;
+  name?: string;
 }
 
 export interface OpenAIContentPart {
-  type: 'text' | 'image_url'
-  text?: string
-  image_url?: { url: string }
+  type: "text" | "image_url";
+  text?: string;
+  image_url?: { url: string };
 }
 
 export interface OpenAIToolCall {
-  id: string
-  type: 'function'
-  function: { name: string; arguments: string }
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
 }
 
 export interface OpenAITool {
-  type: 'function'
-  function: { name: string; description?: string; parameters: Record<string, unknown> }
+  type: "function";
+  function: { name: string; description?: string; parameters: Record<string, unknown> };
 }
 
 export interface OpenAIChatRequest {
-  model: string
-  messages: OpenAIMessage[]
-  max_tokens: number
-  temperature?: number
-  top_p?: number
-  stream: boolean
-  tools?: OpenAITool[]
-  tool_choice?: 'auto' | 'none' | 'required' | { type: 'function'; function: { name: string } }
-  stop?: string[]
+  model: string;
+  messages: OpenAIMessage[];
+  max_tokens: number;
+  temperature?: number;
+  top_p?: number;
+  stream: boolean;
+  tools?: OpenAITool[];
+  tool_choice?: "auto" | "none" | "required" | { type: "function"; function: { name: string } };
+  stop?: string[];
 }
 
 function contentBlocksToOpenAI(content: string | ContentBlock[]): string | OpenAIContentPart[] {
-  if (typeof content === 'string') return content
+  if (typeof content === "string") return content;
 
-  const parts: OpenAIContentPart[] = []
+  const parts: OpenAIContentPart[] = [];
   for (const block of content) {
-    if (block.type === 'text') {
-      parts.push({ type: 'text', text: block.text })
-    } else if (block.type === 'image') {
-      const src = block.source
-      if (src.type === 'base64') {
-        parts.push({ type: 'image_url', image_url: { url: `data:${src.media_type};base64,${src.data}` } })
+    if (block.type === "text") {
+      parts.push({ type: "text", text: block.text });
+    } else if (block.type === "image") {
+      const src = block.source;
+      if (src.type === "base64") {
+        parts.push({
+          type: "image_url",
+          image_url: { url: `data:${src.media_type};base64,${src.data}` },
+        });
       } else {
-        parts.push({ type: 'image_url', image_url: { url: src.url } })
+        parts.push({ type: "image_url", image_url: { url: src.url } });
       }
-    } else if (block.type === 'thinking') {
+    } else if (block.type === "thinking") {
       // Thinking blocks are not forwarded to OpenAI-compat providers
     }
   }
-  return parts.length === 1 && parts[0]?.type === 'text' ? (parts[0].text ?? '') : parts
+  return parts.length === 1 && parts[0]?.type === "text" ? (parts[0].text ?? "") : parts;
 }
 
 function messageToOpenAI(msg: Message): OpenAIMessage[] {
-  const content = msg.content
+  const content = msg.content;
 
-  if (typeof content === 'string') {
-    return [{ role: msg.role, content }]
+  if (typeof content === "string") {
+    return [{ role: msg.role, content }];
   }
 
   // Assistant messages with tool_use blocks need special handling
-  if (msg.role === 'assistant') {
-    const toolCalls: OpenAIToolCall[] = []
-    const textParts: string[] = []
+  if (msg.role === "assistant") {
+    const toolCalls: OpenAIToolCall[] = [];
+    const textParts: string[] = [];
 
     for (const block of content) {
-      if (block.type === 'tool_use') {
+      if (block.type === "tool_use") {
         toolCalls.push({
           id: block.id,
-          type: 'function',
+          type: "function",
           function: { name: block.name, arguments: JSON.stringify(block.input) },
-        })
-      } else if (block.type === 'text') {
-        textParts.push(block.text)
+        });
+      } else if (block.type === "text") {
+        textParts.push(block.text);
       }
     }
 
     const msg_: OpenAIMessage = {
-      role: 'assistant',
-      content: textParts.join('') || null as unknown as string,
-    }
-    if (toolCalls.length > 0) msg_.tool_calls = toolCalls
-    return [msg_]
+      role: "assistant",
+      content: textParts.join("") || (null as unknown as string),
+    };
+    if (toolCalls.length > 0) msg_.tool_calls = toolCalls;
+    return [msg_];
   }
 
   // User messages with tool_result blocks become tool-role messages
-  const toolResultMessages: OpenAIMessage[] = []
-  const otherBlocks: ContentBlock[] = []
+  const toolResultMessages: OpenAIMessage[] = [];
+  const otherBlocks: ContentBlock[] = [];
 
   for (const block of content) {
-    if (block.type === 'tool_result') {
-      const resultContent = typeof block.content === 'string'
-        ? block.content
-        : (block.content as ContentBlock[]).filter(b => b.type === 'text').map(b => (b as { text: string }).text).join('')
+    if (block.type === "tool_result") {
+      const resultContent =
+        typeof block.content === "string"
+          ? block.content
+          : (block.content as ContentBlock[])
+              .filter((b) => b.type === "text")
+              .map((b) => (b as { text: string }).text)
+              .join("");
       toolResultMessages.push({
-        role: 'tool',
+        role: "tool",
         tool_call_id: block.tool_use_id,
         content: resultContent,
-      })
+      });
     } else {
-      otherBlocks.push(block)
+      otherBlocks.push(block);
     }
   }
 
-  const result: OpenAIMessage[] = []
+  const result: OpenAIMessage[] = [];
   if (otherBlocks.length > 0) {
-    result.push({ role: 'user', content: contentBlocksToOpenAI(otherBlocks) })
+    result.push({ role: "user", content: contentBlocksToOpenAI(otherBlocks) });
   }
-  result.push(...toolResultMessages)
-  return result
+  result.push(...toolResultMessages);
+  return result;
 }
 
 export function anthropicToOpenAI(req: MessagesRequest, model: string): OpenAIChatRequest {
-  const messages: OpenAIMessage[] = []
+  const messages: OpenAIMessage[] = [];
 
   if (req.system) {
-    const systemText = typeof req.system === 'string'
-      ? req.system
-      : req.system.map(b => b.text).join('\n')
-    messages.push({ role: 'system', content: systemText })
+    const systemText =
+      typeof req.system === "string" ? req.system : req.system.map((b) => b.text).join("\n");
+    messages.push({ role: "system", content: systemText });
   }
 
   for (const msg of req.messages) {
-    messages.push(...messageToOpenAI(msg))
+    messages.push(...messageToOpenAI(msg));
   }
 
   const openaiReq: OpenAIChatRequest = {
@@ -138,26 +144,26 @@ export function anthropicToOpenAI(req: MessagesRequest, model: string): OpenAICh
     messages,
     max_tokens: req.max_tokens,
     stream: true,
-  }
+  };
 
-  if (req.temperature !== undefined) openaiReq.temperature = req.temperature
-  if (req.top_p !== undefined) openaiReq.top_p = req.top_p
-  if (req.stop_sequences?.length) openaiReq.stop = req.stop_sequences
+  if (req.temperature !== undefined) openaiReq.temperature = req.temperature;
+  if (req.top_p !== undefined) openaiReq.top_p = req.top_p;
+  if (req.stop_sequences?.length) openaiReq.stop = req.stop_sequences;
 
   if (req.tools?.length) {
-    openaiReq.tools = req.tools.map(t => ({
-      type: 'function',
+    openaiReq.tools = req.tools.map((t) => ({
+      type: "function",
       function: { name: t.name, description: t.description, parameters: t.input_schema },
-    }))
+    }));
 
     if (req.tool_choice) {
-      if (req.tool_choice.type === 'auto') openaiReq.tool_choice = 'auto'
-      else if (req.tool_choice.type === 'any') openaiReq.tool_choice = 'required'
-      else if (req.tool_choice.type === 'tool' && req.tool_choice.name) {
-        openaiReq.tool_choice = { type: 'function', function: { name: req.tool_choice.name } }
+      if (req.tool_choice.type === "auto") openaiReq.tool_choice = "auto";
+      else if (req.tool_choice.type === "any") openaiReq.tool_choice = "required";
+      else if (req.tool_choice.type === "tool" && req.tool_choice.name) {
+        openaiReq.tool_choice = { type: "function", function: { name: req.tool_choice.name } };
       }
     }
   }
 
-  return openaiReq
+  return openaiReq;
 }

--- a/packages/daemon/src/core/anthropic/tokens.ts
+++ b/packages/daemon/src/core/anthropic/tokens.ts
@@ -1,47 +1,48 @@
-import { getEncoding } from 'js-tiktoken'
-import type { MessagesRequest, Message, ContentBlock } from './types.js'
+import { getEncoding } from "js-tiktoken";
+import type { ContentBlock, Message, MessagesRequest } from "./types.js";
 
 // cl100k_base covers GPT-4 / Claude-compatible token counting
-const enc = getEncoding('cl100k_base')
+const enc = getEncoding("cl100k_base");
 
 function countText(text: string): number {
-  return enc.encode(text).length
+  return enc.encode(text).length;
 }
 
 function countContent(content: string | ContentBlock[]): number {
-  if (typeof content === 'string') return countText(content)
-  let total = 0
+  if (typeof content === "string") return countText(content);
+  let total = 0;
   for (const block of content) {
-    if (block.type === 'text') total += countText(block.text)
-    else if (block.type === 'thinking') total += countText(block.thinking)
-    else if (block.type === 'tool_use') total += countText(JSON.stringify(block.input))
-    else if (block.type === 'tool_result') {
-      if (typeof block.content === 'string') total += countText(block.content)
-      else total += countContent(block.content)
+    if (block.type === "text") total += countText(block.text);
+    else if (block.type === "thinking") total += countText(block.thinking);
+    else if (block.type === "tool_use") total += countText(JSON.stringify(block.input));
+    else if (block.type === "tool_result") {
+      if (typeof block.content === "string") total += countText(block.content);
+      else total += countContent(block.content);
     }
   }
-  return total
+  return total;
 }
 
 function countMessage(msg: Message): number {
-  return 4 + countContent(msg.content) // 4 tokens overhead per message
+  return 4 + countContent(msg.content); // 4 tokens overhead per message
 }
 
 export function countRequestTokens(req: MessagesRequest): number {
-  let total = 0
+  let total = 0;
 
   if (req.system) {
-    const text = typeof req.system === 'string' ? req.system : req.system.map(b => b.text).join('')
-    total += countText(text) + 4
+    const text =
+      typeof req.system === "string" ? req.system : req.system.map((b) => b.text).join("");
+    total += countText(text) + 4;
   }
 
   for (const msg of req.messages) {
-    total += countMessage(msg)
+    total += countMessage(msg);
   }
 
   if (req.tools?.length) {
-    total += countText(JSON.stringify(req.tools)) + 4
+    total += countText(JSON.stringify(req.tools)) + 4;
   }
 
-  return total
+  return total;
 }

--- a/packages/daemon/src/core/anthropic/types.ts
+++ b/packages/daemon/src/core/anthropic/types.ts
@@ -1,40 +1,40 @@
 // Anthropic Messages API — request/response types
 
-export type Role = 'user' | 'assistant'
+export type Role = "user" | "assistant";
 
 export interface TextContent {
-  type: 'text'
-  text: string
+  type: "text";
+  text: string;
 }
 
 export interface ImageContent {
-  type: 'image'
-  source: { type: 'base64'; media_type: string; data: string } | { type: 'url'; url: string }
+  type: "image";
+  source: { type: "base64"; media_type: string; data: string } | { type: "url"; url: string };
 }
 
 export interface ToolUseContent {
-  type: 'tool_use'
-  id: string
-  name: string
-  input: Record<string, unknown>
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
 }
 
 export interface ToolResultContent {
-  type: 'tool_result'
-  tool_use_id: string
-  content: string | ContentBlock[]
-  is_error?: boolean
+  type: "tool_result";
+  tool_use_id: string;
+  content: string | ContentBlock[];
+  is_error?: boolean;
 }
 
 export interface ThinkingContent {
-  type: 'thinking'
-  thinking: string
+  type: "thinking";
+  thinking: string;
 }
 
 export interface DocumentContent {
-  type: 'document'
-  source: { type: 'base64'; media_type: string; data: string } | { type: 'text'; text: string }
-  title?: string
+  type: "document";
+  source: { type: "base64"; media_type: string; data: string } | { type: "text"; text: string };
+  title?: string;
 }
 
 export type ContentBlock =
@@ -43,80 +43,80 @@ export type ContentBlock =
   | ToolUseContent
   | ToolResultContent
   | ThinkingContent
-  | DocumentContent
+  | DocumentContent;
 
 export interface Message {
-  role: Role
-  content: string | ContentBlock[]
+  role: Role;
+  content: string | ContentBlock[];
 }
 
 export interface Tool {
-  name: string
-  description?: string
-  input_schema: Record<string, unknown>
+  name: string;
+  description?: string;
+  input_schema: Record<string, unknown>;
 }
 
 export interface ThinkingConfig {
-  type: 'enabled'
-  budget_tokens: number
+  type: "enabled";
+  budget_tokens: number;
 }
 
 export interface MessagesRequest {
-  model: string
-  messages: Message[]
-  max_tokens: number
-  system?: string | Array<{ type: 'text'; text: string }>
-  tools?: Tool[]
-  tool_choice?: { type: 'auto' | 'any' | 'tool'; name?: string }
-  temperature?: number
-  top_p?: number
-  top_k?: number
-  stream?: boolean
-  thinking?: ThinkingConfig
-  metadata?: { user_id?: string }
-  stop_sequences?: string[]
+  model: string;
+  messages: Message[];
+  max_tokens: number;
+  system?: string | Array<{ type: "text"; text: string }>;
+  tools?: Tool[];
+  tool_choice?: { type: "auto" | "any" | "tool"; name?: string };
+  temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  stream?: boolean;
+  thinking?: ThinkingConfig;
+  metadata?: { user_id?: string };
+  stop_sequences?: string[];
 }
 
 export interface Usage {
-  input_tokens: number
-  output_tokens: number
-  cache_read_input_tokens?: number
-  cache_creation_input_tokens?: number
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
 }
 
 export interface MessagesResponse {
-  id: string
-  type: 'message'
-  role: 'assistant'
-  content: ContentBlock[]
-  model: string
-  stop_reason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'tool_use' | null
-  stop_sequence: string | null
-  usage: Usage
+  id: string;
+  type: "message";
+  role: "assistant";
+  content: ContentBlock[];
+  model: string;
+  stop_reason: "end_turn" | "max_tokens" | "stop_sequence" | "tool_use" | null;
+  stop_sequence: string | null;
+  usage: Usage;
 }
 
 export interface CountTokensRequest {
-  model: string
-  messages: Message[]
-  system?: string | Array<{ type: 'text'; text: string }>
-  tools?: Tool[]
-  thinking?: ThinkingConfig
+  model: string;
+  messages: Message[];
+  system?: string | Array<{ type: "text"; text: string }>;
+  tools?: Tool[];
+  thinking?: ThinkingConfig;
 }
 
 export interface CountTokensResponse {
-  input_tokens: number
+  input_tokens: number;
 }
 
 export interface ModelInfo {
-  type: 'model'
-  id: string
-  display_name: string
-  created_at: string
+  type: "model";
+  id: string;
+  display_name: string;
+  created_at: string;
 }
 
 export interface ModelsListResponse {
-  data: ModelInfo[]
-  has_more: boolean
-  first_id: string | null
-  last_id: string | null
+  data: ModelInfo[];
+  has_more: boolean;
+  first_id: string | null;
+  last_id: string | null;
 }

--- a/packages/daemon/src/core/files/private-file.test.ts
+++ b/packages/daemon/src/core/files/private-file.test.ts
@@ -1,46 +1,46 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
-import { tmpdir, platform } from 'node:os'
-import { join } from 'node:path'
-import { appendPrivateFile, writePrivateFile } from './private-file.js'
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { platform, tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { appendPrivateFile, writePrivateFile } from "./private-file.js";
 
 function withTempDir(fn: (dir: string) => void): void {
-  const dir = mkdtempSync(join(tmpdir(), 'private-file-'))
+  const dir = mkdtempSync(join(tmpdir(), "private-file-"));
   try {
-    fn(dir)
+    fn(dir);
   } finally {
-    rmSync(dir, { recursive: true, force: true })
+    rmSync(dir, { recursive: true, force: true });
   }
 }
 
 function posixMode(path: string): number {
-  return statSync(path).mode & 0o777
+  return statSync(path).mode & 0o777;
 }
 
-test('writePrivateFile writes with owner-only permissions on POSIX', t => {
-  if (platform() === 'win32') return t.skip('POSIX-only')
+test("writePrivateFile writes with owner-only permissions on POSIX", (t) => {
+  if (platform() === "win32") return t.skip("POSIX-only");
 
-  withTempDir(dir => {
-    const file = join(dir, 'history.json')
-    writePrivateFile(file, '{"ok":true}')
+  withTempDir((dir) => {
+    const file = join(dir, "history.json");
+    writePrivateFile(file, '{"ok":true}');
 
-    assert.equal(readFileSync(file, 'utf-8'), '{"ok":true}')
-    assert.equal(posixMode(file), 0o600)
-  })
-})
+    assert.equal(readFileSync(file, "utf-8"), '{"ok":true}');
+    assert.equal(posixMode(file), 0o600);
+  });
+});
 
-test('appendPrivateFile tightens permissions on existing files', t => {
-  if (platform() === 'win32') return t.skip('POSIX-only')
+test("appendPrivateFile tightens permissions on existing files", (t) => {
+  if (platform() === "win32") return t.skip("POSIX-only");
 
-  withTempDir(dir => {
-    const file = join(dir, 'sessions.jsonl')
-    writeFileSync(file, 'old\n', 'utf-8')
-    chmodSync(file, 0o644)
+  withTempDir((dir) => {
+    const file = join(dir, "sessions.jsonl");
+    writeFileSync(file, "old\n", "utf-8");
+    chmodSync(file, 0o644);
 
-    appendPrivateFile(file, 'new\n')
+    appendPrivateFile(file, "new\n");
 
-    assert.equal(readFileSync(file, 'utf-8'), 'old\nnew\n')
-    assert.equal(posixMode(file), 0o600)
-  })
-})
+    assert.equal(readFileSync(file, "utf-8"), "old\nnew\n");
+    assert.equal(posixMode(file), 0o600);
+  });
+});

--- a/packages/daemon/src/core/files/private-file.ts
+++ b/packages/daemon/src/core/files/private-file.ts
@@ -1,23 +1,23 @@
-import { appendFileSync, chmodSync, mkdirSync, writeFileSync } from 'node:fs'
-import { dirname } from 'node:path'
+import { appendFileSync, chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 
-const PRIVATE_FILE_MODE = 0o600
+const PRIVATE_FILE_MODE = 0o600;
 
 export function writePrivateFile(path: string, data: string): void {
-  mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, data, { encoding: 'utf-8', mode: PRIVATE_FILE_MODE })
-  chmodPrivateFile(path)
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, data, { encoding: "utf-8", mode: PRIVATE_FILE_MODE });
+  chmodPrivateFile(path);
 }
 
 export function appendPrivateFile(path: string, data: string): void {
-  mkdirSync(dirname(path), { recursive: true })
-  appendFileSync(path, data, { encoding: 'utf-8', mode: PRIVATE_FILE_MODE })
-  chmodPrivateFile(path)
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, data, { encoding: "utf-8", mode: PRIVATE_FILE_MODE });
+  chmodPrivateFile(path);
 }
 
 function chmodPrivateFile(path: string): void {
   try {
-    chmodSync(path, PRIVATE_FILE_MODE)
+    chmodSync(path, PRIVATE_FILE_MODE);
   } catch {
     // Best-effort on platforms without POSIX permissions, especially Windows.
   }

--- a/packages/daemon/src/core/sse/writer.ts
+++ b/packages/daemon/src/core/sse/writer.ts
@@ -1,98 +1,101 @@
 // Server-Sent Events serialization in Anthropic format
 
 export function sseEvent(event: string, data: unknown): string {
-  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 }
 
 export function sseMessageStart(id: string, model: string, inputTokens: number): string {
-  return sseEvent('message_start', {
-    type: 'message_start',
+  return sseEvent("message_start", {
+    type: "message_start",
     message: {
       id,
-      type: 'message',
-      role: 'assistant',
+      type: "message",
+      role: "assistant",
       content: [],
       model,
       stop_reason: null,
       stop_sequence: null,
       usage: { input_tokens: inputTokens, output_tokens: 0 },
     },
-  })
+  });
 }
 
 export function sseContentBlockStart(index: number, block: unknown): string {
-  return sseEvent('content_block_start', { type: 'content_block_start', index, content_block: block })
+  return sseEvent("content_block_start", {
+    type: "content_block_start",
+    index,
+    content_block: block,
+  });
 }
 
 export function sseContentBlockDelta(index: number, delta: unknown): string {
-  return sseEvent('content_block_delta', { type: 'content_block_delta', index, delta })
+  return sseEvent("content_block_delta", { type: "content_block_delta", index, delta });
 }
 
 export function sseContentBlockStop(index: number): string {
-  return sseEvent('content_block_stop', { type: 'content_block_stop', index })
+  return sseEvent("content_block_stop", { type: "content_block_stop", index });
 }
 
 export function sseMessageDelta(stopReason: string | null, outputTokens: number): string {
-  return sseEvent('message_delta', {
-    type: 'message_delta',
+  return sseEvent("message_delta", {
+    type: "message_delta",
     delta: { stop_reason: stopReason, stop_sequence: null },
     usage: { output_tokens: outputTokens },
-  })
+  });
 }
 
 export function sseMessageStop(): string {
-  return sseEvent('message_stop', { type: 'message_stop' })
+  return sseEvent("message_stop", { type: "message_stop" });
 }
 
 export function ssePing(): string {
-  return sseEvent('ping', { type: 'ping' })
+  return sseEvent("ping", { type: "ping" });
 }
 
 export function sseError(type: string, message: string): string {
-  return sseEvent('error', { type: 'error', error: { type, message } })
+  return sseEvent("error", { type: "error", error: { type, message } });
 }
 
 export const SSE_HEADERS = {
-  'Content-Type': 'text/event-stream',
-  'Cache-Control': 'no-cache',
-  'Connection': 'keep-alive',
-  'X-Accel-Buffering': 'no',
-} as const
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  Connection: "keep-alive",
+  "X-Accel-Buffering": "no",
+} as const;
 
 export function teeWithCapture(stream: ReadableStream<string>): {
-  stream: ReadableStream<string>
-  getCapturedText: () => string
+  stream: ReadableStream<string>;
+  getCapturedText: () => string;
 } {
-  let captured = ''
-  const decoder = new TextDecoder()
+  let captured = "";
 
   const transform = new TransformStream<string, string>({
     transform(chunk, controller) {
-      controller.enqueue(chunk)
+      controller.enqueue(chunk);
       try {
-        const lines = chunk.split('\n')
-        let currentEvent = ''
+        const lines = chunk.split("\n");
+        let currentEvent = "";
         for (const line of lines) {
-          if (line.startsWith('event: ')) {
-            currentEvent = line.slice(7).trim()
-          } else if (line.startsWith('data: ') && currentEvent === 'content_block_delta') {
+          if (line.startsWith("event: ")) {
+            currentEvent = line.slice(7).trim();
+          } else if (line.startsWith("data: ") && currentEvent === "content_block_delta") {
             try {
-              const parsed = JSON.parse(line.slice(6))
-              if (parsed.delta?.type === 'text_delta' && parsed.delta.text) {
-                captured += parsed.delta.text
+              const parsed = JSON.parse(line.slice(6));
+              if (parsed.delta?.type === "text_delta" && parsed.delta.text) {
+                captured += parsed.delta.text;
               }
             } catch {}
-          } else if (line === '' || line === '\r') {
-            currentEvent = ''
+          } else if (line === "" || line === "\r") {
+            currentEvent = "";
           }
         }
       } catch {}
     },
-  })
+  });
 
-  const wrapped = stream.pipeThrough(transform)
+  const wrapped = stream.pipeThrough(transform);
   return {
     stream: wrapped,
     getCapturedText: () => captured,
-  }
+  };
 }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,7 +1,7 @@
-import { loadConfig } from './config/index.js'
-import { configureOutboundNetwork } from './runtime/network.js'
-import { startDaemon } from './runtime/daemon.js'
+import { loadConfig } from "./config/index.js";
+import { startDaemon } from "./runtime/daemon.js";
+import { configureOutboundNetwork } from "./runtime/network.js";
 
-const config = loadConfig()
-configureOutboundNetwork(config.proxy.enabled ? config.proxy.url : undefined)
-startDaemon(config)
+const config = loadConfig();
+configureOutboundNetwork(config.proxy.enabled ? config.proxy.url : undefined);
+startDaemon(config);

--- a/packages/daemon/src/observability/log.ts
+++ b/packages/daemon/src/observability/log.ts
@@ -1,37 +1,39 @@
 // Central log + SSE emitter. Anything that should appear in the panel's
 // live-logs feed must go through `log()` here.
 
-const listeners = new Set<(line: string) => void>()
-const buffer: string[] = []
-const BUFFER_SIZE = 500
+const listeners = new Set<(line: string) => void>();
+const buffer: string[] = [];
+const BUFFER_SIZE = 500;
 
 export function emitLog(line: string) {
-  buffer.push(line)
-  if (buffer.length > BUFFER_SIZE) buffer.shift()
-  for (const fn of listeners) fn(line)
+  buffer.push(line);
+  if (buffer.length > BUFFER_SIZE) buffer.shift();
+  for (const fn of listeners) fn(line);
 }
 
 export function getLogBuffer(): string[] {
-  return [...buffer]
+  return [...buffer];
 }
 
 export function addLogListener(fn: (line: string) => void) {
-  listeners.add(fn)
-  return () => { listeners.delete(fn) }
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
 }
 
-export type LogLevel = 'info' | 'warn' | 'error'
+export type LogLevel = "info" | "warn" | "error";
 
 export function log(level: LogLevel, source: string, msg: string) {
-  const ts = new Date().toISOString().slice(11, 23) // HH:MM:SS.mmm
-  const line = `${ts} [${level.toUpperCase()}] [${source}] ${msg}`
-  const out = level === 'error' ? process.stderr : process.stdout
-  out.write(line + '\n')
-  emitLog(line)
+  const ts = new Date().toISOString().slice(11, 23); // HH:MM:SS.mmm
+  const line = `${ts} [${level.toUpperCase()}] [${source}] ${msg}`;
+  const out = level === "error" ? process.stderr : process.stdout;
+  out.write(line + "\n");
+  emitLog(line);
 }
 
 export const logger = {
-  info:  (source: string, msg: string) => log('info', source, msg),
-  warn:  (source: string, msg: string) => log('warn', source, msg),
-  error: (source: string, msg: string) => log('error', source, msg),
-}
+  info: (source: string, msg: string) => log("info", source, msg),
+  warn: (source: string, msg: string) => log("warn", source, msg),
+  error: (source: string, msg: string) => log("error", source, msg),
+};

--- a/packages/daemon/src/panel/app.test.ts
+++ b/packages/daemon/src/panel/app.test.ts
@@ -1,327 +1,327 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { buildDefaultConfig } from '../config/index.js'
-import { createPanelApp } from './app.js'
-import type { Config } from '../config/schema.js'
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildDefaultConfig } from "../config/index.js";
+import type { Config } from "../config/schema.js";
+import { createPanelApp } from "./app.js";
 
 function testPanelApp(config: Config) {
-  return createPanelApp(config, { saveConfig: () => {} })
+  return createPanelApp(config, { saveConfig: () => {} });
 }
 
-test('panel API rejects browser requests from untrusted origins', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = testPanelApp(config)
+test("panel API rejects browser requests from untrusted origins", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = testPanelApp(config);
 
-  const response = await app.request('/api/launch-commands', {
+  const response = await app.request("/api/launch-commands", {
     headers: {
-      Origin: 'https://example.invalid',
-      'Sec-Fetch-Site': 'cross-site',
+      Origin: "https://example.invalid",
+      "Sec-Fetch-Site": "cross-site",
     },
-  })
+  });
 
-  assert.equal(response.status, 403)
-  assert.deepEqual(await response.json(), { error: 'Forbidden origin' })
-})
+  assert.equal(response.status, 403);
+  assert.deepEqual(await response.json(), { error: "Forbidden origin" });
+});
 
-test('panel API allows trusted Tauri origins in production', async () => {
-  const previous = process.env['NODE_ENV']
-  process.env['NODE_ENV'] = 'production'
+test("panel API allows trusted Tauri origins in production", async () => {
+  const previous = process.env["NODE_ENV"];
+  process.env["NODE_ENV"] = "production";
   try {
-    const config = buildDefaultConfig()
-    config.server.authToken = 'secret'
-    const app = testPanelApp(config)
+    const config = buildDefaultConfig();
+    config.server.authToken = "secret";
+    const app = testPanelApp(config);
 
-    const response = await app.request('/api/status', {
-      headers: { Origin: 'https://tauri.localhost' },
-    })
+    const response = await app.request("/api/status", {
+      headers: { Origin: "https://tauri.localhost" },
+    });
 
-    assert.equal(response.status, 200)
-    assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'https://tauri.localhost')
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "https://tauri.localhost");
   } finally {
-    if (previous === undefined) delete process.env['NODE_ENV']
-    else process.env['NODE_ENV'] = previous
+    if (previous === undefined) delete process.env["NODE_ENV"];
+    else process.env["NODE_ENV"] = previous;
   }
-})
+});
 
-test('panel API allows vite dev origin only outside production', async () => {
-  const previous = process.env['NODE_ENV']
-  delete process.env['NODE_ENV']
+test("panel API allows vite dev origin only outside production", async () => {
+  const previous = process.env["NODE_ENV"];
+  delete process.env["NODE_ENV"];
   try {
-    const config = buildDefaultConfig()
-    config.server.authToken = 'secret'
-    const app = testPanelApp(config)
+    const config = buildDefaultConfig();
+    config.server.authToken = "secret";
+    const app = testPanelApp(config);
 
-    const response = await app.request('/api/status', {
-      headers: { Origin: 'http://localhost:5173' },
-    })
+    const response = await app.request("/api/status", {
+      headers: { Origin: "http://localhost:5173" },
+    });
 
-    assert.equal(response.status, 200)
-    assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'http://localhost:5173')
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "http://localhost:5173");
   } finally {
-    if (previous === undefined) delete process.env['NODE_ENV']
-    else process.env['NODE_ENV'] = previous
+    if (previous === undefined) delete process.env["NODE_ENV"];
+    else process.env["NODE_ENV"] = previous;
   }
-})
+});
 
-test('panel API rejects vite dev origin in production', async () => {
-  const previous = process.env['NODE_ENV']
-  process.env['NODE_ENV'] = 'production'
+test("panel API rejects vite dev origin in production", async () => {
+  const previous = process.env["NODE_ENV"];
+  process.env["NODE_ENV"] = "production";
   try {
-    const config = buildDefaultConfig()
-    config.server.authToken = 'secret'
-    const app = testPanelApp(config)
+    const config = buildDefaultConfig();
+    config.server.authToken = "secret";
+    const app = testPanelApp(config);
 
-    const response = await app.request('/api/status', {
-      headers: { Origin: 'http://localhost:5173' },
-    })
+    const response = await app.request("/api/status", {
+      headers: { Origin: "http://localhost:5173" },
+    });
 
-    assert.equal(response.status, 403)
+    assert.equal(response.status, 403);
   } finally {
-    if (previous === undefined) delete process.env['NODE_ENV']
-    else process.env['NODE_ENV'] = previous
+    if (previous === undefined) delete process.env["NODE_ENV"];
+    else process.env["NODE_ENV"] = previous;
   }
-})
+});
 
-test('panel API accepts gateway token as explicit local bypass', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = testPanelApp(config)
+test("panel API accepts gateway token as explicit local bypass", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = testPanelApp(config);
 
-  const response = await app.request('/api/status', {
+  const response = await app.request("/api/status", {
     headers: {
-      Origin: 'https://example.invalid',
-      Authorization: 'Bearer secret',
+      Origin: "https://example.invalid",
+      Authorization: "Bearer secret",
     },
-  })
+  });
 
-  assert.equal(response.status, 200)
-})
+  assert.equal(response.status, 200);
+});
 
-test('panel API keeps local curl-style reads working without Origin', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = testPanelApp(config)
+test("panel API keeps local curl-style reads working without Origin", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = testPanelApp(config);
 
-  const response = await app.request('/api/status')
+  const response = await app.request("/api/status");
 
-  assert.equal(response.status, 200)
-  const body = await response.json() as { proxyPort?: number }
-  assert.equal(body.proxyPort, config.server.proxyPort)
-})
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { proxyPort?: number };
+  assert.equal(body.proxyPort, config.server.proxyPort);
+});
 
-test('panel API requires token for sensitive local requests without Origin', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = testPanelApp(config)
+test("panel API requires token for sensitive local requests without Origin", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = testPanelApp(config);
 
-  const response = await app.request('/api/launch-commands')
+  const response = await app.request("/api/launch-commands");
 
-  assert.equal(response.status, 401)
-  assert.deepEqual(await response.json(), { error: 'Authentication required' })
-})
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { error: "Authentication required" });
+});
 
-test('panel API exposes token-free quick launch commands without Origin', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  config.providers.openrouter.enabled = true
-  const app = testPanelApp(config)
+test("panel API exposes token-free quick launch commands without Origin", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  config.providers.openrouter.enabled = true;
+  const app = testPanelApp(config);
 
-  const response = await app.request('/api/quick-launch')
+  const response = await app.request("/api/quick-launch");
 
-  assert.equal(response.status, 200)
-  const body = await response.json() as {
-    all?: string
-    manual?: string
-    perProvider?: Array<{ id: string; cli: string }>
-  }
-  assert.equal(body.all, 'ccpg --all')
-  assert.equal(body.manual, undefined)
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as {
+    all?: string;
+    manual?: string;
+    perProvider?: Array<{ id: string; cli: string }>;
+  };
+  assert.equal(body.all, "ccpg --all");
+  assert.equal(body.manual, undefined);
   assert.deepEqual(body.perProvider, [
-    { id: 'openrouter', label: 'OpenRouter', cli: 'ccpg --OpenRouter' },
-  ])
-})
+    { id: "openrouter", label: "OpenRouter", cli: "ccpg --OpenRouter" },
+  ]);
+});
 
-test('panel API allows sensitive local requests with gateway token', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = testPanelApp(config)
+test("panel API allows sensitive local requests with gateway token", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = testPanelApp(config);
 
-  const response = await app.request('/api/launch-commands', {
-    headers: { Authorization: 'Bearer secret' },
-  })
+  const response = await app.request("/api/launch-commands", {
+    headers: { Authorization: "Bearer secret" },
+  });
 
-  assert.equal(response.status, 200)
-  const body = await response.json() as { manual?: string }
-  assert.ok(body.manual?.includes('ANTHROPIC_AUTH_TOKEN=secret'))
-})
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { manual?: string };
+  assert.ok(body.manual?.includes("ANTHROPIC_AUTH_TOKEN=secret"));
+});
 
-test('panel API rejects sensitive local requests with wrong gateway token', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = testPanelApp(config)
+test("panel API rejects sensitive local requests with wrong gateway token", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = testPanelApp(config);
 
-  const response = await app.request('/api/control/shutdown', {
-    method: 'POST',
-    headers: { Authorization: 'Bearer wrong' },
-  })
+  const response = await app.request("/api/control/shutdown", {
+    method: "POST",
+    headers: { Authorization: "Bearer wrong" },
+  });
 
-  assert.equal(response.status, 401)
-})
+  assert.equal(response.status, 401);
+});
 
-test('panel API rejects unknown shell names before installing snippets', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = testPanelApp(config)
+test("panel API rejects unknown shell names before installing snippets", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = testPanelApp(config);
 
-  const response = await app.request('/api/shell-setup/install', {
-    method: 'POST',
+  const response = await app.request("/api/shell-setup/install", {
+    method: "POST",
     headers: {
-      Authorization: 'Bearer secret',
-      'Content-Type': 'application/json',
+      Authorization: "Bearer secret",
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify({ shells: ['zsh', '../bad'] }),
-  })
+    body: JSON.stringify({ shells: ["zsh", "../bad"] }),
+  });
 
-  assert.equal(response.status, 400)
-  assert.deepEqual(await response.json(), { error: 'Unknown shell: ../bad' })
-})
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: "Unknown shell: ../bad" });
+});
 
-test('PUT /api/config persists proxy settings and returns them on GET', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = testPanelApp(config)
+test("PUT /api/config persists proxy settings and returns them on GET", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = testPanelApp(config);
 
-  const putResponse = await app.request('/api/config', {
-    method: 'PUT',
+  const putResponse = await app.request("/api/config", {
+    method: "PUT",
     headers: {
-      Authorization: 'Bearer secret',
-      'Content-Type': 'application/json',
+      Authorization: "Bearer secret",
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify({ proxy: { enabled: true, url: 'http://127.0.0.1:7890' } }),
-  })
-  assert.equal(putResponse.status, 200)
+    body: JSON.stringify({ proxy: { enabled: true, url: "http://127.0.0.1:7890" } }),
+  });
+  assert.equal(putResponse.status, 200);
 
-  const getResponse = await app.request('/api/config', {
-    headers: { Authorization: 'Bearer secret' },
-  })
-  const body = await getResponse.json() as { proxy?: { enabled: boolean; url: string } }
-  assert.equal(body.proxy?.enabled, true)
-  assert.equal(body.proxy?.url, 'http://127.0.0.1:7890')
-})
+  const getResponse = await app.request("/api/config", {
+    headers: { Authorization: "Bearer secret" },
+  });
+  const body = (await getResponse.json()) as { proxy?: { enabled: boolean; url: string } };
+  assert.equal(body.proxy?.enabled, true);
+  assert.equal(body.proxy?.url, "http://127.0.0.1:7890");
+});
 
-test('PUT /api/config persists token saver settings and returns them on GET', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = testPanelApp(config)
+test("PUT /api/config persists token saver settings and returns them on GET", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = testPanelApp(config);
 
-  const putResponse = await app.request('/api/config', {
-    method: 'PUT',
+  const putResponse = await app.request("/api/config", {
+    method: "PUT",
     headers: {
-      Authorization: 'Bearer secret',
-      'Content-Type': 'application/json',
+      Authorization: "Bearer secret",
+      "Content-Type": "application/json",
     },
     body: JSON.stringify({
       tokenSavers: {
         rtkEnabled: true,
         cavemanEnabled: true,
-        cavemanLevel: 'full',
+        cavemanLevel: "full",
       },
     }),
-  })
-  assert.equal(putResponse.status, 200)
+  });
+  assert.equal(putResponse.status, 200);
 
-  const getResponse = await app.request('/api/config', {
-    headers: { Authorization: 'Bearer secret' },
-  })
-  const body = await getResponse.json() as {
+  const getResponse = await app.request("/api/config", {
+    headers: { Authorization: "Bearer secret" },
+  });
+  const body = (await getResponse.json()) as {
     tokenSavers?: {
-      rtkEnabled: boolean
-      cavemanEnabled: boolean
-      cavemanLevel: string
-    }
-  }
+      rtkEnabled: boolean;
+      cavemanEnabled: boolean;
+      cavemanLevel: string;
+    };
+  };
   assert.deepEqual(body.tokenSavers, {
     rtkEnabled: true,
     cavemanEnabled: true,
-    cavemanLevel: 'full',
-  })
-})
+    cavemanLevel: "full",
+  });
+});
 
-test('PUT /api/config rejects invalid proxy URL when enabled', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = testPanelApp(config)
+test("PUT /api/config rejects invalid proxy URL when enabled", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = testPanelApp(config);
 
-  const response = await app.request('/api/config', {
-    method: 'PUT',
+  const response = await app.request("/api/config", {
+    method: "PUT",
     headers: {
-      Authorization: 'Bearer secret',
-      'Content-Type': 'application/json',
+      Authorization: "Bearer secret",
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify({ proxy: { enabled: true, url: 'not-a-url' } }),
-  })
-  assert.equal(response.status, 400)
-  const body = await response.json() as { error: string }
-  assert.ok(body.error.includes('http://') || body.error.includes('https://'))
-})
+    body: JSON.stringify({ proxy: { enabled: true, url: "not-a-url" } }),
+  });
+  assert.equal(response.status, 400);
+  const body = (await response.json()) as { error: string };
+  assert.ok(body.error.includes("http://") || body.error.includes("https://"));
+});
 
-test('PUT /api/config rejects proxy URL with embedded credentials even when disabled', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = testPanelApp(config)
+test("PUT /api/config rejects proxy URL with embedded credentials even when disabled", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = testPanelApp(config);
 
   for (const enabled of [true, false]) {
-    const response = await app.request('/api/config', {
-      method: 'PUT',
+    const response = await app.request("/api/config", {
+      method: "PUT",
       headers: {
-        Authorization: 'Bearer secret',
-        'Content-Type': 'application/json',
+        Authorization: "Bearer secret",
+        "Content-Type": "application/json",
       },
-      body: JSON.stringify({ proxy: { enabled, url: 'http://user:pass@proxy.example.com:8080' } }),
-    })
-    assert.equal(response.status, 400, `expected rejection when enabled=${enabled}`)
-    const body = await response.json() as { error: string }
-    assert.ok(body.error.toLowerCase().includes('credential'))
+      body: JSON.stringify({ proxy: { enabled, url: "http://user:pass@proxy.example.com:8080" } }),
+    });
+    assert.equal(response.status, 400, `expected rejection when enabled=${enabled}`);
+    const body = (await response.json()) as { error: string };
+    assert.ok(body.error.toLowerCase().includes("credential"));
   }
-})
+});
 
-test('PUT /api/config rejects enabling proxy when existing URL is empty', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = testPanelApp(config)
+test("PUT /api/config rejects enabling proxy when existing URL is empty", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = testPanelApp(config);
 
-  const response = await app.request('/api/config', {
-    method: 'PUT',
+  const response = await app.request("/api/config", {
+    method: "PUT",
     headers: {
-      Authorization: 'Bearer secret',
-      'Content-Type': 'application/json',
+      Authorization: "Bearer secret",
+      "Content-Type": "application/json",
     },
     body: JSON.stringify({ proxy: { enabled: true } }),
-  })
-  assert.equal(response.status, 400)
-})
+  });
+  assert.equal(response.status, 400);
+});
 
-test('PUT /api/config disabling proxy clears the enabled flag', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  config.proxy = { enabled: true, url: 'http://127.0.0.1:7890' }
-  const app = testPanelApp(config)
+test("PUT /api/config disabling proxy clears the enabled flag", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  config.proxy = { enabled: true, url: "http://127.0.0.1:7890" };
+  const app = testPanelApp(config);
 
-  const putResponse = await app.request('/api/config', {
-    method: 'PUT',
+  const putResponse = await app.request("/api/config", {
+    method: "PUT",
     headers: {
-      Authorization: 'Bearer secret',
-      'Content-Type': 'application/json',
+      Authorization: "Bearer secret",
+      "Content-Type": "application/json",
     },
     body: JSON.stringify({ proxy: { enabled: false } }),
-  })
-  assert.equal(putResponse.status, 200)
+  });
+  assert.equal(putResponse.status, 200);
 
-  const getResponse = await app.request('/api/config', {
-    headers: { Authorization: 'Bearer secret' },
-  })
-  const body = await getResponse.json() as { proxy?: { enabled: boolean; url: string } }
-  assert.equal(body.proxy?.enabled, false)
-  assert.equal(body.proxy?.url, 'http://127.0.0.1:7890')
-})
+  const getResponse = await app.request("/api/config", {
+    headers: { Authorization: "Bearer secret" },
+  });
+  const body = (await getResponse.json()) as { proxy?: { enabled: boolean; url: string } };
+  assert.equal(body.proxy?.enabled, false);
+  assert.equal(body.proxy?.url, "http://127.0.0.1:7890");
+});

--- a/packages/daemon/src/panel/app.ts
+++ b/packages/daemon/src/panel/app.ts
@@ -1,32 +1,32 @@
-import { Hono } from 'hono'
-import type { Config } from '../config/schema.js'
-import { requirePanelAccess } from './middleware/auth.js'
-import { registerConfigRoutes } from './routes/config-routes.js'
-import { registerOAuthRoutes } from './routes/oauth-routes.js'
-import { registerProviderRoutes } from './routes/provider-routes.js'
-import { registerSessionRoutes } from './routes/session-routes.js'
-import { registerShellRoutes } from './routes/shell-routes.js'
-import { registerStaticRoutes } from './routes/static-routes.js'
-import { registerStatusRoutes } from './routes/status-routes.js'
-import { PanelRuntime } from './runtime.js'
+import { Hono } from "hono";
+import type { Config } from "../config/schema.js";
+import { requirePanelAccess } from "./middleware/auth.js";
+import { registerConfigRoutes } from "./routes/config-routes.js";
+import { registerOAuthRoutes } from "./routes/oauth-routes.js";
+import { registerProviderRoutes } from "./routes/provider-routes.js";
+import { registerSessionRoutes } from "./routes/session-routes.js";
+import { registerShellRoutes } from "./routes/shell-routes.js";
+import { registerStaticRoutes } from "./routes/static-routes.js";
+import { registerStatusRoutes } from "./routes/status-routes.js";
+import { PanelRuntime } from "./runtime.js";
 
 export type PanelAppOptions = {
-  saveConfig?: (config: Config) => void
-}
+  saveConfig?: (config: Config) => void;
+};
 
 export function createPanelApp(initialConfig: Config, options: PanelAppOptions = {}) {
-  const app = new Hono()
-  const runtime = new PanelRuntime(initialConfig, options.saveConfig)
+  const app = new Hono();
+  const runtime = new PanelRuntime(initialConfig, options.saveConfig);
 
-  app.use('/api/*', requirePanelAccess(runtime))
+  app.use("/api/*", requirePanelAccess(runtime));
 
-  registerStatusRoutes(app, runtime)
-  registerSessionRoutes(app)
-  registerShellRoutes(app, runtime)
-  registerConfigRoutes(app, runtime)
-  registerProviderRoutes(app, runtime)
-  registerOAuthRoutes(app, runtime)
-  registerStaticRoutes(app)
+  registerStatusRoutes(app, runtime);
+  registerSessionRoutes(app);
+  registerShellRoutes(app, runtime);
+  registerConfigRoutes(app, runtime);
+  registerProviderRoutes(app, runtime);
+  registerOAuthRoutes(app, runtime);
+  registerStaticRoutes(app);
 
-  return app
+  return app;
 }

--- a/packages/daemon/src/panel/contracts.ts
+++ b/packages/daemon/src/panel/contracts.ts
@@ -1,148 +1,143 @@
-import type { Config } from '../config/schema.js'
-import type { ModelInfo } from '../core/anthropic/types.js'
+import type { Config } from "../config/schema.js";
+import type { ModelInfo } from "../core/anthropic/types.js";
 import type {
+  SessionModelStat,
   SessionRecord,
   SessionRequestLogEntry,
-  SessionModelStat,
   TokenSaverStats,
-} from '../runtime/sessions.js'
+} from "../runtime/sessions.js";
 
 export type GatewayStatusResponse = {
-  running: boolean
-  pid: number | null
-  activeProvider: Config['activeProvider']
-  uptimeMs: number
-  proxyPort: number
-  panelPort: number
-  modelMode: Config['modelMode']
-}
+  running: boolean;
+  pid: number | null;
+  activeProvider: Config["activeProvider"];
+  uptimeMs: number;
+  proxyPort: number;
+  panelPort: number;
+  modelMode: Config["modelMode"];
+};
 
 export type ProviderStat = {
-  requests: number
-  errors: number
-  avgLatencyMs: number
-  totalLatencyMs: number
-  lastActivityAt: number | null
-  lastError: string | null
-}
+  requests: number;
+  errors: number;
+  avgLatencyMs: number;
+  totalLatencyMs: number;
+  lastActivityAt: number | null;
+  lastError: string | null;
+};
 
 export type GatewayProviderStat = ProviderStat & {
-  id: string
-  label: string
-  baseUrl?: string
-  hasKey?: boolean
-}
+  id: string;
+  label: string;
+  baseUrl?: string;
+  hasKey?: boolean;
+};
 
 export type StatsResponse = {
-  uptimeMs: number
-  activeProvider: Config['activeProvider']
-  modelMode: Config['modelMode']
-  providers: GatewayProviderStat[]
-}
+  uptimeMs: number;
+  activeProvider: Config["activeProvider"];
+  modelMode: Config["modelMode"];
+  providers: GatewayProviderStat[];
+};
 
 export type LaunchCommandsResponse = {
-  manual: string
-  all: string
-  perProvider: Array<{ id: string; label: string; cli: string }>
-}
+  manual: string;
+  all: string;
+  perProvider: Array<{ id: string; label: string; cli: string }>;
+};
 
-export type QuickLaunchResponse = Pick<LaunchCommandsResponse, 'all' | 'perProvider'>
+export type QuickLaunchResponse = Pick<LaunchCommandsResponse, "all" | "perProvider">;
 
-export type ShellName = 'zsh' | 'bash' | 'fish' | 'powershell'
+export type ShellName = "zsh" | "bash" | "fish" | "powershell";
 
 export type ShellInfo = {
-  name: ShellName
-  rcPath: string
-  rcExists: boolean
-  installed: boolean
-}
+  name: ShellName;
+  rcPath: string;
+  rcExists: boolean;
+  installed: boolean;
+};
 
 export type ShellSetupResponse = {
-  shells: ShellInfo[]
-  currentShell: ShellName | null
-  snippets: Record<'posix' | 'fish' | 'powershell', string>
-  usage: string
-}
+  shells: ShellInfo[];
+  currentShell: ShellName | null;
+  snippets: Record<"posix" | "fish" | "powershell", string>;
+  usage: string;
+};
 
-export type InstallStatus = 'installed' | 'updated' | 'already-installed' | 'error'
+export type InstallStatus = "installed" | "updated" | "already-installed" | "error";
 
 export type InstallResult = {
-  shell: ShellName
-  status: InstallStatus
-  rcPath: string
-  error?: string
-}
+  shell: ShellName;
+  status: InstallStatus;
+  rcPath: string;
+  error?: string;
+};
 
 export type InstallShellSetupResponse = {
-  results: InstallResult[]
-  setup: ShellSetupResponse
-}
+  results: InstallResult[];
+  setup: ShellSetupResponse;
+};
 
 export type OAuthInfo = {
-  loggedIn: boolean
-  accountId?: string
-  planType?: string | null
-  expiresAt?: number | null
-}
+  loggedIn: boolean;
+  accountId?: string;
+  planType?: string | null;
+  expiresAt?: number | null;
+};
 
 export type ProviderInfo = {
-  id: string
-  label: string
-  enabled: boolean
-  hasKey: boolean
-  keyPreview: string | null
-  baseUrl?: string
-  models?: string[]
-  disabledModels?: string[]
-  authType?: 'api_key' | 'oauth'
-  oauth?: OAuthInfo
-}
+  id: string;
+  label: string;
+  enabled: boolean;
+  hasKey: boolean;
+  keyPreview: string | null;
+  baseUrl?: string;
+  models?: string[];
+  disabledModels?: string[];
+  authType?: "api_key" | "oauth";
+  oauth?: OAuthInfo;
+};
 
-export type { ModelInfo }
+export type { ModelInfo };
 
 export type ProviderTestResult = {
-  ok: boolean
-  latencyMs: number
-  modelCount?: number
-  error?: string
-}
+  ok: boolean;
+  latencyMs: number;
+  modelCount?: number;
+  error?: string;
+};
 
 export type OpenAIAccountOAuthStartResponse = {
-  state: string
-  url: string
-}
+  state: string;
+  url: string;
+};
 
 export type OAuthStatusResponse = {
-  status: 'success' | 'error' | 'pending' | 'unknown'
-  error?: string
-}
+  status: "success" | "error" | "pending" | "unknown";
+  error?: string;
+};
 
 export type CopilotOAuthStartResponse = {
-  flowId: string
-  userCode: string
-  verificationUri: string
-  expiresAt: number
-  interval: number
-}
+  flowId: string;
+  userCode: string;
+  verificationUri: string;
+  expiresAt: number;
+  interval: number;
+};
 
 export type RoutingOption = {
-  id: string
-  label: string
-  models: Array<{ id: string; display_name: string }>
-}
+  id: string;
+  label: string;
+  models: Array<{ id: string; display_name: string }>;
+};
 
-export type PanelConfigResponse = Config
-export type SettingsConfigResponse = Pick<Config, 'server' | 'webTools' | 'proxy' | 'tokenSavers'>
-export type RoutingConfigResponse = Pick<Config, 'routing' | 'thinking'>
+export type PanelConfigResponse = Config;
+export type SettingsConfigResponse = Pick<Config, "server" | "webTools" | "proxy" | "tokenSavers">;
+export type RoutingConfigResponse = Pick<Config, "routing" | "thinking">;
 
 export type SessionsResponse = {
-  current: SessionRecord | null
-  archive: SessionRecord[]
-}
+  current: SessionRecord | null;
+  archive: SessionRecord[];
+};
 
-export type {
-  SessionRecord,
-  SessionRequestLogEntry,
-  SessionModelStat,
-  TokenSaverStats,
-}
+export type { SessionModelStat, SessionRecord, SessionRequestLogEntry, TokenSaverStats };

--- a/packages/daemon/src/panel/launch-prepare.test.ts
+++ b/packages/daemon/src/panel/launch-prepare.test.ts
@@ -1,9 +1,9 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { shellQuote } from './launch-prepare.js'
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shellQuote } from "./launch-prepare.js";
 
-test('shellQuote preserves single argument boundaries for POSIX shells', () => {
-  assert.equal(shellQuote('plain'), "'plain'")
-  assert.equal(shellQuote("a'b"), "'a'\\''b'")
-  assert.equal(shellQuote('$(touch /tmp/owned); echo hi'), "'$(touch /tmp/owned); echo hi'")
-})
+test("shellQuote preserves single argument boundaries for POSIX shells", () => {
+  assert.equal(shellQuote("plain"), "'plain'");
+  assert.equal(shellQuote("a'b"), "'a'\\''b'");
+  assert.equal(shellQuote("$(touch /tmp/owned); echo hi"), "'$(touch /tmp/owned); echo hi'");
+});

--- a/packages/daemon/src/panel/launch-prepare.ts
+++ b/packages/daemon/src/panel/launch-prepare.ts
@@ -2,62 +2,62 @@
 // switch the active provider in config, wipe Claude's gateway-model cache,
 // and return shell-evaluable `export KEY=value` lines.
 
-import { existsSync, unlinkSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
-import type { Config, ProviderId } from '../config/schema.js'
-import { CLI_FLAGS, PROVIDER_IDS } from '../config/schema.js'
-import { saveConfig } from '../config/index.js'
-import { endSession, startSession } from '../runtime/sessions.js'
+import { existsSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { saveConfig } from "../config/index.js";
+import type { Config, ProviderId } from "../config/schema.js";
+import { CLI_FLAGS, PROVIDER_IDS } from "../config/schema.js";
+import { endSession, startSession } from "../runtime/sessions.js";
 
 export interface LaunchPrepareRequest {
-  flag: string
+  flag: string;
 }
 
 export interface LaunchEnvVars {
-  authToken: string
-  baseUrl: string
-  sessionId: string
+  authToken: string;
+  baseUrl: string;
+  sessionId: string;
 }
 
 export interface LaunchPrepareResult {
-  ok: true
-  providerId: ProviderId | null
-  sessionId: string
-  shellScript: string
-  envVars: LaunchEnvVars
+  ok: true;
+  providerId: ProviderId | null;
+  sessionId: string;
+  shellScript: string;
+  envVars: LaunchEnvVars;
 }
 
 export interface LaunchPrepareFailure {
-  ok: false
-  error: string
+  ok: false;
+  error: string;
 }
 
 export function resolveProviderFlag(flag: string): ProviderId | null {
-  if (!flag.startsWith('--')) return null
-  const target = flag.slice(2).toLowerCase()
+  if (!flag.startsWith("--")) return null;
+  const target = flag.slice(2).toLowerCase();
   for (const [definedFlag, providerId] of Object.entries(CLI_FLAGS)) {
-    if (definedFlag.slice(2).toLowerCase() === target) return providerId
+    if (definedFlag.slice(2).toLowerCase() === target) return providerId;
   }
-  if ((PROVIDER_IDS as readonly string[]).includes(target)) return target as ProviderId
-  return null
+  if ((PROVIDER_IDS as readonly string[]).includes(target)) return target as ProviderId;
+  return null;
 }
 
 export function prepareLaunch(
   config: Config,
   flag: string,
 ): LaunchPrepareResult | LaunchPrepareFailure {
-  if (flag === '--all' || flag === '--a') {
-    config.modelMode = 'all'
+  if (flag === "--all" || flag === "--a") {
+    config.modelMode = "all";
     if (!config.providers[config.activeProvider]?.enabled) {
-      const fallbackProvider = PROVIDER_IDS.find(id => config.providers[id]?.enabled)
-      if (fallbackProvider) config.activeProvider = fallbackProvider
+      const fallbackProvider = PROVIDER_IDS.find((id) => config.providers[id]?.enabled);
+      if (fallbackProvider) config.activeProvider = fallbackProvider;
     }
-    saveConfig(config)
-    clearClaudeGatewayCache()
+    saveConfig(config);
+    clearClaudeGatewayCache();
 
-    endSession()
-    const session = startSession(config)
+    endSession();
+    const session = startSession(config);
 
     return {
       ok: true,
@@ -65,31 +65,31 @@ export function prepareLaunch(
       sessionId: session.id,
       shellScript: buildShellExports(config, session.id),
       envVars: buildEnvVars(config, session.id),
-    }
+    };
   }
 
-  const providerId = resolveProviderFlag(flag)
+  const providerId = resolveProviderFlag(flag);
   if (!providerId) {
-    return { ok: false, error: `Unknown provider flag: ${flag}` }
+    return { ok: false, error: `Unknown provider flag: ${flag}` };
   }
 
-  const provider = config.providers[providerId]
+  const provider = config.providers[providerId];
   if (!provider) {
-    return { ok: false, error: `Provider ${providerId} not configured` }
+    return { ok: false, error: `Provider ${providerId} not configured` };
   }
   if (!provider.enabled) {
-    return { ok: false, error: `Provider ${providerId} is disabled — enable it in the app first` }
+    return { ok: false, error: `Provider ${providerId} is disabled — enable it in the app first` };
   }
 
-  config.activeProvider = providerId
-  config.modelMode = 'single'
-  saveConfig(config)
-  clearClaudeGatewayCache()
+  config.activeProvider = providerId;
+  config.modelMode = "single";
+  saveConfig(config);
+  clearClaudeGatewayCache();
 
   // End any session that was running (e.g. user switching providers), then
   // start a new one now that the user has issued a terminal launch command.
-  endSession()
-  const session = startSession(config)
+  endSession();
+  const session = startSession(config);
 
   return {
     ok: true,
@@ -97,7 +97,7 @@ export function prepareLaunch(
     sessionId: session.id,
     shellScript: buildShellExports(config, session.id),
     envVars: buildEnvVars(config, session.id),
-  }
+  };
 }
 
 function buildEnvVars(config: Config, sessionId: string): LaunchEnvVars {
@@ -105,7 +105,7 @@ function buildEnvVars(config: Config, sessionId: string): LaunchEnvVars {
     authToken: config.server.authToken,
     baseUrl: `http://127.0.0.1:${config.server.proxyPort}`,
     sessionId,
-  }
+  };
 }
 
 function buildShellExports(config: Config, sessionId: string): string {
@@ -114,17 +114,17 @@ function buildShellExports(config: Config, sessionId: string): string {
     `export ANTHROPIC_BASE_URL=${shellQuote(`http://127.0.0.1:${config.server.proxyPort}`)}`,
     `export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`,
     `export CC_GATEWAY_SESSION_ID=${shellQuote(sessionId)}`,
-  ].join('\n')
+  ].join("\n");
 }
 
 export function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 function clearClaudeGatewayCache(): void {
-  const cachePath = join(homedir(), '.claude', 'cache', 'gateway-models.json')
+  const cachePath = join(homedir(), ".claude", "cache", "gateway-models.json");
   try {
-    if (existsSync(cachePath)) unlinkSync(cachePath)
+    if (existsSync(cachePath)) unlinkSync(cachePath);
   } catch {
     // Best-effort: stale cache will be regenerated by Claude on next launch.
   }

--- a/packages/daemon/src/panel/middleware/auth.ts
+++ b/packages/daemon/src/panel/middleware/auth.ts
@@ -1,68 +1,69 @@
-import type { Context, Next } from 'hono'
-import type { PanelRuntime } from '../runtime.js'
+import type { Context, Next } from "hono";
+import type { PanelRuntime } from "../runtime.js";
 
-const PANEL_AUTH_HEADERS = 'Content-Type, Authorization, x-api-key'
-const PANEL_AUTH_METHODS = 'GET, POST, PUT, DELETE, OPTIONS'
+const PANEL_AUTH_HEADERS = "Content-Type, Authorization, x-api-key";
+const PANEL_AUTH_METHODS = "GET, POST, PUT, DELETE, OPTIONS";
 const TAURI_PANEL_ORIGINS = new Set([
-  'tauri://localhost',
-  'https://tauri.localhost',
-  'http://tauri.localhost',
-])
-const DEV_PANEL_ORIGINS = new Set([
-  'http://localhost:5173',
-  'http://127.0.0.1:5173',
-])
+  "tauri://localhost",
+  "https://tauri.localhost",
+  "http://tauri.localhost",
+]);
+const DEV_PANEL_ORIGINS = new Set(["http://localhost:5173", "http://127.0.0.1:5173"]);
 
 export function requirePanelAccess(runtime: PanelRuntime) {
   return async (c: Context, next: Next) => {
-    const config = runtime.currentConfig()
-    const origin = c.req.header('Origin') ?? ''
-    const token = readBearerToken(c.req.header('Authorization') ?? c.req.header('x-api-key') ?? '')
-    const hasValidToken = !!config.server.authToken && token === config.server.authToken
-    const isAllowedOrigin = isAllowedPanelOrigin(origin)
-    const isCrossSiteBrowserRequest = c.req.header('Sec-Fetch-Site') === 'cross-site'
+    const config = runtime.currentConfig();
+    const origin = c.req.header("Origin") ?? "";
+    const token = readBearerToken(c.req.header("Authorization") ?? c.req.header("x-api-key") ?? "");
+    const hasValidToken = !!config.server.authToken && token === config.server.authToken;
+    const isAllowedOrigin = isAllowedPanelOrigin(origin);
+    const isCrossSiteBrowserRequest = c.req.header("Sec-Fetch-Site") === "cross-site";
 
     if (origin && !isAllowedOrigin && !hasValidToken) {
-      return c.json({ error: 'Forbidden origin' }, 403)
+      return c.json({ error: "Forbidden origin" }, 403);
     }
     if (!origin && isCrossSiteBrowserRequest && !hasValidToken) {
-      return c.json({ error: 'Forbidden origin' }, 403)
+      return c.json({ error: "Forbidden origin" }, 403);
     }
     if (!origin && requiresLocalToken(c.req.path, c.req.method) && !hasValidToken) {
-      return c.json({ error: 'Authentication required' }, 401)
+      return c.json({ error: "Authentication required" }, 401);
     }
 
     if (origin && isAllowedOrigin) {
-      c.header('Access-Control-Allow-Origin', origin)
-      c.header('Access-Control-Allow-Headers', PANEL_AUTH_HEADERS)
-      c.header('Access-Control-Allow-Methods', PANEL_AUTH_METHODS)
-      c.header('Vary', 'Origin')
+      c.header("Access-Control-Allow-Origin", origin);
+      c.header("Access-Control-Allow-Headers", PANEL_AUTH_HEADERS);
+      c.header("Access-Control-Allow-Methods", PANEL_AUTH_METHODS);
+      c.header("Vary", "Origin");
     }
 
-    if (c.req.method === 'OPTIONS') {
-      return c.body(null, 204)
+    if (c.req.method === "OPTIONS") {
+      return c.body(null, 204);
     }
 
-    await next()
-  }
+    await next();
+  };
 }
 
 function isAllowedPanelOrigin(origin: string): boolean {
-  if (!origin) return false
-  if (TAURI_PANEL_ORIGINS.has(origin)) return true
-  if (process.env['NODE_ENV'] !== 'production' && DEV_PANEL_ORIGINS.has(origin)) return true
-  return false
+  if (!origin) return false;
+  if (TAURI_PANEL_ORIGINS.has(origin)) return true;
+  if (process.env["NODE_ENV"] !== "production" && DEV_PANEL_ORIGINS.has(origin)) return true;
+  return false;
 }
 
 function readBearerToken(auth: string): string {
-  return auth.replace(/^Bearer\s+/i, '')
+  return auth.replace(/^Bearer\s+/i, "");
 }
 
 function requiresLocalToken(path: string, method: string): boolean {
-  if (method === 'PUT' && path === '/api/config') return true
-  if (method === 'DELETE' && path === '/api/sessions') return true
-  if (method === 'POST' && path === '/api/control/shutdown') return true
-  if (method === 'POST' && path === '/api/shell-setup/install') return true
-  if (method === 'GET' && (path === '/api/launch-commands' || path === '/api/launch-command')) return true
-  return method === 'POST' && /^\/api\/providers\/(?:openai_account|copilot)\/oauth\/(?:start|logout)$/.test(path)
+  if (method === "PUT" && path === "/api/config") return true;
+  if (method === "DELETE" && path === "/api/sessions") return true;
+  if (method === "POST" && path === "/api/control/shutdown") return true;
+  if (method === "POST" && path === "/api/shell-setup/install") return true;
+  if (method === "GET" && (path === "/api/launch-commands" || path === "/api/launch-command"))
+    return true;
+  return (
+    method === "POST" &&
+    /^\/api\/providers\/(?:openai_account|copilot)\/oauth\/(?:start|logout)$/.test(path)
+  );
 }

--- a/packages/daemon/src/panel/routes/config-routes.ts
+++ b/packages/daemon/src/panel/routes/config-routes.ts
@@ -1,76 +1,79 @@
-import type { Hono } from 'hono'
-import type { Config, ProviderConfig, ProviderId } from '../../config/schema.js'
-import { normalizeConfig } from '../../config/validation.js'
-import type { PanelRuntime } from '../runtime.js'
+import type { Hono } from "hono";
+import type { Config, ProviderConfig, ProviderId } from "../../config/schema.js";
+import { normalizeConfig } from "../../config/validation.js";
+import type { PanelRuntime } from "../runtime.js";
 
 export function registerConfigRoutes(app: Hono, runtime: PanelRuntime): void {
-  app.get('/api/config', c => c.json(maskConfig(runtime.currentConfig())))
+  app.get("/api/config", (c) => c.json(maskConfig(runtime.currentConfig())));
 
-  app.put('/api/config', async c => {
-    const config = runtime.currentConfig()
-    const update = await c.req.json<Partial<Config>>()
-    const merged: Config = structuredClone(config)
+  app.put("/api/config", async (c) => {
+    const config = runtime.currentConfig();
+    const update = await c.req.json<Partial<Config>>();
+    const merged: Config = structuredClone(config);
 
     if (update.server) {
-      const { authToken, ...serverUpdate } = update.server
-      Object.assign(merged.server, serverUpdate)
-      if (typeof authToken === 'string' && authToken.trim() && !authToken.includes('••••')) {
-        merged.server.authToken = authToken
+      const { authToken, ...serverUpdate } = update.server;
+      Object.assign(merged.server, serverUpdate);
+      if (typeof authToken === "string" && authToken.trim() && !authToken.includes("••••")) {
+        merged.server.authToken = authToken;
       }
     }
     if (update.providers) {
-      for (const [id, pc] of Object.entries(update.providers) as [ProviderId, Partial<ProviderConfig>][]) {
-        if (!merged.providers[id]) continue
-        Object.assign(merged.providers[id], pc)
-        if (pc?.apiKey?.includes('••••')) {
-          merged.providers[id].apiKey = config.providers[id].apiKey
+      for (const [id, pc] of Object.entries(update.providers) as [
+        ProviderId,
+        Partial<ProviderConfig>,
+      ][]) {
+        if (!merged.providers[id]) continue;
+        Object.assign(merged.providers[id], pc);
+        if (pc?.apiKey?.includes("••••")) {
+          merged.providers[id].apiKey = config.providers[id].apiKey;
         }
       }
     }
-    if (update.routing) Object.assign(merged.routing, update.routing)
-    if (update.thinking) Object.assign(merged.thinking, update.thinking)
-    if (update.webTools) Object.assign(merged.webTools, update.webTools)
-    if (update.tokenSavers) Object.assign(merged.tokenSavers, update.tokenSavers)
+    if (update.routing) Object.assign(merged.routing, update.routing);
+    if (update.thinking) Object.assign(merged.thinking, update.thinking);
+    if (update.webTools) Object.assign(merged.webTools, update.webTools);
+    if (update.tokenSavers) Object.assign(merged.tokenSavers, update.tokenSavers);
     if (update.proxy) {
       if (update.proxy.url !== undefined) {
-        const urlError = validateProxyUrl(update.proxy.url)
-        if (urlError) return c.json({ error: urlError }, 400)
+        const urlError = validateProxyUrl(update.proxy.url);
+        if (urlError) return c.json({ error: urlError }, 400);
       }
-      Object.assign(merged.proxy, update.proxy)
+      Object.assign(merged.proxy, update.proxy);
       if (merged.proxy.enabled && !merged.proxy.url) {
-        return c.json({ error: 'Proxy URL is required when proxy is enabled' }, 400)
+        return c.json({ error: "Proxy URL is required when proxy is enabled" }, 400);
       }
     }
-    if (update.activeProvider) merged.activeProvider = update.activeProvider
-    if (update.modelMode) merged.modelMode = update.modelMode
+    if (update.activeProvider) merged.activeProvider = update.activeProvider;
+    if (update.modelMode) merged.modelMode = update.modelMode;
 
-    runtime.saveAndUpdateConfig(normalizeConfig(merged, config))
-    return c.json({ ok: true })
-  })
+    runtime.saveAndUpdateConfig(normalizeConfig(merged, config));
+    return c.json({ ok: true });
+  });
 }
 
 function validateProxyUrl(url: string): string | null {
-  if (!url) return null
-  if (!url.startsWith('http://') && !url.startsWith('https://')) {
-    return 'Proxy URL must start with http:// or https://'
+  if (!url) return null;
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    return "Proxy URL must start with http:// or https://";
   }
   try {
-    const parsed = new URL(url)
+    const parsed = new URL(url);
     if (parsed.username || parsed.password) {
-      return 'Proxy URL must not contain credentials — use a proxy that does not require authentication'
+      return "Proxy URL must not contain credentials — use a proxy that does not require authentication";
     }
   } catch {
-    return 'Proxy URL is not a valid URL'
+    return "Proxy URL is not a valid URL";
   }
-  return null
+  return null;
 }
 
 function maskConfig(config: Config): Config {
-  const masked: Config = structuredClone(config)
-  masked.server.authToken = ''
+  const masked: Config = structuredClone(config);
+  masked.server.authToken = "";
   for (const id of Object.keys(masked.providers) as ProviderId[]) {
-    const key = masked.providers[id].apiKey ?? ''
-    if (key) masked.providers[id].apiKey = `${key.slice(0, 6)}••••••••`
+    const key = masked.providers[id].apiKey ?? "";
+    if (key) masked.providers[id].apiKey = `${key.slice(0, 6)}••••••••`;
   }
-  return masked
+  return masked;
 }

--- a/packages/daemon/src/panel/routes/oauth-pages.ts
+++ b/packages/daemon/src/panel/routes/oauth-pages.ts
@@ -77,7 +77,7 @@ const BASE_STYLES = `
   }
   .dot.success { background: #7fb069; box-shadow: 0 0 6px #7fb069; }
   .dot.error   { background: #ef4444; box-shadow: 0 0 6px #ef4444; }
-`
+`;
 
 function shell(body: string): string {
   return `<!doctype html>
@@ -89,11 +89,11 @@ function shell(body: string): string {
   <style>${BASE_STYLES}</style>
 </head>
 <body>${body}</body>
-</html>`
+</html>`;
 }
 
 export function oauthSuccessPage(provider: string): string {
-  const providerLabel = escapeHtml(provider)
+  const providerLabel = escapeHtml(provider);
   return shell(`
   <div class="card">
     <div class="wordmark">Claude Code <span>Gateway</span></div>
@@ -111,12 +111,12 @@ export function oauthSuccessPage(provider: string): string {
     <div class="hint">This window can be safely closed.</div>
   </div>
   <script>setTimeout(() => window.close(), 4000)</script>
-`)
+`);
 }
 
 export function oauthErrorPage(provider: string, message?: string): string {
-  const providerLabel = escapeHtml(provider)
-  const detail = message ?? 'An unexpected error occurred during authentication.'
+  const providerLabel = escapeHtml(provider);
+  const detail = message ?? "An unexpected error occurred during authentication.";
   return shell(`
   <div class="card">
     <div class="wordmark">Claude Code <span>Gateway</span></div>
@@ -133,7 +133,7 @@ export function oauthErrorPage(provider: string, message?: string): string {
     <p>${escapeHtml(detail)}</p>
     <div class="hint">Return to the gateway and try again.</div>
   </div>
-`)
+`);
 }
 
 export function oauthBadRequestPage(): string {
@@ -149,9 +149,13 @@ export function oauthBadRequestPage(): string {
     <p>Invalid OAuth state or missing authorization code.</p>
     <div class="hint">Return to the gateway and try again.</div>
   </div>
-`)
+`);
 }
 
 function escapeHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }

--- a/packages/daemon/src/panel/routes/oauth-routes.ts
+++ b/packages/daemon/src/panel/routes/oauth-routes.ts
@@ -1,105 +1,109 @@
-import type { Context, Hono } from 'hono'
-import type { ServerResponse } from 'node:http'
-import { oauthBadRequestPage, oauthErrorPage, oauthSuccessPage } from './oauth-pages.js'
+import type { ServerResponse } from "node:http";
+import type { Context, Hono } from "hono";
+import {
+  exchangeForCopilotToken,
+  fetchGithubLogin,
+  pollDeviceFlow,
+  startDeviceFlow,
+} from "../../proxy/providers/copilot-auth.js";
 import {
   createAuthorizationUrl,
   createPkcePair,
   createState,
   exchangeAuthorizationCode,
   OPENAI_ACCOUNT_REDIRECT_URI,
-} from '../../proxy/providers/openai-account-auth.js'
-import {
-  exchangeForCopilotToken,
-  fetchGithubLogin,
-  pollDeviceFlow,
-  startDeviceFlow,
-} from '../../proxy/providers/copilot-auth.js'
-import type { PanelRuntime, OAuthFlow } from '../runtime.js'
+} from "../../proxy/providers/openai-account-auth.js";
+import type { OAuthFlow, PanelRuntime } from "../runtime.js";
+import { oauthBadRequestPage, oauthErrorPage, oauthSuccessPage } from "./oauth-pages.js";
 
 export function registerOAuthRoutes(app: Hono, runtime: PanelRuntime): void {
-  app.post('/api/providers/openai_account/oauth/start', async c => startOpenAIAccountFlow(c, runtime))
+  app.post("/api/providers/openai_account/oauth/start", async (c) =>
+    startOpenAIAccountFlow(c, runtime),
+  );
 
-  app.get('/api/providers/openai_account/oauth/status/:state', c => {
-    const flow = runtime.oauthFlows.get(c.req.param('state'))
-    if (!flow) return c.json({ status: 'unknown' })
-    return c.json({ status: flow.status, error: flow.error })
-  })
+  app.get("/api/providers/openai_account/oauth/status/:state", (c) => {
+    const flow = runtime.oauthFlows.get(c.req.param("state"));
+    if (!flow) return c.json({ status: "unknown" });
+    return c.json({ status: flow.status, error: flow.error });
+  });
 
-  app.post('/api/providers/openai_account/oauth/logout', c => {
-    const config = runtime.currentConfig()
-    config.providers.openai_account.oauth = {}
-    config.providers.openai_account.enabled = false
-    runtime.saveAndUpdateConfig(config)
-    return c.json({ ok: true })
-  })
+  app.post("/api/providers/openai_account/oauth/logout", (c) => {
+    const config = runtime.currentConfig();
+    config.providers.openai_account.oauth = {};
+    config.providers.openai_account.enabled = false;
+    runtime.saveAndUpdateConfig(config);
+    return c.json({ ok: true });
+  });
 
-  app.post('/api/providers/copilot/oauth/start', async c => startCopilotFlow(c, runtime))
+  app.post("/api/providers/copilot/oauth/start", async (c) => startCopilotFlow(c, runtime));
 
-  app.get('/api/providers/copilot/oauth/status/:flowId', c => {
-    const flow = runtime.copilotFlows.get(c.req.param('flowId'))
-    if (!flow) return c.json({ status: 'unknown' })
+  app.get("/api/providers/copilot/oauth/status/:flowId", (c) => {
+    const flow = runtime.copilotFlows.get(c.req.param("flowId"));
+    if (!flow) return c.json({ status: "unknown" });
     return c.json({
       status: flow.status,
       error: flow.error,
       userCode: flow.userCode,
       verificationUri: flow.verificationUri,
       expiresAt: flow.expiresAt,
-    })
-  })
+    });
+  });
 
-  app.post('/api/providers/copilot/oauth/logout', c => {
-    const config = runtime.currentConfig()
-    config.providers.copilot.oauth = {}
-    config.providers.copilot.enabled = false
-    runtime.saveAndUpdateConfig(config)
-    return c.json({ ok: true })
-  })
+  app.post("/api/providers/copilot/oauth/logout", (c) => {
+    const config = runtime.currentConfig();
+    config.providers.copilot.oauth = {};
+    config.providers.copilot.enabled = false;
+    runtime.saveAndUpdateConfig(config);
+    return c.json({ ok: true });
+  });
 }
 
 async function startOpenAIAccountFlow(c: Context, runtime: PanelRuntime) {
-  cleanupOAuthFlows(runtime)
+  cleanupOAuthFlows(runtime);
 
-  const existing = Array.from(runtime.oauthFlows.entries()).find(([, flow]) => flow.status === 'pending')
-  if (existing) return c.json({ error: 'An OpenAI login flow is already pending' }, 409)
+  const existing = Array.from(runtime.oauthFlows.entries()).find(
+    ([, flow]) => flow.status === "pending",
+  );
+  if (existing) return c.json({ error: "An OpenAI login flow is already pending" }, 409);
 
-  const state = createState()
-  const pkce = createPkcePair()
-  const flow: OAuthFlow = { verifier: pkce.verifier, status: 'pending' }
-  runtime.oauthFlows.set(state, flow)
+  const state = createState();
+  const pkce = createPkcePair();
+  const flow: OAuthFlow = { verifier: pkce.verifier, status: "pending" };
+  runtime.oauthFlows.set(state, flow);
 
   try {
     const server = runtime.createCallbackServer(async (req, res) => {
-      const requestUrl = new URL(req.url ?? '/', OPENAI_ACCOUNT_REDIRECT_URI)
-      if (requestUrl.pathname !== '/auth/callback') {
-        res.writeHead(404).end('Not found')
-        return
+      const requestUrl = new URL(req.url ?? "/", OPENAI_ACCOUNT_REDIRECT_URI);
+      if (requestUrl.pathname !== "/auth/callback") {
+        res.writeHead(404).end("Not found");
+        return;
       }
 
-      const returnedState = requestUrl.searchParams.get('state') ?? ''
-      const code = requestUrl.searchParams.get('code') ?? ''
-      const activeFlow = runtime.oauthFlows.get(returnedState)
+      const returnedState = requestUrl.searchParams.get("state") ?? "";
+      const code = requestUrl.searchParams.get("code") ?? "";
+      const activeFlow = runtime.oauthFlows.get(returnedState);
       if (!activeFlow || returnedState !== state || !code) {
-        res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' })
-        res.end(oauthBadRequestPage())
-        return
+        res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+        res.end(oauthBadRequestPage());
+        return;
       }
 
-      await completeOpenAIAccountFlow(runtime, activeFlow, code, res)
-    })
+      await completeOpenAIAccountFlow(runtime, activeFlow, code, res);
+    });
 
     await new Promise<void>((resolve, reject) => {
-      server.once('error', reject)
-      server.listen(1455, '127.0.0.1', () => resolve())
-    })
+      server.once("error", reject);
+      server.listen(1455, "127.0.0.1", () => resolve());
+    });
 
-    flow.server = server
-    flow.timer = setTimeout(() => timeoutOpenAIFlow(runtime, state), 5 * 60 * 1000)
+    flow.server = server;
+    flow.timer = setTimeout(() => timeoutOpenAIFlow(runtime, state), 5 * 60 * 1000);
   } catch (err) {
-    runtime.oauthFlows.delete(state)
-    return c.json({ error: err instanceof Error ? err.message : String(err) }, 500)
+    runtime.oauthFlows.delete(state);
+    return c.json({ error: err instanceof Error ? err.message : String(err) }, 500);
   }
 
-  return c.json({ state, url: createAuthorizationUrl(pkce, state) })
+  return c.json({ state, url: createAuthorizationUrl(pkce, state) });
 }
 
 async function completeOpenAIAccountFlow(
@@ -109,47 +113,47 @@ async function completeOpenAIAccountFlow(
   res: ServerResponse,
 ): Promise<void> {
   try {
-    const tokens = await exchangeAuthorizationCode(code, activeFlow.verifier)
-    const config = runtime.currentConfig()
+    const tokens = await exchangeAuthorizationCode(code, activeFlow.verifier);
+    const config = runtime.currentConfig();
     config.providers.openai_account.oauth = {
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
       expiresAt: tokens.expiresAt,
       accountId: tokens.accountId,
       planType: tokens.planType,
-    }
-    config.providers.openai_account.authType = 'oauth'
-    config.providers.openai_account.enabled = true
-    runtime.saveAndUpdateConfig(config)
-    activeFlow.status = 'success'
-    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
-    res.end(oauthSuccessPage('OpenAI'))
+    };
+    config.providers.openai_account.authType = "oauth";
+    config.providers.openai_account.enabled = true;
+    runtime.saveAndUpdateConfig(config);
+    activeFlow.status = "success";
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(oauthSuccessPage("OpenAI"));
   } catch (err) {
-    activeFlow.status = 'error'
-    activeFlow.error = err instanceof Error ? err.message : String(err)
-    res.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' })
-    res.end(oauthErrorPage('OpenAI', activeFlow.error))
+    activeFlow.status = "error";
+    activeFlow.error = err instanceof Error ? err.message : String(err);
+    res.writeHead(500, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(oauthErrorPage("OpenAI", activeFlow.error));
   } finally {
-    activeFlow.server?.close()
+    activeFlow.server?.close();
   }
 }
 
 async function startCopilotFlow(c: Context, runtime: PanelRuntime) {
-  cleanupCopilotFlows(runtime)
+  cleanupCopilotFlows(runtime);
 
   try {
-    const device = await startDeviceFlow()
-    const flowId = createState()
+    const device = await startDeviceFlow();
+    const flowId = createState();
     const flow = {
       deviceCode: device.device_code,
       userCode: device.user_code,
       verificationUri: device.verification_uri,
       interval: Math.max(device.interval, 1),
       expiresAt: Date.now() + device.expires_in * 1000,
-      status: 'pending' as const,
-    }
-    runtime.copilotFlows.set(flowId, flow)
-    scheduleCopilotPoll(runtime, flowId, flow.interval * 1000)
+      status: "pending" as const,
+    };
+    runtime.copilotFlows.set(flowId, flow);
+    scheduleCopilotPoll(runtime, flowId, flow.interval * 1000);
 
     return c.json({
       flowId,
@@ -157,90 +161,95 @@ async function startCopilotFlow(c: Context, runtime: PanelRuntime) {
       verificationUri: flow.verificationUri,
       expiresAt: flow.expiresAt,
       interval: flow.interval,
-    })
+    });
   } catch (err) {
-    return c.json({ error: err instanceof Error ? err.message : String(err) }, 500)
+    return c.json({ error: err instanceof Error ? err.message : String(err) }, 500);
   }
 }
 
 function scheduleCopilotPoll(runtime: PanelRuntime, flowId: string, intervalMs: number): void {
-  const flow = runtime.copilotFlows.get(flowId)
-  if (!flow) return
-  flow.poller = setTimeout(() => pollCopilotFlow(runtime, flowId, intervalMs), intervalMs)
+  const flow = runtime.copilotFlows.get(flowId);
+  if (!flow) return;
+  flow.poller = setTimeout(() => pollCopilotFlow(runtime, flowId, intervalMs), intervalMs);
 }
 
-async function pollCopilotFlow(runtime: PanelRuntime, flowId: string, intervalMs: number): Promise<void> {
-  const flow = runtime.copilotFlows.get(flowId)
-  if (!flow || flow.status !== 'pending') return
+async function pollCopilotFlow(
+  runtime: PanelRuntime,
+  flowId: string,
+  intervalMs: number,
+): Promise<void> {
+  const flow = runtime.copilotFlows.get(flowId);
+  if (!flow || flow.status !== "pending") return;
   if (Date.now() > flow.expiresAt) {
-    flow.status = 'error'
-    flow.error = 'Device code expired — please try logging in again'
-    return
+    flow.status = "error";
+    flow.error = "Device code expired — please try logging in again";
+    return;
   }
 
   try {
-    const result = await pollDeviceFlow(flow.deviceCode)
-    if (result.status === 'pending') return scheduleCopilotPoll(runtime, flowId, intervalMs)
-    if (result.status === 'slow_down') return scheduleCopilotPoll(runtime, flowId, result.interval * 1000)
-    if (result.status === 'expired') {
-      flow.status = 'error'
-      flow.error = 'Device code expired — please try logging in again'
-      return
+    const result = await pollDeviceFlow(flow.deviceCode);
+    if (result.status === "pending") return scheduleCopilotPoll(runtime, flowId, intervalMs);
+    if (result.status === "slow_down")
+      return scheduleCopilotPoll(runtime, flowId, result.interval * 1000);
+    if (result.status === "expired") {
+      flow.status = "error";
+      flow.error = "Device code expired — please try logging in again";
+      return;
     }
-    if (result.status === 'denied') {
-      flow.status = 'error'
-      flow.error = 'GitHub login was denied'
-      return
+    if (result.status === "denied") {
+      flow.status = "error";
+      flow.error = "GitHub login was denied";
+      return;
     }
-    if (result.status === 'error') {
-      flow.status = 'error'
-      flow.error = result.error
-      return
+    if (result.status === "error") {
+      flow.status = "error";
+      flow.error = result.error;
+      return;
     }
 
-    const githubToken = result.token.accessToken
-    const copilot = await exchangeForCopilotToken(githubToken)
-    const login = await fetchGithubLogin(githubToken).catch(() => undefined)
-    const config = runtime.currentConfig()
+    const githubToken = result.token.accessToken;
+    const copilot = await exchangeForCopilotToken(githubToken);
+    const login = await fetchGithubLogin(githubToken).catch(() => undefined);
+    const config = runtime.currentConfig();
     config.providers.copilot.oauth = {
       accessToken: githubToken,
       accountId: login,
       copilotToken: copilot.token,
       copilotExpiresAt: copilot.expiresAt,
       copilotEndpoint: copilot.endpoint,
-    }
-    config.providers.copilot.authType = 'oauth'
-    config.providers.copilot.enabled = true
-    runtime.saveAndUpdateConfig(config)
-    flow.status = 'success'
+    };
+    config.providers.copilot.authType = "oauth";
+    config.providers.copilot.enabled = true;
+    runtime.saveAndUpdateConfig(config);
+    flow.status = "success";
   } catch (err) {
-    flow.status = 'error'
-    flow.error = err instanceof Error ? err.message : String(err)
+    flow.status = "error";
+    flow.error = err instanceof Error ? err.message : String(err);
   }
 }
 
 function cleanupOAuthFlows(runtime: PanelRuntime): void {
   for (const [state, flow] of runtime.oauthFlows) {
-    if (flow.status === 'pending') continue
-    if (flow.timer) clearTimeout(flow.timer)
-    flow.server?.close()
-    runtime.oauthFlows.delete(state)
+    if (flow.status === "pending") continue;
+    if (flow.timer) clearTimeout(flow.timer);
+    flow.server?.close();
+    runtime.oauthFlows.delete(state);
   }
 }
 
 function cleanupCopilotFlows(runtime: PanelRuntime): void {
   for (const [id, flow] of runtime.copilotFlows) {
-    if (flow.status === 'pending') continue
-    if (flow.poller) clearTimeout(flow.poller)
-    runtime.copilotFlows.delete(id)
+    if (flow.status === "pending") continue;
+    if (flow.poller) clearTimeout(flow.poller);
+    runtime.copilotFlows.delete(id);
   }
 }
 
 function timeoutOpenAIFlow(runtime: PanelRuntime, state: string): void {
-  const current = runtime.oauthFlows.get(state)
-  if (current?.status === 'pending') {
-    current.status = 'error'
-    current.error = 'OpenAI login timed out'
+  const current = runtime.oauthFlows.get(state);
+  if (current?.status === "pending") {
+    current.status = "error";
+    current.error = "OpenAI login timed out";
   }
-  current?.server?.close()
+  current?.server?.close();
 }

--- a/packages/daemon/src/panel/routes/provider-routes.ts
+++ b/packages/daemon/src/panel/routes/provider-routes.ts
@@ -1,21 +1,16 @@
-import type { Hono } from 'hono'
-import { PROVIDER_LABELS } from '../../config/schema.js'
-import type { ProviderConfig, ProviderId } from '../../config/schema.js'
-import type {
-  ProviderInfo,
-  RoutingOption,
-} from '../contracts.js'
-import type { PanelRuntime } from '../runtime.js'
+import type { Hono } from "hono";
+import type { ProviderConfig, ProviderId } from "../../config/schema.js";
+import { PROVIDER_LABELS } from "../../config/schema.js";
+import type { ProviderInfo, RoutingOption } from "../contracts.js";
+import type { PanelRuntime } from "../runtime.js";
 
 export function registerProviderRoutes(app: Hono, runtime: PanelRuntime): void {
-  app.get('/api/providers', c => {
-    const config = runtime.currentConfig()
+  app.get("/api/providers", (c) => {
+    const config = runtime.currentConfig();
     const result = Object.entries(config.providers).map(([id, pc]) => {
-      const key = pc.apiKey ?? ''
-      const keyPreview = key
-        ? `${key.slice(0, Math.min(12, Math.max(4, key.length - 4)))}…`
-        : null
-      const oauth = pc.oauth
+      const key = pc.apiKey ?? "";
+      const keyPreview = key ? `${key.slice(0, Math.min(12, Math.max(4, key.length - 4)))}…` : null;
+      const oauth = pc.oauth;
       return {
         id,
         label: PROVIDER_LABELS[id as ProviderId] ?? id,
@@ -26,67 +21,72 @@ export function registerProviderRoutes(app: Hono, runtime: PanelRuntime): void {
         models: pc.models ?? [],
         disabledModels: pc.disabledModels ?? [],
         authType: pc.authType,
-        oauth: oauth?.accountId ? {
-          loggedIn: true,
-          accountId: oauth.accountId,
-          planType: oauth.planType ?? null,
-          expiresAt: oauth.expiresAt ?? null,
-        } : { loggedIn: false },
-      }
-    }) satisfies ProviderInfo[]
-    return c.json(result)
-  })
+        oauth: oauth?.accountId
+          ? {
+              loggedIn: true,
+              accountId: oauth.accountId,
+              planType: oauth.planType ?? null,
+              expiresAt: oauth.expiresAt ?? null,
+            }
+          : { loggedIn: false },
+      };
+    }) satisfies ProviderInfo[];
+    return c.json(result);
+  });
 
-  app.post('/api/providers/:id/test', async c => {
-    const id = c.req.param('id') as ProviderId
-    const provider = runtime.registry.get(id)
-    if (!provider) return c.json({ ok: false, error: 'Provider not enabled' }, 400)
-    return c.json(await provider.testConnection())
-  })
+  app.post("/api/providers/:id/test", async (c) => {
+    const id = c.req.param("id") as ProviderId;
+    const provider = runtime.registry.get(id);
+    if (!provider) return c.json({ ok: false, error: "Provider not enabled" }, 400);
+    return c.json(await provider.testConnection());
+  });
 
-  app.get('/api/models/:providerId', async c => {
-    const id = c.req.param('providerId') as ProviderId
-    const provider = runtime.registry.get(id)
-    if (!provider) return c.json([], 200)
-    return c.json(await provider.listModels().catch(() => []))
-  })
+  app.get("/api/models/:providerId", async (c) => {
+    const id = c.req.param("providerId") as ProviderId;
+    const provider = runtime.registry.get(id);
+    if (!provider) return c.json([], 200);
+    return c.json(await provider.listModels().catch(() => []));
+  });
 
-  app.get('/api/routing/options', async c => {
-    const config = runtime.currentConfig()
+  app.get("/api/routing/options", async (c) => {
+    const config = runtime.currentConfig();
     const enabledProviders = (Object.entries(config.providers) as [ProviderId, ProviderConfig][])
       .filter(([, pc]) => pc.enabled)
-      .map(([id]) => id)
+      .map(([id]) => id);
 
-    const options = await Promise.all(
-      enabledProviders.map(async id => ({
+    const options = (await Promise.all(
+      enabledProviders.map(async (id) => ({
         id,
         label: PROVIDER_LABELS[id] ?? id,
         models: await listSelectableModels(runtime, id),
       })),
-    ) satisfies RoutingOption[]
+    )) satisfies RoutingOption[];
 
-    return c.json(options)
-  })
+    return c.json(options);
+  });
 }
 
-async function listSelectableModels(runtime: PanelRuntime, id: ProviderId): Promise<Array<{ id: string; display_name: string }>> {
-  const config = runtime.currentConfig()
-  const provider = runtime.registry.get(id)
-  let models: Array<{ id: string; display_name: string }> = []
+async function listSelectableModels(
+  runtime: PanelRuntime,
+  id: ProviderId,
+): Promise<Array<{ id: string; display_name: string }>> {
+  const config = runtime.currentConfig();
+  const provider = runtime.registry.get(id);
+  let models: Array<{ id: string; display_name: string }> = [];
   if (provider) {
     try {
-      const list = await provider.listEnabledModels()
-      models = list.map(model => ({ id: model.id, display_name: model.display_name }))
+      const list = await provider.listEnabledModels();
+      models = list.map((model) => ({ id: model.id, display_name: model.display_name }));
     } catch {
-      models = []
+      models = [];
     }
   }
 
-  const seen = new Set(models.map(model => model.id))
+  const seen = new Set(models.map((model) => model.id));
   for (const extra of config.providers[id].models ?? []) {
-    if (seen.has(extra)) continue
-    models.push({ id: extra, display_name: extra })
-    seen.add(extra)
+    if (seen.has(extra)) continue;
+    models.push({ id: extra, display_name: extra });
+    seen.add(extra);
   }
-  return models
+  return models;
 }

--- a/packages/daemon/src/panel/routes/session-routes.ts
+++ b/packages/daemon/src/panel/routes/session-routes.ts
@@ -1,4 +1,4 @@
-import type { Hono } from 'hono'
+import type { Hono } from "hono";
 import {
   attachSessionProcess,
   clearArchivedSessions,
@@ -6,42 +6,46 @@ import {
   getCurrentSession,
   heartbeatSession,
   listArchivedSessions,
-} from '../../runtime/sessions.js'
-import type { SessionsResponse } from '../contracts.js'
+} from "../../runtime/sessions.js";
+import type { SessionsResponse } from "../contracts.js";
 
 export function registerSessionRoutes(app: Hono): void {
-  app.get('/api/sessions', c => {
+  app.get("/api/sessions", (c) => {
     const response = {
       current: getCurrentSession(),
       archive: listArchivedSessions(),
-    } satisfies SessionsResponse
-    return c.json(response)
-  })
+    } satisfies SessionsResponse;
+    return c.json(response);
+  });
 
-  app.delete('/api/sessions', c => {
-    clearArchivedSessions()
+  app.delete("/api/sessions", (c) => {
+    clearArchivedSessions();
     const response = {
       ok: true,
       current: getCurrentSession(),
       archive: listArchivedSessions(),
-    } satisfies SessionsResponse & { ok: true }
-    return c.json(response)
-  })
+    } satisfies SessionsResponse & { ok: true };
+    return c.json(response);
+  });
 
-  app.post('/api/launch/end', async c => {
-    const body = await c.req.json<{ sessionId?: string }>().catch(() => ({} as { sessionId?: string }))
-    return c.json({ ok: endSession(body.sessionId) })
-  })
+  app.post("/api/launch/end", async (c) => {
+    const body = await c.req
+      .json<{ sessionId?: string }>()
+      .catch(() => ({}) as { sessionId?: string });
+    return c.json({ ok: endSession(body.sessionId) });
+  });
 
-  app.post('/api/launch/heartbeat', async c => {
-    const body = await c.req.json<{ sessionId?: string }>().catch(() => ({} as { sessionId?: string }))
-    return c.json({ ok: heartbeatSession(body.sessionId) })
-  })
+  app.post("/api/launch/heartbeat", async (c) => {
+    const body = await c.req
+      .json<{ sessionId?: string }>()
+      .catch(() => ({}) as { sessionId?: string });
+    return c.json({ ok: heartbeatSession(body.sessionId) });
+  });
 
-  app.post('/api/launch/attach', async c => {
-    const body = await c.req.json<{ sessionId?: string; pid?: number }>().catch(
-      () => ({} as { sessionId?: string; pid?: number }),
-    )
-    return c.json({ ok: attachSessionProcess(body.sessionId, body.pid) })
-  })
+  app.post("/api/launch/attach", async (c) => {
+    const body = await c.req
+      .json<{ sessionId?: string; pid?: number }>()
+      .catch(() => ({}) as { sessionId?: string; pid?: number });
+    return c.json({ ok: attachSessionProcess(body.sessionId, body.pid) });
+  });
 }

--- a/packages/daemon/src/panel/routes/shell-routes.ts
+++ b/packages/daemon/src/panel/routes/shell-routes.ts
@@ -1,129 +1,125 @@
-import type { Hono } from 'hono'
-import { CLI_FLAGS, PROVIDER_LABELS } from '../../config/schema.js'
-import type { ProviderId } from '../../config/schema.js'
+import type { Hono } from "hono";
+import type { ProviderId } from "../../config/schema.js";
+import { CLI_FLAGS, PROVIDER_LABELS } from "../../config/schema.js";
+import type {
+  InstallShellSetupResponse,
+  LaunchCommandsResponse,
+  QuickLaunchResponse,
+} from "../contracts.js";
+import { prepareLaunch } from "../launch-prepare.js";
+import type { PanelRuntime } from "../runtime.js";
 import {
   getShellSetup,
   getSnippetForShell,
   installSnippet,
   type ShellName,
-} from '../shell-setup.js'
-import { prepareLaunch } from '../launch-prepare.js'
-import type {
-  InstallShellSetupResponse,
-  LaunchCommandsResponse,
-  QuickLaunchResponse,
-} from '../contracts.js'
-import type { PanelRuntime } from '../runtime.js'
+} from "../shell-setup.js";
 
 export function registerShellRoutes(app: Hono, runtime: PanelRuntime): void {
-  app.get('/api/launch-commands', c => {
-    const config = runtime.currentConfig()
-    const env = `ANTHROPIC_AUTH_TOKEN=${config.server.authToken} ANTHROPIC_BASE_URL=http://localhost:${config.server.proxyPort} CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 claude`
+  app.get("/api/launch-commands", (c) => {
+    const config = runtime.currentConfig();
+    const env = `ANTHROPIC_AUTH_TOKEN=${config.server.authToken} ANTHROPIC_BASE_URL=http://localhost:${config.server.proxyPort} CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 claude`;
     const response = {
       manual: env,
-      all: 'ccpg --all',
+      all: "ccpg --all",
       perProvider: buildQuickLaunchProviders(config),
-    } satisfies LaunchCommandsResponse
-    return c.json(response)
-  })
+    } satisfies LaunchCommandsResponse;
+    return c.json(response);
+  });
 
-  app.get('/api/quick-launch', c => {
+  app.get("/api/quick-launch", (c) => {
     const response = {
-      all: 'ccpg --all',
+      all: "ccpg --all",
       perProvider: buildQuickLaunchProviders(runtime.currentConfig()),
-    } satisfies QuickLaunchResponse
-    return c.json(response)
-  })
+    } satisfies QuickLaunchResponse;
+    return c.json(response);
+  });
 
-  app.get('/api/shell-setup', c => c.json(getShellSetup(runtime.currentConfig())))
+  app.get("/api/shell-setup", (c) => c.json(getShellSetup(runtime.currentConfig())));
 
-  app.get('/api/shell-setup/snippet/:shell', c => {
-    const config = runtime.currentConfig()
-    const shell = c.req.param('shell') as ShellName
+  app.get("/api/shell-setup/snippet/:shell", (c) => {
+    const config = runtime.currentConfig();
+    const shell = c.req.param("shell") as ShellName;
     if (!isShellName(shell)) {
-      return c.json({ error: `Unknown shell: ${shell}` }, 400)
+      return c.json({ error: `Unknown shell: ${shell}` }, 400);
     }
-    return c.text(
-      '\n' + getSnippetForShell(config, shell) + '\n',
-      200,
-      { 'Content-Type': 'text/x-shellscript; charset=utf-8' },
-    )
-  })
+    return c.text("\n" + getSnippetForShell(config, shell) + "\n", 200, {
+      "Content-Type": "text/x-shellscript; charset=utf-8",
+    });
+  });
 
-  app.post('/api/shell-setup/install', async c => {
-    const config = runtime.currentConfig()
-    const body = await c.req.json<{ shells?: unknown }>().catch(
-      () => ({} as { shells?: unknown }),
-    )
-    const requested = parseRequestedShells(body.shells)
-    if (!requested.ok) return c.json({ error: requested.error }, 400)
-    if (!requested.length) return c.json({ error: 'shells: [] required' }, 400)
-    const results = requested.shells.map(shell => installSnippet(config, shell))
-    const response = { results, setup: getShellSetup(config) } satisfies InstallShellSetupResponse
-    return c.json(response)
-  })
+  app.post("/api/shell-setup/install", async (c) => {
+    const config = runtime.currentConfig();
+    const body = await c.req.json<{ shells?: unknown }>().catch(() => ({}) as { shells?: unknown });
+    const requested = parseRequestedShells(body.shells);
+    if (!requested.ok) return c.json({ error: requested.error }, 400);
+    if (!requested.length) return c.json({ error: "shells: [] required" }, 400);
+    const results = requested.shells.map((shell) => installSnippet(config, shell));
+    const response = { results, setup: getShellSetup(config) } satisfies InstallShellSetupResponse;
+    return c.json(response);
+  });
 
-  app.post('/api/launch/prepare', async c => {
-    const config = runtime.currentConfig()
-    const body = await c.req.json<{ flag?: string; format?: 'shell' | 'json' }>().catch(
-      () => ({} as { flag?: string; format?: 'shell' | 'json' }),
-    )
-    const flag = body.flag ?? ''
-    const format = body.format ?? 'shell'
-    const result = prepareLaunch(config, flag)
+  app.post("/api/launch/prepare", async (c) => {
+    const config = runtime.currentConfig();
+    const body = await c.req
+      .json<{ flag?: string; format?: "shell" | "json" }>()
+      .catch(() => ({}) as { flag?: string; format?: "shell" | "json" });
+    const flag = body.flag ?? "";
+    const format = body.format ?? "shell";
+    const result = prepareLaunch(config, flag);
 
-    if (format === 'json') {
-      if (result.ok) return c.json({ ok: true, ...result.envVars })
-      return c.json({ ok: false, error: result.error })
+    if (format === "json") {
+      if (result.ok) return c.json({ ok: true, ...result.envVars });
+      return c.json({ ok: false, error: result.error });
     }
 
-    const script = result.ok
-      ? result.shellScript
-      : `echo "ccpg: ${result.error}" >&2\nreturn 1`
-    return c.text(script, 200, { 'Content-Type': 'text/x-shellscript; charset=utf-8' })
-  })
+    const script = result.ok ? result.shellScript : `echo "ccpg: ${result.error}" >&2\nreturn 1`;
+    return c.text(script, 200, { "Content-Type": "text/x-shellscript; charset=utf-8" });
+  });
 
-  app.get('/api/launch-command', c => {
-    const config = runtime.currentConfig()
+  app.get("/api/launch-command", (c) => {
+    const config = runtime.currentConfig();
     const cmd = [
       `ANTHROPIC_AUTH_TOKEN=${config.server.authToken}`,
       `ANTHROPIC_BASE_URL=http://localhost:${config.server.proxyPort}`,
-      'CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1',
-      'claude',
-    ].join(' ')
-    return c.json({ command: cmd })
-  })
+      "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1",
+      "claude",
+    ].join(" ");
+    return c.json({ command: cmd });
+  });
 }
 
-function buildQuickLaunchProviders(config: ReturnType<PanelRuntime['currentConfig']>) {
-  return (Object.entries(config.providers) as [ProviderId, typeof config.providers[ProviderId]][])
+function buildQuickLaunchProviders(config: ReturnType<PanelRuntime["currentConfig"]>) {
+  return (Object.entries(config.providers) as [ProviderId, (typeof config.providers)[ProviderId]][])
     .filter(([, pc]) => pc.enabled)
     .map(([id]) => ({
       id,
       label: PROVIDER_LABELS[id] ?? id,
       cli: `ccpg ${flagFor(id) ?? `--${id}`}`,
-    }))
+    }));
 }
 
 function flagFor(id: ProviderId): string | null {
   for (const [flag, providerId] of Object.entries(CLI_FLAGS)) {
-    if (providerId === id) return flag
+    if (providerId === id) return flag;
   }
-  return null
+  return null;
 }
 
 function isShellName(value: string): value is ShellName {
-  return value === 'zsh' || value === 'bash' || value === 'fish' || value === 'powershell'
+  return value === "zsh" || value === "bash" || value === "fish" || value === "powershell";
 }
 
-function parseRequestedShells(value: unknown): { ok: true; shells: ShellName[]; length: number } | { ok: false; error: string } {
-  if (!Array.isArray(value)) return { ok: false, error: 'shells: [] required' }
-  const shells: ShellName[] = []
+function parseRequestedShells(
+  value: unknown,
+): { ok: true; shells: ShellName[]; length: number } | { ok: false; error: string } {
+  if (!Array.isArray(value)) return { ok: false, error: "shells: [] required" };
+  const shells: ShellName[] = [];
   for (const item of value) {
-    if (typeof item !== 'string' || !isShellName(item)) {
-      return { ok: false, error: `Unknown shell: ${String(item)}` }
+    if (typeof item !== "string" || !isShellName(item)) {
+      return { ok: false, error: `Unknown shell: ${String(item)}` };
     }
-    shells.push(item)
+    shells.push(item);
   }
-  return { ok: true, shells, length: shells.length }
+  return { ok: true, shells, length: shells.length };
 }

--- a/packages/daemon/src/panel/routes/static-routes.ts
+++ b/packages/daemon/src/panel/routes/static-routes.ts
@@ -1,24 +1,24 @@
-import { serveStatic } from '@hono/node-server/serve-static'
-import type { Hono } from 'hono'
-import { existsSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { serveStatic } from "@hono/node-server/serve-static";
+import type { Hono } from "hono";
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const STATIC_ROOT = resolveStaticRoot()
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const STATIC_ROOT = resolveStaticRoot();
 
 export function registerStaticRoutes(app: Hono): void {
-  app.get('/favicon.ico', c => c.body(null, 204))
-  if (!existsSync(STATIC_ROOT)) return
+  app.get("/favicon.ico", (c) => c.body(null, 204));
+  if (!existsSync(STATIC_ROOT)) return;
 
-  app.get('/', serveStatic({ root: STATIC_ROOT, path: 'index.html' }))
-  app.use('/*', serveStatic({ root: STATIC_ROOT }))
-  app.get('/*', serveStatic({ root: STATIC_ROOT, path: 'index.html' }))
+  app.get("/", serveStatic({ root: STATIC_ROOT, path: "index.html" }));
+  app.use("/*", serveStatic({ root: STATIC_ROOT }));
+  app.get("/*", serveStatic({ root: STATIC_ROOT, path: "index.html" }));
 }
 
 function resolveStaticRoot(): string {
-  if (__dirname.includes('src/panel/routes')) return join(__dirname, '../../../dist/static')
-  const bundled = join(__dirname, 'static')
-  if (existsSync(bundled)) return bundled
-  return join(dirname(process.execPath), 'static')
+  if (__dirname.includes("src/panel/routes")) return join(__dirname, "../../../dist/static");
+  const bundled = join(__dirname, "static");
+  if (existsSync(bundled)) return bundled;
+  return join(dirname(process.execPath), "static");
 }

--- a/packages/daemon/src/panel/routes/status-routes.ts
+++ b/packages/daemon/src/panel/routes/status-routes.ts
@@ -1,19 +1,16 @@
-import type { Hono } from 'hono'
-import { addLogListener, getLogBuffer } from '../../observability/log.js'
-import { getDaemonStatus } from '../../runtime/process.js'
-import { getStats, getUptimeMs } from '../../runtime/stats.js'
-import { PROVIDER_LABELS } from '../../config/schema.js'
-import type { ProviderId } from '../../config/schema.js'
-import type {
-  GatewayStatusResponse,
-  StatsResponse,
-} from '../contracts.js'
-import type { PanelRuntime } from '../runtime.js'
+import type { Hono } from "hono";
+import type { ProviderId } from "../../config/schema.js";
+import { PROVIDER_LABELS } from "../../config/schema.js";
+import { addLogListener, getLogBuffer } from "../../observability/log.js";
+import { getDaemonStatus } from "../../runtime/process.js";
+import { getStats, getUptimeMs } from "../../runtime/stats.js";
+import type { GatewayStatusResponse, StatsResponse } from "../contracts.js";
+import type { PanelRuntime } from "../runtime.js";
 
 export function registerStatusRoutes(app: Hono, runtime: PanelRuntime): void {
-  app.get('/api/status', c => {
-    const config = runtime.currentConfig()
-    const status = getDaemonStatus()
+  app.get("/api/status", (c) => {
+    const config = runtime.currentConfig();
+    const status = getDaemonStatus();
     const response = {
       running: status.running,
       pid: status.pid,
@@ -21,20 +18,22 @@ export function registerStatusRoutes(app: Hono, runtime: PanelRuntime): void {
       uptimeMs: getUptimeMs(),
       proxyPort: config.server.proxyPort,
       panelPort: config.server.panelPort,
-      modelMode: config.modelMode ?? 'single',
-    } satisfies GatewayStatusResponse
-    return c.json(response)
-  })
+      modelMode: config.modelMode ?? "single",
+    } satisfies GatewayStatusResponse;
+    return c.json(response);
+  });
 
-  app.post('/api/control/shutdown', c => {
-    setTimeout(() => process.kill(process.pid, 'SIGTERM'), 50)
-    return c.json({ ok: true, signal: 'SIGTERM' })
-  })
+  app.post("/api/control/shutdown", (c) => {
+    setTimeout(() => process.kill(process.pid, "SIGTERM"), 50);
+    return c.json({ ok: true, signal: "SIGTERM" });
+  });
 
-  app.get('/api/stats', c => {
-    const config = runtime.currentConfig()
-    const runtimeStats = getStats()
-    const providers = (Object.entries(config.providers) as [ProviderId, typeof config.providers[ProviderId]][])
+  app.get("/api/stats", (c) => {
+    const config = runtime.currentConfig();
+    const runtimeStats = getStats();
+    const providers = (
+      Object.entries(config.providers) as [ProviderId, (typeof config.providers)[ProviderId]][]
+    )
       .filter(([, pc]) => pc.enabled)
       .map(([id, pc]) => ({
         id,
@@ -42,49 +41,55 @@ export function registerStatusRoutes(app: Hono, runtime: PanelRuntime): void {
         baseUrl: pc.baseUrl,
         hasKey: !!pc.apiKey,
         ...(runtimeStats[id] ?? {
-          requests: 0, errors: 0, avgLatencyMs: 0, totalLatencyMs: 0,
-          lastActivityAt: null, lastError: null,
+          requests: 0,
+          errors: 0,
+          avgLatencyMs: 0,
+          totalLatencyMs: 0,
+          lastActivityAt: null,
+          lastError: null,
         }),
-      }))
+      }));
 
     const response = {
       uptimeMs: getUptimeMs(),
       activeProvider: config.activeProvider,
-      modelMode: config.modelMode ?? 'single',
+      modelMode: config.modelMode ?? "single",
       providers,
-    } satisfies StatsResponse
-    return c.json(response)
-  })
+    } satisfies StatsResponse;
+    return c.json(response);
+  });
 
-  app.get('/api/logs', c => {
-    const encoder = new TextEncoder()
+  app.get("/api/logs", (c) => {
+    const encoder = new TextEncoder();
     const stream = new ReadableStream({
       start(controller) {
         for (const line of getLogBuffer()) {
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ line })}\n\n`))
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ line })}\n\n`));
         }
 
-        const remove = addLogListener(line => {
+        const remove = addLogListener((line) => {
           try {
-            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ line })}\n\n`))
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ line })}\n\n`));
           } catch {
-            remove()
+            remove();
           }
-        })
+        });
 
-        c.req.raw.signal.addEventListener('abort', () => {
-          remove()
-          try { controller.close() } catch {}
-        })
+        c.req.raw.signal.addEventListener("abort", () => {
+          remove();
+          try {
+            controller.close();
+          } catch {}
+        });
       },
-    })
+    });
 
     return new Response(stream, {
       headers: {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        'Connection': 'keep-alive',
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
       },
-    })
-  })
+    });
+  });
 }

--- a/packages/daemon/src/panel/runtime.ts
+++ b/packages/daemon/src/panel/runtime.ts
@@ -1,56 +1,56 @@
-import { createServer, type RequestListener, type Server } from 'node:http'
-import { saveConfig } from '../config/index.js'
-import type { Config } from '../config/schema.js'
-import { ProviderRegistry } from '../proxy/providers/registry.js'
+import { createServer, type RequestListener, type Server } from "node:http";
+import { saveConfig } from "../config/index.js";
+import type { Config } from "../config/schema.js";
+import { ProviderRegistry } from "../proxy/providers/registry.js";
 
 export type OAuthFlow = {
-  verifier: string
-  status: 'pending' | 'success' | 'error'
-  error?: string
-  server?: Server
-  timer?: NodeJS.Timeout
-}
+  verifier: string;
+  status: "pending" | "success" | "error";
+  error?: string;
+  server?: Server;
+  timer?: NodeJS.Timeout;
+};
 
 export type CopilotFlow = {
-  deviceCode: string
-  userCode: string
-  verificationUri: string
-  interval: number
-  expiresAt: number
-  status: 'pending' | 'success' | 'error'
-  error?: string
-  poller?: NodeJS.Timeout
-}
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  interval: number;
+  expiresAt: number;
+  status: "pending" | "success" | "error";
+  error?: string;
+  poller?: NodeJS.Timeout;
+};
 
 export class PanelRuntime {
-  private config: Config
-  readonly registry: ProviderRegistry
-  readonly oauthFlows = new Map<string, OAuthFlow>()
-  readonly copilotFlows = new Map<string, CopilotFlow>()
+  private config: Config;
+  readonly registry: ProviderRegistry;
+  readonly oauthFlows = new Map<string, OAuthFlow>();
+  readonly copilotFlows = new Map<string, CopilotFlow>();
 
   constructor(
     initialConfig: Config,
     private readonly persistConfig: (config: Config) => void = saveConfig,
   ) {
-    this.config = initialConfig
-    this.registry = new ProviderRegistry(initialConfig)
+    this.config = initialConfig;
+    this.registry = new ProviderRegistry(initialConfig);
   }
 
   currentConfig(): Config {
-    return this.config
+    return this.config;
   }
 
   updateConfig(config: Config): void {
-    this.config = config
-    this.registry.updateConfig(config)
+    this.config = config;
+    this.registry.updateConfig(config);
   }
 
   saveAndUpdateConfig(config: Config): void {
-    this.persistConfig(config)
-    this.updateConfig(config)
+    this.persistConfig(config);
+    this.updateConfig(config);
   }
 
   createCallbackServer(handler: RequestListener): Server {
-    return createServer(handler)
+    return createServer(handler);
   }
 }

--- a/packages/daemon/src/panel/shell-setup.ts
+++ b/packages/daemon/src/panel/shell-setup.ts
@@ -2,67 +2,67 @@
 // pastes into their rc file, expose a "prepare launch" endpoint the snippet
 // calls at runtime.
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { homedir, platform } from 'node:os'
-import { dirname, join } from 'node:path'
-import { spawnSync } from 'node:child_process'
-import type { Config } from '../config/schema.js'
+import { spawnSync } from "node:child_process";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+import type { Config } from "../config/schema.js";
 
-const SNIPPET_SENTINEL = '# >>> claude-code-provider-gateway setup >>>'
-const SNIPPET_END = '# <<< claude-code-provider-gateway setup <<<'
-const SHELL_COMMAND = 'ccpg'
+const SNIPPET_SENTINEL = "# >>> claude-code-provider-gateway setup >>>";
+const SNIPPET_END = "# <<< claude-code-provider-gateway setup <<<";
+const SHELL_COMMAND = "ccpg";
 
-export type ShellName = 'zsh' | 'bash' | 'fish' | 'powershell'
+export type ShellName = "zsh" | "bash" | "fish" | "powershell";
 
 export interface ShellInfo {
-  name: ShellName
-  rcPath: string
-  rcExists: boolean
-  installed: boolean
+  name: ShellName;
+  rcPath: string;
+  rcExists: boolean;
+  installed: boolean;
 }
 
 export interface ShellSetupResponse {
-  shells: ShellInfo[]
-  currentShell: ShellName | null
-  snippets: Record<'posix' | 'fish' | 'powershell', string>
-  usage: string
+  shells: ShellInfo[];
+  currentShell: ShellName | null;
+  snippets: Record<"posix" | "fish" | "powershell", string>;
+  usage: string;
 }
 
 const SHELL_RC_PATHS: Record<ShellName, () => string> = {
-  zsh: () => join(homedir(), '.zshrc'),
-  bash: () => join(homedir(), '.bashrc'),
-  fish: () => join(homedir(), '.config', 'fish', 'config.fish'),
+  zsh: () => join(homedir(), ".zshrc"),
+  bash: () => join(homedir(), ".bashrc"),
+  fish: () => join(homedir(), ".config", "fish", "config.fish"),
   powershell: getPowerShellProfilePath,
-}
+};
 
 function isShellInstalled(shell: ShellName): boolean {
-  if (shell === 'powershell') {
-    if (platform() === 'win32') return true
-    return whichSync('pwsh') !== null
+  if (shell === "powershell") {
+    if (platform() === "win32") return true;
+    return whichSync("pwsh") !== null;
   }
-  return whichSync(shell) !== null
+  return whichSync(shell) !== null;
 }
 
 function whichSync(cmd: string): string | null {
-  const isWin = platform() === 'win32'
-  const result = spawnSync(isWin ? 'where' : 'which', [cmd], { stdio: 'pipe', encoding: 'utf-8' })
-  return result.status === 0 ? result.stdout.trim() : null
+  const isWin = platform() === "win32";
+  const result = spawnSync(isWin ? "where" : "which", [cmd], { stdio: "pipe", encoding: "utf-8" });
+  return result.status === 0 ? result.stdout.trim() : null;
 }
 
 export function getShellSetup(config: Config): ShellSetupResponse {
-  const shells: ShellInfo[] = (['zsh', 'bash', 'fish', 'powershell'] as ShellName[])
+  const shells: ShellInfo[] = (["zsh", "bash", "fish", "powershell"] as ShellName[])
     .filter(isShellInstalled)
-    .map(name => {
-    const rcPath = SHELL_RC_PATHS[name]()
-    const rcExists = existsSync(rcPath)
-    const desired = getSnippetForShell(config, name)
-    return {
-      name,
-      rcPath,
-      rcExists,
-      installed: rcExists && rcContainsCurrentSnippet(rcPath, desired),
-    }
-  })
+    .map((name) => {
+      const rcPath = SHELL_RC_PATHS[name]();
+      const rcExists = existsSync(rcPath);
+      const desired = getSnippetForShell(config, name);
+      return {
+        name,
+        rcPath,
+        rcExists,
+        installed: rcExists && rcContainsCurrentSnippet(rcPath, desired),
+      };
+    });
 
   return {
     shells,
@@ -73,108 +73,108 @@ export function getShellSetup(config: Config): ShellSetupResponse {
       powershell: buildPowerShellSnippet(config.server.panelPort),
     },
     usage: `${SHELL_COMMAND} --deepseek    # any provider flag, case-insensitive`,
-  }
+  };
 }
 
 function rcContainsCurrentSnippet(rcPath: string, desired: string): boolean {
   try {
-    return extractSnippetBlock(readFileSync(rcPath, 'utf-8')) === desired
+    return extractSnippetBlock(readFileSync(rcPath, "utf-8")) === desired;
   } catch {
-    return false
+    return false;
   }
 }
 
 function getPowerShellProfilePath(): string {
-  const home = homedir()
-  if (platform() === 'win32') {
-    const ps7 = join(home, 'Documents', 'PowerShell', 'Microsoft.PowerShell_profile.ps1')
-    const ps5dir = join(home, 'Documents', 'WindowsPowerShell')
-    if (existsSync(ps5dir) && !existsSync(join(home, 'Documents', 'PowerShell'))) {
-      return join(ps5dir, 'Microsoft.PowerShell_profile.ps1')
+  const home = homedir();
+  if (platform() === "win32") {
+    const ps7 = join(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1");
+    const ps5dir = join(home, "Documents", "WindowsPowerShell");
+    if (existsSync(ps5dir) && !existsSync(join(home, "Documents", "PowerShell"))) {
+      return join(ps5dir, "Microsoft.PowerShell_profile.ps1");
     }
-    return ps7
+    return ps7;
   }
-  return join(home, '.config', 'powershell', 'Microsoft.PowerShell_profile.ps1')
+  return join(home, ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
 }
 
 function detectCurrentShell(): ShellName | null {
-  if (platform() === 'win32') {
-    return process.env['PSModulePath'] ? 'powershell' : null
+  if (platform() === "win32") {
+    return process.env["PSModulePath"] ? "powershell" : null;
   }
-  const shellPath = process.env['SHELL'] ?? ''
-  if (shellPath.endsWith('/zsh')) return 'zsh'
-  if (shellPath.endsWith('/bash')) return 'bash'
-  if (shellPath.endsWith('/fish')) return 'fish'
-  if (process.env['PSModulePath']) return 'powershell'
-  return null
+  const shellPath = process.env["SHELL"] ?? "";
+  if (shellPath.endsWith("/zsh")) return "zsh";
+  if (shellPath.endsWith("/bash")) return "bash";
+  if (shellPath.endsWith("/fish")) return "fish";
+  if (process.env["PSModulePath"]) return "powershell";
+  return null;
 }
 
 function buildPosixSnippet(panelPort: number): string {
-  const endpoint = `http://127.0.0.1:${panelPort}/api/launch/prepare`
-  const endEndpoint = `http://127.0.0.1:${panelPort}/api/launch/end`
-  const heartbeatEndpoint = `http://127.0.0.1:${panelPort}/api/launch/heartbeat`
-  const attachEndpoint = `http://127.0.0.1:${panelPort}/api/launch/attach`
+  const endpoint = `http://127.0.0.1:${panelPort}/api/launch/prepare`;
+  const endEndpoint = `http://127.0.0.1:${panelPort}/api/launch/end`;
+  const heartbeatEndpoint = `http://127.0.0.1:${panelPort}/api/launch/heartbeat`;
+  const attachEndpoint = `http://127.0.0.1:${panelPort}/api/launch/attach`;
   return [
     SNIPPET_SENTINEL,
     `${SHELL_COMMAND}() {`,
     '  if [ -z "$1" ]; then',
     `    echo "usage: ${SHELL_COMMAND} --<provider> [claude args...]" >&2`,
-    '    return 1',
-    '  fi',
+    "    return 1",
+    "  fi",
     '  local flag="$1"; shift',
-    '  local env_script',
+    "  local env_script",
     `  if ! env_script=$(curl -fsS -X POST '${endpoint}' \\`,
-    '        -H \'Content-Type: application/json\' \\',
+    "        -H 'Content-Type: application/json' \\",
     '        -d "{\\"flag\\":\\"$flag\\"}" 2>/dev/null); then',
     '    echo "Claude Code Gateway is not running. Open the app first." >&2',
-    '    return 1',
-    '  fi',
-    '  # Subshell keeps ANTHROPIC_* env vars scoped to this invocation.',
-    '  (',
+    "    return 1",
+    "  fi",
+    "  # Subshell keeps ANTHROPIC_* env vars scoped to this invocation.",
+    "  (",
     '    eval "$env_script"',
-    '    __ccpg_heartbeat() {',
-    '      while true; do',
+    "    __ccpg_heartbeat() {",
+    "      while true; do",
     `        curl -fsS -X POST '${heartbeatEndpoint}' \\`,
-    '          -H \'Content-Type: application/json\' \\',
+    "          -H 'Content-Type: application/json' \\",
     '          -d "{\\"sessionId\\":\\"$CC_GATEWAY_SESSION_ID\\"}" >/dev/null 2>&1 || true',
-    '        sleep 2',
-    '      done',
-    '    }',
-    '    __ccpg_end_session() {',
+    "        sleep 2",
+    "      done",
+    "    }",
+    "    __ccpg_end_session() {",
     '      if [ -n "$__ccpg_heartbeat_pid" ]; then kill "$__ccpg_heartbeat_pid" >/dev/null 2>&1 || true; fi',
     `      curl -fsS -X POST '${endEndpoint}' \\`,
-    '        -H \'Content-Type: application/json\' \\',
+    "        -H 'Content-Type: application/json' \\",
     '        -d "{\\"sessionId\\":\\"$CC_GATEWAY_SESSION_ID\\"}" >/dev/null 2>&1 || true',
-    '    }',
-    '    trap __ccpg_end_session EXIT HUP INT TERM',
-    '    __ccpg_heartbeat &',
-    '    __ccpg_heartbeat_pid=$!',
+    "    }",
+    "    trap __ccpg_end_session EXIT HUP INT TERM",
+    "    __ccpg_heartbeat &",
+    "    __ccpg_heartbeat_pid=$!",
     '    command claude "$@" &',
-    '    __ccpg_claude_pid=$!',
+    "    __ccpg_claude_pid=$!",
     `    curl -fsS -X POST '${attachEndpoint}' \\`,
-    '      -H \'Content-Type: application/json\' \\',
+    "      -H 'Content-Type: application/json' \\",
     '      -d "{\\"sessionId\\":\\"$CC_GATEWAY_SESSION_ID\\",\\"pid\\":$__ccpg_claude_pid}" >/dev/null 2>&1 || true',
     '    wait "$__ccpg_claude_pid"',
-  '  )',
-    '}',
+    "  )",
+    "}",
     SNIPPET_END,
-  ].join('\n')
+  ].join("\n");
 }
 
 export function getSnippetForShell(config: Config, shell: ShellName): string {
-  const panelPort = config.server.panelPort
-  if (shell === 'fish') return buildFishSnippet(panelPort)
-  if (shell === 'powershell') return buildPowerShellSnippet(panelPort)
-  return buildPosixSnippet(panelPort)
+  const panelPort = config.server.panelPort;
+  if (shell === "fish") return buildFishSnippet(panelPort);
+  if (shell === "powershell") return buildPowerShellSnippet(panelPort);
+  return buildPosixSnippet(panelPort);
 }
 
-export type InstallStatus = 'installed' | 'updated' | 'already-installed' | 'error'
+export type InstallStatus = "installed" | "updated" | "already-installed" | "error";
 
 export interface InstallResult {
-  shell: ShellName
-  status: InstallStatus
-  rcPath: string
-  error?: string
+  shell: ShellName;
+  status: InstallStatus;
+  rcPath: string;
+  error?: string;
 }
 
 // Install (or refresh) the snippet in the rc file. Always idempotent w.r.t.
@@ -182,139 +182,139 @@ export interface InstallResult {
 // write the current version, so users get bugfixes by clicking "Add" again.
 // Creates the file (and parent dir for fish) if missing.
 export function installSnippet(config: Config, shell: ShellName): InstallResult {
-  const rcPath = SHELL_RC_PATHS[shell]()
-  const desired = getSnippetForShell(config, shell)
+  const rcPath = SHELL_RC_PATHS[shell]();
+  const desired = getSnippetForShell(config, shell);
 
   try {
-    mkdirSync(dirname(rcPath), { recursive: true })
+    mkdirSync(dirname(rcPath), { recursive: true });
 
     if (!existsSync(rcPath)) {
-      writeFileSync(rcPath, desired + '\n', { encoding: 'utf-8' })
-      return { shell, status: 'installed', rcPath }
+      writeFileSync(rcPath, desired + "\n", { encoding: "utf-8" });
+      return { shell, status: "installed", rcPath };
     }
 
-    const current = readFileSync(rcPath, 'utf-8')
-    const existing = extractSnippetBlock(current)
+    const current = readFileSync(rcPath, "utf-8");
+    const existing = extractSnippetBlock(current);
 
     if (existing === desired) {
-      return { shell, status: 'already-installed', rcPath }
+      return { shell, status: "already-installed", rcPath };
     }
 
     if (existing !== null) {
-      const replaced = current.replace(existing, desired)
-      writeFileSync(rcPath, replaced, { encoding: 'utf-8' })
-      return { shell, status: 'updated', rcPath }
+      const replaced = current.replace(existing, desired);
+      writeFileSync(rcPath, replaced, { encoding: "utf-8" });
+      return { shell, status: "updated", rcPath };
     }
 
-    const block = '\n' + desired + '\n'
-    appendFileSync(rcPath, block, { encoding: 'utf-8' })
-    return { shell, status: 'installed', rcPath }
+    const block = "\n" + desired + "\n";
+    appendFileSync(rcPath, block, { encoding: "utf-8" });
+    return { shell, status: "installed", rcPath };
   } catch (err) {
     return {
       shell,
-      status: 'error',
+      status: "error",
       rcPath,
       error: err instanceof Error ? err.message : String(err),
-    }
+    };
   }
 }
 
 // Returns the exact substring of `content` that is our managed block (sentinel
 // to end-sentinel inclusive), or null if no block is present.
 function extractSnippetBlock(content: string): string | null {
-  const start = content.indexOf(SNIPPET_SENTINEL)
-  if (start === -1) return null
-  const endMarker = content.indexOf(SNIPPET_END, start)
-  if (endMarker === -1) return null
-  return content.slice(start, endMarker + SNIPPET_END.length)
+  const start = content.indexOf(SNIPPET_SENTINEL);
+  if (start === -1) return null;
+  const endMarker = content.indexOf(SNIPPET_END, start);
+  if (endMarker === -1) return null;
+  return content.slice(start, endMarker + SNIPPET_END.length);
 }
 
 function buildPowerShellSnippet(panelPort: number): string {
-  const prepareUrl = `http://127.0.0.1:${panelPort}/api/launch/prepare`
-  const heartbeatUrl = `http://127.0.0.1:${panelPort}/api/launch/heartbeat`
-  const endUrl = `http://127.0.0.1:${panelPort}/api/launch/end`
-  const attachUrl = `http://127.0.0.1:${panelPort}/api/launch/attach`
+  const prepareUrl = `http://127.0.0.1:${panelPort}/api/launch/prepare`;
+  const heartbeatUrl = `http://127.0.0.1:${panelPort}/api/launch/heartbeat`;
+  const endUrl = `http://127.0.0.1:${panelPort}/api/launch/end`;
+  const attachUrl = `http://127.0.0.1:${panelPort}/api/launch/attach`;
   return [
     SNIPPET_SENTINEL,
     `function ${SHELL_COMMAND} {`,
-    '  if ($args.Count -eq 0) {',
+    "  if ($args.Count -eq 0) {",
     `    Write-Error "usage: ${SHELL_COMMAND} --<provider> [claude args...]"`,
-    '    return',
-    '  }',
-    '  $flag = $args[0]',
-    '  $claudeArgs = if ($args.Count -gt 1) { @($args[1..($args.Count - 1)]) } else { @() }',
-    '  try {',
+    "    return",
+    "  }",
+    "  $flag = $args[0]",
+    "  $claudeArgs = if ($args.Count -gt 1) { @($args[1..($args.Count - 1)]) } else { @() }",
+    "  try {",
     `    $r = Invoke-RestMethod -Method Post -Uri '${prepareUrl}' \``,
-    "      -ContentType 'application/json' \`",
+    "      -ContentType 'application/json' `",
     "      -Body (ConvertTo-Json @{ flag = $flag; format = 'json' })",
-    '  } catch {',
+    "  } catch {",
     "    Write-Error 'Claude Code Gateway is not running. Open the app first.'",
-    '    return',
-    '  }',
-    "  if (-not $r.ok) { Write-Error \"ccpg: $($r.error)\"; return }",
-    '  $sid = $r.sessionId',
-    '  $saved = @{',
-    '    ANTHROPIC_AUTH_TOKEN = $env:ANTHROPIC_AUTH_TOKEN',
-    '    ANTHROPIC_BASE_URL = $env:ANTHROPIC_BASE_URL',
-    '    CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY = $env:CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY',
-    '    CC_GATEWAY_SESSION_ID = $env:CC_GATEWAY_SESSION_ID',
-    '  }',
-    '  $env:ANTHROPIC_AUTH_TOKEN = $r.authToken',
-    '  $env:ANTHROPIC_BASE_URL = $r.baseUrl',
+    "    return",
+    "  }",
+    '  if (-not $r.ok) { Write-Error "ccpg: $($r.error)"; return }',
+    "  $sid = $r.sessionId",
+    "  $saved = @{",
+    "    ANTHROPIC_AUTH_TOKEN = $env:ANTHROPIC_AUTH_TOKEN",
+    "    ANTHROPIC_BASE_URL = $env:ANTHROPIC_BASE_URL",
+    "    CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY = $env:CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY",
+    "    CC_GATEWAY_SESSION_ID = $env:CC_GATEWAY_SESSION_ID",
+    "  }",
+    "  $env:ANTHROPIC_AUTH_TOKEN = $r.authToken",
+    "  $env:ANTHROPIC_BASE_URL = $r.baseUrl",
     "  $env:CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY = '1'",
-    '  $env:CC_GATEWAY_SESSION_ID = $sid',
-    '  $hbJob = Start-Job -ScriptBlock {',
-    '    param($url, $sid)',
-    '    while ($true) {',
-    '      try { Invoke-RestMethod -Method Post -Uri $url -ContentType \'application/json\' `',
+    "  $env:CC_GATEWAY_SESSION_ID = $sid",
+    "  $hbJob = Start-Job -ScriptBlock {",
+    "    param($url, $sid)",
+    "    while ($true) {",
+    "      try { Invoke-RestMethod -Method Post -Uri $url -ContentType 'application/json' `",
     '        -Body "{`"sessionId`":`"$sid`"}" | Out-Null } catch {}',
-    '      Start-Sleep 2',
-    '    }',
+    "      Start-Sleep 2",
+    "    }",
     `  } -ArgumentList '${heartbeatUrl}', $sid`,
-    '  try {',
-    '    $proc = Start-Process claude -ArgumentList $claudeArgs -NoNewWindow -PassThru',
+    "  try {",
+    "    $proc = Start-Process claude -ArgumentList $claudeArgs -NoNewWindow -PassThru",
     `    try { Invoke-RestMethod -Method Post -Uri '${attachUrl}' -ContentType 'application/json' \``,
     '      -Body "{`"sessionId`":`"$sid`",`"pid`":$($proc.Id)}" | Out-Null } catch {}',
-    '    $proc.WaitForExit()',
-    '  } finally {',
-    '    Stop-Job $hbJob -ErrorAction SilentlyContinue',
-    '    Remove-Job $hbJob -Force -ErrorAction SilentlyContinue',
+    "    $proc.WaitForExit()",
+    "  } finally {",
+    "    Stop-Job $hbJob -ErrorAction SilentlyContinue",
+    "    Remove-Job $hbJob -Force -ErrorAction SilentlyContinue",
     `    try { Invoke-RestMethod -Method Post -Uri '${endUrl}' -ContentType 'application/json' \``,
     '      -Body "{`"sessionId`":`"$sid`"}" | Out-Null } catch {}',
-    '    $saved.GetEnumerator() | ForEach-Object {',
+    "    $saved.GetEnumerator() | ForEach-Object {",
     '      if ($null -eq $_.Value) { Remove-Item "env:$($_.Key)" -ErrorAction SilentlyContinue }',
     '      else { Set-Item "env:$($_.Key)" $_.Value }',
-    '    }',
-    '  }',
-    '}',
+    "    }",
+    "  }",
+    "}",
     SNIPPET_END,
-  ].join('\n')
+  ].join("\n");
 }
 
 function buildFishSnippet(panelPort: number): string {
-  const endpoint = `http://127.0.0.1:${panelPort}/api/launch/prepare`
-  const endEndpoint = `http://127.0.0.1:${panelPort}/api/launch/end`
-  const heartbeatEndpoint = `http://127.0.0.1:${panelPort}/api/launch/heartbeat`
-  const attachEndpoint = `http://127.0.0.1:${panelPort}/api/launch/attach`
+  const endpoint = `http://127.0.0.1:${panelPort}/api/launch/prepare`;
+  const endEndpoint = `http://127.0.0.1:${panelPort}/api/launch/end`;
+  const heartbeatEndpoint = `http://127.0.0.1:${panelPort}/api/launch/heartbeat`;
+  const attachEndpoint = `http://127.0.0.1:${panelPort}/api/launch/attach`;
   return [
     SNIPPET_SENTINEL,
     `function ${SHELL_COMMAND}`,
-    '  if test (count $argv) -eq 0',
+    "  if test (count $argv) -eq 0",
     `    echo "usage: ${SHELL_COMMAND} --<provider> [claude args...]" >&2`,
-    '    return 1',
-    '  end',
-    '  set flag $argv[1]',
-    '  set rest $argv[2..-1]',
+    "    return 1",
+    "  end",
+    "  set flag $argv[1]",
+    "  set rest $argv[2..-1]",
     `  set env_script (curl -fsS -X POST '${endpoint}' \\`,
-    '        -H \'Content-Type: application/json\' \\',
+    "        -H 'Content-Type: application/json' \\",
     `        -d "{\\"flag\\":\\"$flag\\"}" 2>/dev/null; or echo __CC_GATEWAY_DOWN__)`,
     '  if string match -q "__CC_GATEWAY_DOWN__" -- "$env_script"',
     '    echo "Claude Code Gateway is not running. Open the app first." >&2',
-    '    return 1',
-  '  end',
-  '  # Nested fish process keeps ANTHROPIC_* env vars scoped to this call.',
+    "    return 1",
+    "  end",
+    "  # Nested fish process keeps ANTHROPIC_* env vars scoped to this call.",
     `  fish -c "$env_script; while true; curl -fsS -X POST '${heartbeatEndpoint}' -H 'Content-Type: application/json' -d '{\\"sessionId\\":\\"'$CC_GATEWAY_SESSION_ID'\\"}' >/dev/null 2>&1; sleep 2; end &; set __ccpg_heartbeat_pid \\$last_pid; function __ccpg_end_session --on-event fish_exit; kill \\$__ccpg_heartbeat_pid >/dev/null 2>&1; curl -fsS -X POST '${endEndpoint}' -H 'Content-Type: application/json' -d '{\\"sessionId\\":\\"'$CC_GATEWAY_SESSION_ID'\\"}' >/dev/null 2>&1; end; command claude $rest &; set __ccpg_claude_pid \\$last_pid; curl -fsS -X POST '${attachEndpoint}' -H 'Content-Type: application/json' -d '{\\"sessionId\\":\\"'$CC_GATEWAY_SESSION_ID'\\",\\"pid\\":'\\$__ccpg_claude_pid'}' >/dev/null 2>&1; wait \\$__ccpg_claude_pid"`,
-    'end',
+    "end",
     SNIPPET_END,
-  ].join('\n')
+  ].join("\n");
 }

--- a/packages/daemon/src/proxy/app.ts
+++ b/packages/daemon/src/proxy/app.ts
@@ -1,25 +1,25 @@
-import { Hono } from 'hono'
-import type { Config } from '../config/schema.js'
-import { ProxyRuntime } from './runtime.js'
-import type { ConfigLoader } from './runtime.js'
-import { registerAnthropicRoutes } from './routes/anthropic-routes.js'
-import { registerStatusRoutes } from './routes/status-routes.js'
+import { Hono } from "hono";
+import type { Config } from "../config/schema.js";
+import { registerAnthropicRoutes } from "./routes/anthropic-routes.js";
+import { registerStatusRoutes } from "./routes/status-routes.js";
+import type { ConfigLoader } from "./runtime.js";
+import { ProxyRuntime } from "./runtime.js";
 
 interface ProxyAppOptions {
-  loadConfig?: ConfigLoader
+  loadConfig?: ConfigLoader;
 }
 
 export function createProxyApp(initialConfig: Config, options: ProxyAppOptions = {}) {
-  const app = new Hono()
-  const runtime = new ProxyRuntime(initialConfig, options.loadConfig)
+  const app = new Hono();
+  const runtime = new ProxyRuntime(initialConfig, options.loadConfig);
 
-  app.use('*', async (c, next) => {
-    runtime.reloadConfig()
-    await next()
-  })
+  app.use("*", async (c, next) => {
+    runtime.reloadConfig();
+    await next();
+  });
 
-  registerStatusRoutes(app, runtime)
-  registerAnthropicRoutes(app, runtime)
+  registerStatusRoutes(app, runtime);
+  registerAnthropicRoutes(app, runtime);
 
-  return app
+  return app;
 }

--- a/packages/daemon/src/proxy/errors.ts
+++ b/packages/daemon/src/proxy/errors.ts
@@ -1,33 +1,33 @@
 export type AnthropicErrorType =
-  | 'authentication_error'
-  | 'not_found_error'
-  | 'rate_limit_error'
-  | 'api_error'
+  | "authentication_error"
+  | "not_found_error"
+  | "rate_limit_error"
+  | "api_error";
 
-export type ErrorStatus = 400 | 401 | 403 | 404 | 429 | 500
+export type ErrorStatus = 400 | 401 | 403 | 404 | 429 | 500;
 
 export interface AnthropicErrorResponse {
-  type: 'error'
+  type: "error";
   error: {
-    type: AnthropicErrorType
-    message: string
-  }
+    type: AnthropicErrorType;
+    message: string;
+  };
 }
 
 export function anthropicError(type: AnthropicErrorType, message: string): AnthropicErrorResponse {
-  return { type: 'error', error: { type, message } }
+  return { type: "error", error: { type, message } };
 }
 
 export function providerErrorType(status: number): AnthropicErrorType {
-  if (status === 429) return 'rate_limit_error'
-  if (status === 401) return 'authentication_error'
-  if (status === 404) return 'not_found_error'
-  return 'api_error'
+  if (status === 429) return "rate_limit_error";
+  if (status === 401) return "authentication_error";
+  if (status === 404) return "not_found_error";
+  return "api_error";
 }
 
 export function providerErrorStatus(status: number): ErrorStatus {
   if (status === 400 || status === 401 || status === 403 || status === 404 || status === 429) {
-    return status
+    return status;
   }
-  return 500
+  return 500;
 }

--- a/packages/daemon/src/proxy/middleware/auth.ts
+++ b/packages/daemon/src/proxy/middleware/auth.ts
@@ -1,18 +1,18 @@
-import type { Context, Next } from 'hono'
-import { anthropicError } from '../errors.js'
-import type { ProxyRuntime } from '../runtime.js'
+import type { Context, Next } from "hono";
+import { anthropicError } from "../errors.js";
+import type { ProxyRuntime } from "../runtime.js";
 
 export function requireAnthropicAuth(runtime: ProxyRuntime) {
   return async (c: Context, next: Next) => {
-    const config = runtime.currentConfig()
-    if (!config.server.authToken) return next()
+    const config = runtime.currentConfig();
+    if (!config.server.authToken) return next();
 
-    const auth = c.req.header('Authorization') ?? c.req.header('x-api-key') ?? ''
-    const token = auth.replace(/^Bearer\s+/i, '')
+    const auth = c.req.header("Authorization") ?? c.req.header("x-api-key") ?? "";
+    const token = auth.replace(/^Bearer\s+/i, "");
     if (token !== config.server.authToken) {
-      return c.json(anthropicError('authentication_error', 'Invalid API key'), 401)
+      return c.json(anthropicError("authentication_error", "Invalid API key"), 401);
     }
 
-    return next()
-  }
+    return next();
+  };
 }

--- a/packages/daemon/src/proxy/model-router.ts
+++ b/packages/daemon/src/proxy/model-router.ts
@@ -1,62 +1,66 @@
-import type { Config, ProviderId, RoutingRule } from '../config/schema.js'
-import { PROVIDER_IDS } from '../config/schema.js'
+import type { Config, ProviderId, RoutingRule } from "../config/schema.js";
+import { PROVIDER_IDS } from "../config/schema.js";
 
 export interface ResolvedModel {
-  providerId: ProviderId
-  providerModel: string
+  providerId: ProviderId;
+  providerModel: string;
   /** How the model was resolved — used by the service layer to detect background passthrough calls */
-  source: 'prefix' | 'tier' | 'passthrough'
+  source: "prefix" | "tier" | "passthrough";
 }
 
-const CLAUDE_OPUS_PATTERN   = /claude-(3-opus|opus)/i
-const CLAUDE_SONNET_PATTERN = /claude-(3[.-]5?-sonnet|sonnet)/i
-const CLAUDE_HAIKU_PATTERN  = /claude-(3-haiku|haiku)/i
+const CLAUDE_OPUS_PATTERN = /claude-(3-opus|opus)/i;
+const CLAUDE_SONNET_PATTERN = /claude-(3[.-]5?-sonnet|sonnet)/i;
+const CLAUDE_HAIKU_PATTERN = /claude-(3-haiku|haiku)/i;
 
 function applyRule(rule: RoutingRule | undefined): ResolvedModel | null {
-  if (!rule || !rule.enabled || !rule.providerId || !rule.model) return null
+  if (!rule || !rule.enabled || !rule.providerId || !rule.model) return null;
 
   // Normalize the stored model name: the panel lets users pick models by their full
   // gateway ID (e.g. "anthropic/deepseek/deepseek-v4-flash"), but only the bare
   // provider model name ("deepseek-v4-flash") should be sent to the provider API.
-  let providerModel = rule.model
-  if (providerModel.startsWith('anthropic/')) {
-    providerModel = providerModel.slice('anthropic/'.length)
+  let providerModel = rule.model;
+  if (providerModel.startsWith("anthropic/")) {
+    providerModel = providerModel.slice("anthropic/".length);
   }
   // After stripping the gateway prefix we may have "<providerId>/<model>" — strip that too.
   if (providerModel.startsWith(`${rule.providerId}/`)) {
-    providerModel = providerModel.slice(rule.providerId.length + 1)
+    providerModel = providerModel.slice(rule.providerId.length + 1);
   }
 
-  return { providerId: rule.providerId as ProviderId, providerModel, source: 'tier' as const }
+  return { providerId: rule.providerId as ProviderId, providerModel, source: "tier" as const };
 }
 
 export function resolveModel(requestedModel: string, config: Config): ResolvedModel {
   // Strip Claude Code-discoverable prefix: "anthropic/<provider>/<model>"
-  let model = requestedModel
-  if (model.startsWith('anthropic/')) {
-    model = model.slice('anthropic/'.length)
+  let model = requestedModel;
+  if (model.startsWith("anthropic/")) {
+    model = model.slice("anthropic/".length);
   }
 
   // Direct provider/model syntax: "nvidia_nim/z-ai/glm4.7"
   for (const pid of PROVIDER_IDS) {
     if (model.startsWith(`${pid}/`)) {
-      return { providerId: pid, providerModel: model.slice(pid.length + 1), source: 'prefix' }
+      return { providerId: pid, providerModel: model.slice(pid.length + 1), source: "prefix" };
     }
   }
-  const requestedForTier = requestedModel
+  const requestedForTier = requestedModel;
 
   // Claude model tier mapping (only when the rule is explicitly enabled)
-  let tierRule: RoutingRule | undefined
-  if (CLAUDE_OPUS_PATTERN.test(requestedForTier)) tierRule = config.routing.opus
-  else if (CLAUDE_SONNET_PATTERN.test(requestedForTier)) tierRule = config.routing.sonnet
-  else if (CLAUDE_HAIKU_PATTERN.test(requestedForTier)) tierRule = config.routing.haiku
+  let tierRule: RoutingRule | undefined;
+  if (CLAUDE_OPUS_PATTERN.test(requestedForTier)) tierRule = config.routing.opus;
+  else if (CLAUDE_SONNET_PATTERN.test(requestedForTier)) tierRule = config.routing.sonnet;
+  else if (CLAUDE_HAIKU_PATTERN.test(requestedForTier)) tierRule = config.routing.haiku;
 
-  const tierResolved = applyRule(tierRule)
-  if (tierResolved) return { ...tierResolved, source: 'tier' }
+  const tierResolved = applyRule(tierRule);
+  if (tierResolved) return { ...tierResolved, source: "tier" };
 
-  const defaultResolved = applyRule(config.routing.default)
-  if (defaultResolved) return { ...defaultResolved, source: 'tier' }
+  const defaultResolved = applyRule(config.routing.default);
+  if (defaultResolved) return { ...defaultResolved, source: "tier" };
 
   // Passthrough: routing not configured → send the original model name to the active provider
-  return { providerId: config.activeProvider, providerModel: requestedModel, source: 'passthrough' }
+  return {
+    providerId: config.activeProvider,
+    providerModel: requestedModel,
+    source: "passthrough",
+  };
 }

--- a/packages/daemon/src/proxy/optimizations.ts
+++ b/packages/daemon/src/proxy/optimizations.ts
@@ -1,58 +1,69 @@
 // Local request optimizations — respond without hitting any provider
 // These reduce latency and quota usage for internal Claude Code housekeeping calls.
 
-import type { MessagesRequest } from '../core/anthropic/types.js'
-import { sseMessageStart, sseContentBlockStart, sseContentBlockDelta, sseContentBlockStop, sseMessageDelta, sseMessageStop, ssePing } from '../core/sse/writer.js'
-import { randomUUID } from 'node:crypto'
+import { randomUUID } from "node:crypto";
+import type { MessagesRequest } from "../core/anthropic/types.js";
+import {
+  sseContentBlockDelta,
+  sseContentBlockStart,
+  sseContentBlockStop,
+  sseMessageDelta,
+  sseMessageStart,
+  sseMessageStop,
+  ssePing,
+} from "../core/sse/writer.js";
 
-type OptimizationResult = { handled: true; stream: ReadableStream<string> } | { handled: false }
+type OptimizationResult = { handled: true; stream: ReadableStream<string> } | { handled: false };
 
 function makeTextStream(text: string, model: string): ReadableStream<string> {
-  const id = `msg_${randomUUID().replace(/-/g, '')}`
+  const id = `msg_${randomUUID().replace(/-/g, "")}`;
   return new ReadableStream<string>({
     start(controller) {
-      controller.enqueue(ssePing())
-      controller.enqueue(sseMessageStart(id, model, 0))
-      controller.enqueue(sseContentBlockStart(0, { type: 'text', text: '' }))
-      controller.enqueue(sseContentBlockDelta(0, { type: 'text_delta', text }))
-      controller.enqueue(sseContentBlockStop(0))
-      controller.enqueue(sseMessageDelta('end_turn', text.length))
-      controller.enqueue(sseMessageStop())
-      controller.close()
+      controller.enqueue(ssePing());
+      controller.enqueue(sseMessageStart(id, model, 0));
+      controller.enqueue(sseContentBlockStart(0, { type: "text", text: "" }));
+      controller.enqueue(sseContentBlockDelta(0, { type: "text_delta", text }));
+      controller.enqueue(sseContentBlockStop(0));
+      controller.enqueue(sseMessageDelta("end_turn", text.length));
+      controller.enqueue(sseMessageStop());
+      controller.close();
     },
-  })
+  });
 }
 
 function getTextContent(req: MessagesRequest): string {
-  const last = req.messages.at(-1)
-  if (!last) return ''
-  if (typeof last.content === 'string') return last.content
-  return last.content.filter(b => b.type === 'text').map(b => (b as { text: string }).text).join('')
+  const last = req.messages.at(-1);
+  if (!last) return "";
+  if (typeof last.content === "string") return last.content;
+  return last.content
+    .filter((b) => b.type === "text")
+    .map((b) => (b as { text: string }).text)
+    .join("");
 }
 
 export function tryOptimize(req: MessagesRequest): OptimizationResult {
-  const text = getTextContent(req).trim()
+  const text = getTextContent(req).trim();
 
   // Network connectivity probe — Claude Code sends this to check network access
-  if (text.includes('GET_NETWORK_INFO') || text.includes('curl') && text.includes('checkip')) {
-    return { handled: true, stream: makeTextStream('{"ip":"127.0.0.1","status":"ok"}', req.model) }
+  if (text.includes("GET_NETWORK_INFO") || (text.includes("curl") && text.includes("checkip"))) {
+    return { handled: true, stream: makeTextStream('{"ip":"127.0.0.1","status":"ok"}', req.model) };
   }
 
   // Title generation — short meta requests we skip to save quota
-  if (req.max_tokens <= 40 && text.toLowerCase().includes('title')) {
-    return { handled: true, stream: makeTextStream('Untitled', req.model) }
+  if (req.max_tokens <= 40 && text.toLowerCase().includes("title")) {
+    return { handled: true, stream: makeTextStream("Untitled", req.model) };
   }
 
   // File path suggestions — Claude Code sends very specific probe messages to get
   // path completions. Only intercept when it looks like a bare completions request,
   // not a genuine user prompt that happens to mention "file path".
   if (
-    (text.includes('filepath') || text.includes('file path'))
-    && req.max_tokens <= 200
-    && req.messages.length <= 2
+    (text.includes("filepath") || text.includes("file path")) &&
+    req.max_tokens <= 200 &&
+    req.messages.length <= 2
   ) {
-    return { handled: true, stream: makeTextStream('[]', req.model) }
+    return { handled: true, stream: makeTextStream("[]", req.model) };
   }
 
-  return { handled: false }
+  return { handled: false };
 }

--- a/packages/daemon/src/proxy/providers/anthropic-passthrough.ts
+++ b/packages/daemon/src/proxy/providers/anthropic-passthrough.ts
@@ -5,95 +5,111 @@
 // has stored locally at ~/.claude/.credentials.json — the same auth the user
 // would use if they were running plain `claude` without the gateway.
 
-import { existsSync, readFileSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
-import type { MessagesRequest, ModelInfo } from '../../core/anthropic/types.js'
-import type { StreamResult } from './base.js'
-import { postProviderStream } from './api-client.js'
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { MessagesRequest, ModelInfo } from "../../core/anthropic/types.js";
+import { postProviderStream } from "./api-client.js";
+import type { StreamResult } from "./base.js";
 
 interface ClaudeCredentials {
   claudeAiOauth?: {
-    accessToken?: string
-    refreshToken?: string
-    expiresAt?: number
-    subscriptionType?: string
-  }
+    accessToken?: string;
+    refreshToken?: string;
+    expiresAt?: number;
+    subscriptionType?: string;
+  };
 }
 
-const ANTHROPIC_API_URL = 'https://api.anthropic.com'
-const ANTHROPIC_VERSION = '2023-06-01'
+const ANTHROPIC_API_URL = "https://api.anthropic.com";
+const ANTHROPIC_VERSION = "2023-06-01";
 // Claude.ai OAuth tokens require this beta header to be accepted.
-const ANTHROPIC_OAUTH_BETA = 'oauth-2025-04-20'
+const ANTHROPIC_OAUTH_BETA = "oauth-2025-04-20";
 
 function credentialsPath(): string {
-  return join(homedir(), '.claude', '.credentials.json')
+  return join(homedir(), ".claude", ".credentials.json");
 }
 
 function readCredentials(): ClaudeCredentials | null {
-  const path = credentialsPath()
-  if (!existsSync(path)) return null
+  const path = credentialsPath();
+  if (!existsSync(path)) return null;
   try {
-    return JSON.parse(readFileSync(path, 'utf-8')) as ClaudeCredentials
+    return JSON.parse(readFileSync(path, "utf-8")) as ClaudeCredentials;
   } catch {
-    return null
+    return null;
   }
 }
 
 export interface AnthropicCredentialsStatus {
-  available: boolean
-  expiresAt: number | null
-  subscriptionType: string | null
+  available: boolean;
+  expiresAt: number | null;
+  subscriptionType: string | null;
 }
 
 export function getAnthropicCredentialsStatus(): AnthropicCredentialsStatus {
-  const oauth = readCredentials()?.claudeAiOauth
+  const oauth = readCredentials()?.claudeAiOauth;
   return {
     available: !!oauth?.accessToken,
     expiresAt: oauth?.expiresAt ?? null,
     subscriptionType: oauth?.subscriptionType ?? null,
-  }
+  };
 }
 
-const NATIVE_CLAUDE_PATTERN = /^claude-(?:3-(?:5-)?)?(?:opus|sonnet|haiku)-/i
+const NATIVE_CLAUDE_PATTERN = /^claude-(?:3-(?:5-)?)?(?:opus|sonnet|haiku)-/i;
 
 export function isNativeClaudeModel(model: string): boolean {
   // Reject anything with a slash (provider-prefixed routing reference).
-  if (model.includes('/')) return false
-  return NATIVE_CLAUDE_PATTERN.test(model)
+  if (model.includes("/")) return false;
+  return NATIVE_CLAUDE_PATTERN.test(model);
 }
 
 // Hardcoded list of "official" Claude tiers shown at the top of /v1/models so
 // the /model picker stays faithful to the native Claude Code experience.
 // Concrete dated IDs let Claude Code resolve the latest variant per tier.
 export const NATIVE_CLAUDE_MODELS: ModelInfo[] = [
-  { type: 'model', id: 'claude-opus-4-5',          display_name: 'Claude Opus 4.5',    created_at: '2025-11-01T00:00:00Z' },
-  { type: 'model', id: 'claude-sonnet-4-6',        display_name: 'Claude Sonnet 4.6',  created_at: '2025-11-01T00:00:00Z' },
-  { type: 'model', id: 'claude-haiku-4-5',         display_name: 'Claude Haiku 4.5',   created_at: '2025-10-01T00:00:00Z' },
-]
+  {
+    type: "model",
+    id: "claude-opus-4-5",
+    display_name: "Claude Opus 4.5",
+    created_at: "2025-11-01T00:00:00Z",
+  },
+  {
+    type: "model",
+    id: "claude-sonnet-4-6",
+    display_name: "Claude Sonnet 4.6",
+    created_at: "2025-11-01T00:00:00Z",
+  },
+  {
+    type: "model",
+    id: "claude-haiku-4-5",
+    display_name: "Claude Haiku 4.5",
+    created_at: "2025-10-01T00:00:00Z",
+  },
+];
 
 export async function streamAnthropicNative(
   req: MessagesRequest,
   providerModel: string,
   timeoutMs: number | undefined,
 ): Promise<StreamResult> {
-  const oauth = readCredentials()?.claudeAiOauth
-  const token = oauth?.accessToken
+  const oauth = readCredentials()?.claudeAiOauth;
+  const token = oauth?.accessToken;
   if (!token) {
     return {
       error: {
         status: 401,
-        message: 'Native Claude models require Claude.ai login. Run `claude login` to enable them.',
+        message: "Native Claude models require Claude.ai login. Run `claude login` to enable them.",
       },
-    }
+    };
   }
-  if (typeof oauth?.expiresAt === 'number' && Date.now() >= oauth.expiresAt) {
+  if (typeof oauth?.expiresAt === "number" && Date.now() >= oauth.expiresAt) {
     return {
       error: {
         status: 401,
-        message: 'Claude.ai OAuth token expired. Open Claude Code (or run `claude login`) to refresh.',
+        message:
+          "Claude.ai OAuth token expired. Open Claude Code (or run `claude login`) to refresh.",
       },
-    }
+    };
   }
 
   // Same defensive body construction as copilot's native path: only forward
@@ -104,48 +120,48 @@ export async function streamAnthropicNative(
     messages: req.messages,
     max_tokens: req.max_tokens,
     stream: true,
-  }
-  if (req.system !== undefined)         body.system         = req.system
-  if (req.tools !== undefined)          body.tools          = req.tools
-  if (req.tool_choice !== undefined)    body.tool_choice    = req.tool_choice
-  if (req.temperature !== undefined)    body.temperature    = req.temperature
-  if (req.top_p !== undefined)          body.top_p          = req.top_p
-  if (req.top_k !== undefined)          body.top_k          = req.top_k
-  if (req.thinking !== undefined)       body.thinking       = req.thinking
-  if (req.metadata !== undefined)       body.metadata       = req.metadata
-  if (req.stop_sequences !== undefined) body.stop_sequences = req.stop_sequences
+  };
+  if (req.system !== undefined) body.system = req.system;
+  if (req.tools !== undefined) body.tools = req.tools;
+  if (req.tool_choice !== undefined) body.tool_choice = req.tool_choice;
+  if (req.temperature !== undefined) body.temperature = req.temperature;
+  if (req.top_p !== undefined) body.top_p = req.top_p;
+  if (req.top_k !== undefined) body.top_k = req.top_k;
+  if (req.thinking !== undefined) body.thinking = req.thinking;
+  if (req.metadata !== undefined) body.metadata = req.metadata;
+  if (req.stop_sequences !== undefined) body.stop_sequences = req.stop_sequences;
 
   const result = await postProviderStream({
     url: `${ANTHROPIC_API_URL}/v1/messages`,
     headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'text/event-stream',
-      'Authorization': `Bearer ${token}`,
-      'anthropic-version': ANTHROPIC_VERSION,
-      'anthropic-beta': ANTHROPIC_OAUTH_BETA,
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+      Authorization: `Bearer ${token}`,
+      "anthropic-version": ANTHROPIC_VERSION,
+      "anthropic-beta": ANTHROPIC_OAUTH_BETA,
     },
     body,
     timeoutMs,
-  })
+  });
 
-  if ('error' in result) return { error: result.error }
+  if ("error" in result) return { error: result.error };
 
   // Anthropic's SSE format is already what Claude Code expects — pipe through.
-  const decoder = new TextDecoder()
+  const decoder = new TextDecoder();
   const stream = new ReadableStream<string>({
     async start(controller) {
-      const reader = result.body.getReader()
+      const reader = result.body.getReader();
       try {
         while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
-          controller.enqueue(decoder.decode(value, { stream: true }))
+          const { done, value } = await reader.read();
+          if (done) break;
+          controller.enqueue(decoder.decode(value, { stream: true }));
         }
       } finally {
-        controller.close()
+        controller.close();
       }
     },
-  })
+  });
 
-  return { stream }
+  return { stream };
 }

--- a/packages/daemon/src/proxy/providers/api-client.test.ts
+++ b/packages/daemon/src/proxy/providers/api-client.test.ts
@@ -1,59 +1,61 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { fetchProviderJson } from './api-client.js'
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fetchProviderJson } from "./api-client.js";
 
-test('fetchProviderJson keeps timeout disabled by default', async () => {
-  let signal: AbortSignal | undefined
-  const originalFetch = globalThis.fetch
+test("fetchProviderJson keeps timeout disabled by default", async () => {
+  let signal: AbortSignal | undefined;
+  const originalFetch = globalThis.fetch;
   globalThis.fetch = async (_url, init) => {
-    signal = init?.signal ?? undefined
-    return new Response(JSON.stringify({ ok: true }), { status: 200 })
-  }
+    signal = init?.signal ?? undefined;
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
 
   try {
-    await fetchProviderJson<{ ok: boolean }>({ url: 'https://example.test/models', headers: {} })
-    assert.equal(signal, undefined)
+    await fetchProviderJson<{ ok: boolean }>({ url: "https://example.test/models", headers: {} });
+    assert.equal(signal, undefined);
   } finally {
-    globalThis.fetch = originalFetch
+    globalThis.fetch = originalFetch;
   }
-})
+});
 
-test('fetchProviderJson passes AbortSignal when timeout is configured', async () => {
-  let signal: AbortSignal | undefined
-  const originalFetch = globalThis.fetch
+test("fetchProviderJson passes AbortSignal when timeout is configured", async () => {
+  let signal: AbortSignal | undefined;
+  const originalFetch = globalThis.fetch;
   globalThis.fetch = async (_url, init) => {
-    signal = init?.signal ?? undefined
-    return new Response(JSON.stringify({ ok: true }), { status: 200 })
-  }
+    signal = init?.signal ?? undefined;
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
 
   try {
     await fetchProviderJson<{ ok: boolean }>({
-      url: 'https://example.test/models',
+      url: "https://example.test/models",
       headers: {},
       timeoutMs: 1000,
-    })
-    assert.ok(signal)
-    assert.equal(signal.aborted, false)
+    });
+    assert.ok(signal);
+    assert.equal(signal.aborted, false);
   } finally {
-    globalThis.fetch = originalFetch
+    globalThis.fetch = originalFetch;
   }
-})
+});
 
-test('fetchProviderJson converts configured timeout into controlled error', async () => {
-  const originalFetch = globalThis.fetch
+test("fetchProviderJson converts configured timeout into controlled error", async () => {
+  const originalFetch = globalThis.fetch;
   globalThis.fetch = async (_url, init) => {
     await new Promise((_resolve, reject) => {
-      init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
-    })
-    return new Response(JSON.stringify({ ok: true }), { status: 200 })
-  }
+      init?.signal?.addEventListener("abort", () =>
+        reject(new DOMException("aborted", "AbortError")),
+      );
+    });
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
 
   try {
     await assert.rejects(
-      fetchProviderJson({ url: 'https://example.test/models', headers: {}, timeoutMs: 1 }),
+      fetchProviderJson({ url: "https://example.test/models", headers: {}, timeoutMs: 1 }),
       /HTTP 504 em https:\/\/example\.test\/models: Provider request timed out/,
-    )
+    );
   } finally {
-    globalThis.fetch = originalFetch
+    globalThis.fetch = originalFetch;
   }
-})
+});

--- a/packages/daemon/src/proxy/providers/api-client.ts
+++ b/packages/daemon/src/proxy/providers/api-client.ts
@@ -1,67 +1,70 @@
-import type { ModelInfo } from '../../core/anthropic/types.js'
+import type { ModelInfo } from "../../core/anthropic/types.js";
 
 interface ProviderFetchOptions {
-  url: string
-  headers: Record<string, string>
-  timeoutMs?: number
+  url: string;
+  headers: Record<string, string>;
+  timeoutMs?: number;
 }
 
 interface ProviderStreamOptions extends ProviderFetchOptions {
-  body: unknown
+  body: unknown;
 }
 
 interface ProviderModel {
-  id: string
-  name?: string
-  created?: number
+  id: string;
+  name?: string;
+  created?: number;
 }
 
 export type ProviderStreamResponse =
   | { body: ReadableStream<Uint8Array> }
-  | { error: { status: number; message: string } }
+  | { error: { status: number; message: string } };
 
-export async function postProviderStream(options: ProviderStreamOptions): Promise<ProviderStreamResponse> {
-  const timeout = createFetchTimeout(options.timeoutMs)
-  let response: Response
+export async function postProviderStream(
+  options: ProviderStreamOptions,
+): Promise<ProviderStreamResponse> {
+  const timeout = createFetchTimeout(options.timeoutMs);
+  let response: Response;
   try {
     response = await fetch(options.url, {
-      method: 'POST',
+      method: "POST",
       headers: options.headers,
       body: JSON.stringify(options.body),
       signal: timeout.signal,
-    })
+    });
   } catch (err) {
-    if (timeout.didAbort()) return { error: timeoutError() }
-    throw err
+    if (timeout.didAbort()) return { error: timeoutError() };
+    throw err;
   } finally {
-    timeout.clear()
+    timeout.clear();
   }
 
-  if (!response.ok) return { error: await readProviderError(response) }
-  if (!response.body) return { error: { status: 500, message: 'Provider returned an empty response body' } }
+  if (!response.ok) return { error: await readProviderError(response) };
+  if (!response.body)
+    return { error: { status: 500, message: "Provider returned an empty response body" } };
 
-  return { body: response.body }
+  return { body: response.body };
 }
 
 export async function fetchProviderJson<T>(options: ProviderFetchOptions): Promise<T> {
-  const timeout = createFetchTimeout(options.timeoutMs)
-  let response: Response
+  const timeout = createFetchTimeout(options.timeoutMs);
+  let response: Response;
   try {
-    response = await fetch(options.url, { headers: options.headers, signal: timeout.signal })
+    response = await fetch(options.url, { headers: options.headers, signal: timeout.signal });
   } catch (err) {
     if (timeout.didAbort()) {
-      const error = timeoutError()
-      throw new Error(`HTTP ${error.status} em ${options.url}: ${error.message}`)
+      const error = timeoutError();
+      throw new Error(`HTTP ${error.status} em ${options.url}: ${error.message}`);
     }
-    throw err
+    throw err;
   } finally {
-    timeout.clear()
+    timeout.clear();
   }
   if (!response.ok) {
-    const error = await readProviderError(response)
-    throw new Error(`HTTP ${error.status} em ${options.url}: ${error.message.slice(0, 300)}`)
+    const error = await readProviderError(response);
+    throw new Error(`HTTP ${error.status} em ${options.url}: ${error.message.slice(0, 300)}`);
   }
-  return await response.json() as T
+  return (await response.json()) as T;
 }
 
 export function mapProviderModels(
@@ -69,35 +72,35 @@ export function mapProviderModels(
   providerId: string,
   label: string,
 ): ModelInfo[] {
-  return models.map(model => ({
-    type: 'model' as const,
+  return models.map((model) => ({
+    type: "model" as const,
     id: `anthropic/${providerId}/${model.id}`,
     display_name: `${label} · ${model.name ?? model.id}`,
     created_at: new Date((model.created ?? 0) * 1000).toISOString(),
-  }))
+  }));
 }
 
 async function readProviderError(response: Response): Promise<{ status: number; message: string }> {
-  const message = await response.text().catch(() => '')
-  return { status: response.status, message }
+  const message = await response.text().catch(() => "");
+  return { status: response.status, message };
 }
 
 function createFetchTimeout(timeoutMs: number | undefined): {
-  signal?: AbortSignal
-  clear: () => void
-  didAbort: () => boolean
+  signal?: AbortSignal;
+  clear: () => void;
+  didAbort: () => boolean;
 } {
-  if (!timeoutMs) return { clear: () => {}, didAbort: () => false }
+  if (!timeoutMs) return { clear: () => {}, didAbort: () => false };
 
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   return {
     signal: controller.signal,
     clear: () => clearTimeout(timer),
     didAbort: () => controller.signal.aborted,
-  }
+  };
 }
 
 function timeoutError(): { status: number; message: string } {
-  return { status: 504, message: 'Provider request timed out' }
+  return { status: 504, message: "Provider request timed out" };
 }

--- a/packages/daemon/src/proxy/providers/base.ts
+++ b/packages/daemon/src/proxy/providers/base.ts
@@ -1,61 +1,70 @@
-import type { MessagesRequest, ModelInfo } from '../../core/anthropic/types.js'
-import type { ProviderConfig } from '../../config/schema.js'
+import type { ProviderConfig } from "../../config/schema.js";
+import type { MessagesRequest, ModelInfo } from "../../core/anthropic/types.js";
 
 export interface StreamResult {
-  stream?: ReadableStream<string>
-  error?: { status: number; message: string }
+  stream?: ReadableStream<string>;
+  error?: { status: number; message: string };
 }
 
 export abstract class BaseProvider {
   constructor(protected readonly config: ProviderConfig) {}
 
-  abstract get id(): string
-  abstract get label(): string
+  abstract get id(): string;
+  abstract get label(): string;
 
-  abstract streamResponse(req: MessagesRequest, inputTokens: number): Promise<StreamResult>
-  abstract listModels(): Promise<ModelInfo[]>
+  abstract streamResponse(req: MessagesRequest, inputTokens: number): Promise<StreamResult>;
+  abstract listModels(): Promise<ModelInfo[]>;
 
   async listEnabledModels(): Promise<ModelInfo[]> {
-    const all = await this.listModels()
-    const disabled = new Set(this.config.disabledModels ?? [])
-    return disabled.size === 0 ? all : all.filter(m => !disabled.has(m.id))
+    const all = await this.listModels();
+    const disabled = new Set(this.config.disabledModels ?? []);
+    return disabled.size === 0 ? all : all.filter((m) => !disabled.has(m.id));
   }
 
-  async testConnection(): Promise<{ ok: boolean; latencyMs: number; modelCount?: number; error?: string }> {
-    const start = Date.now()
+  async testConnection(): Promise<{
+    ok: boolean;
+    latencyMs: number;
+    modelCount?: number;
+    error?: string;
+  }> {
+    const start = Date.now();
     try {
-      const models = await this.listEnabledModels()
-      const latencyMs = Date.now() - start
+      const models = await this.listEnabledModels();
+      const latencyMs = Date.now() - start;
       if (models.length === 0) {
-        return { ok: false, latencyMs, error: 'Nenhum modelo retornado pelo provider' }
+        return { ok: false, latencyMs, error: "Nenhum modelo retornado pelo provider" };
       }
-      return { ok: true, latencyMs, modelCount: models.length }
+      return { ok: true, latencyMs, modelCount: models.length };
     } catch (err) {
-      return { ok: false, latencyMs: Date.now() - start, error: err instanceof Error ? err.message : String(err) }
+      return {
+        ok: false,
+        latencyMs: Date.now() - start,
+        error: err instanceof Error ? err.message : String(err),
+      };
     }
   }
 
   protected baseUrl(): string {
-    return this.config.baseUrl ?? ''
+    return this.config.baseUrl ?? "";
   }
 
   protected authHeader(): string {
-    return `Bearer ${this.config.apiKey ?? ''}`
+    return `Bearer ${this.config.apiKey ?? ""}`;
   }
 
   protected requiresApiKey(): boolean {
-    return true
+    return true;
   }
 
   protected hasApiKey(): boolean {
-    return !!this.config.apiKey?.trim()
+    return !!this.config.apiKey?.trim();
   }
 
   protected missingApiKeyMessage(): string {
-    return `${this.label} API key is missing. Save the API key in Providers before using ${this.id}.`
+    return `${this.label} API key is missing. Save the API key in Providers before using ${this.id}.`;
   }
 
   protected requestTimeoutMs(): number | undefined {
-    return this.config.requestTimeoutMs
+    return this.config.requestTimeoutMs;
   }
 }

--- a/packages/daemon/src/proxy/providers/copilot-auth.ts
+++ b/packages/daemon/src/proxy/providers/copilot-auth.ts
@@ -4,61 +4,63 @@
 //   2. Short-lived Copilot API token (stored in oauth.copilotToken; expires every ~25 minutes).
 // We fetch (1) once via the device flow, then exchange it for (2) on demand.
 
-import type { ProviderOAuthConfig } from '../../config/schema.js'
+import type { ProviderOAuthConfig } from "../../config/schema.js";
 
 // Public client id for the GitHub Copilot CLI / IDE plugins. opencode and other
 // non-Microsoft tools all use this same id; it is not a secret.
-export const COPILOT_CLIENT_ID = 'Iv1.b507a08c87ecfe98'
-export const GITHUB_DEVICE_CODE_URL = 'https://github.com/login/device/code'
-export const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token'
-export const COPILOT_TOKEN_URL = 'https://api.github.com/copilot_internal/v2/token'
-export const COPILOT_USER_URL = 'https://api.github.com/user'
-export const COPILOT_SCOPE = 'read:user'
+export const COPILOT_CLIENT_ID = "Iv1.b507a08c87ecfe98";
+export const GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code";
+export const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
+export const COPILOT_TOKEN_URL = "https://api.github.com/copilot_internal/v2/token";
+export const COPILOT_USER_URL = "https://api.github.com/user";
+export const COPILOT_SCOPE = "read:user";
 
 // Track the latest stable VS Code Copilot Chat extension. If GitHub starts
 // rejecting older clients, bump these together.
-const EDITOR_VERSION = 'vscode/1.99.3'
-const EDITOR_PLUGIN_VERSION = 'copilot-chat/0.26.7'
-const USER_AGENT = 'GitHubCopilotChat/0.26.7'
-const GITHUB_API_VERSION = '2025-04-01'
+const EDITOR_VERSION = "vscode/1.99.3";
+const EDITOR_PLUGIN_VERSION = "copilot-chat/0.26.7";
+const USER_AGENT = "GitHubCopilotChat/0.26.7";
+const GITHUB_API_VERSION = "2025-04-01";
 
 export interface CopilotDeviceCode {
-  device_code: string
-  user_code: string
-  verification_uri: string
-  expires_in: number
-  interval: number
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
 }
 
 export interface CopilotGitHubToken {
-  accessToken: string
-  scope?: string
-  tokenType?: string
+  accessToken: string;
+  scope?: string;
+  tokenType?: string;
 }
 
 export interface CopilotApiToken {
-  token: string
-  expiresAt: number
-  endpoint: string
+  token: string;
+  expiresAt: number;
+  endpoint: string;
 }
 
 export async function startDeviceFlow(): Promise<CopilotDeviceCode> {
   const response = await fetch(GITHUB_DEVICE_CODE_URL, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json',
-      'User-Agent': USER_AGENT,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "User-Agent": USER_AGENT,
     },
     body: JSON.stringify({ client_id: COPILOT_CLIENT_ID, scope: COPILOT_SCOPE }),
-  })
+  });
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    throw new Error(`Copilot device code request failed: HTTP ${response.status} ${text.slice(0, 200)}`)
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `Copilot device code request failed: HTTP ${response.status} ${text.slice(0, 200)}`,
+    );
   }
-  const json = await response.json() as Partial<CopilotDeviceCode>
+  const json = (await response.json()) as Partial<CopilotDeviceCode>;
   if (!json.device_code || !json.user_code || !json.verification_uri) {
-    throw new Error('Copilot device code response missing required fields')
+    throw new Error("Copilot device code response missing required fields");
   }
   return {
     device_code: json.device_code,
@@ -66,127 +68,128 @@ export async function startDeviceFlow(): Promise<CopilotDeviceCode> {
     verification_uri: json.verification_uri,
     expires_in: json.expires_in ?? 900,
     interval: json.interval ?? 5,
-  }
+  };
 }
 
 export type DevicePollResult =
-  | { status: 'pending' }
-  | { status: 'slow_down'; interval: number }
-  | { status: 'success'; token: CopilotGitHubToken }
-  | { status: 'expired' }
-  | { status: 'denied' }
-  | { status: 'error'; error: string }
+  | { status: "pending" }
+  | { status: "slow_down"; interval: number }
+  | { status: "success"; token: CopilotGitHubToken }
+  | { status: "expired" }
+  | { status: "denied" }
+  | { status: "error"; error: string };
 
 export async function pollDeviceFlow(deviceCode: string): Promise<DevicePollResult> {
   const response = await fetch(GITHUB_TOKEN_URL, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json',
-      'User-Agent': USER_AGENT,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "User-Agent": USER_AGENT,
     },
     body: JSON.stringify({
       client_id: COPILOT_CLIENT_ID,
       device_code: deviceCode,
-      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
     }),
-  })
+  });
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    return { status: 'error', error: `HTTP ${response.status} ${text.slice(0, 200)}` }
+    const text = await response.text().catch(() => "");
+    return { status: "error", error: `HTTP ${response.status} ${text.slice(0, 200)}` };
   }
-  const json = await response.json() as Record<string, unknown>
-  const error = typeof json['error'] === 'string' ? json['error'] : null
-  if (error === 'authorization_pending') return { status: 'pending' }
-  if (error === 'slow_down') {
-    const interval = typeof json['interval'] === 'number' ? json['interval'] : 5
-    return { status: 'slow_down', interval }
+  const json = (await response.json()) as Record<string, unknown>;
+  const error = typeof json["error"] === "string" ? json["error"] : null;
+  if (error === "authorization_pending") return { status: "pending" };
+  if (error === "slow_down") {
+    const interval = typeof json["interval"] === "number" ? json["interval"] : 5;
+    return { status: "slow_down", interval };
   }
-  if (error === 'expired_token') return { status: 'expired' }
-  if (error === 'access_denied') return { status: 'denied' }
-  if (error) return { status: 'error', error }
+  if (error === "expired_token") return { status: "expired" };
+  if (error === "access_denied") return { status: "denied" };
+  if (error) return { status: "error", error };
 
-  const accessToken = typeof json['access_token'] === 'string' ? json['access_token'] : ''
-  if (!accessToken) return { status: 'error', error: 'no access_token in response' }
+  const accessToken = typeof json["access_token"] === "string" ? json["access_token"] : "";
+  if (!accessToken) return { status: "error", error: "no access_token in response" };
   return {
-    status: 'success',
+    status: "success",
     token: {
       accessToken,
-      scope: typeof json['scope'] === 'string' ? json['scope'] : undefined,
-      tokenType: typeof json['token_type'] === 'string' ? json['token_type'] : undefined,
+      scope: typeof json["scope"] === "string" ? json["scope"] : undefined,
+      tokenType: typeof json["token_type"] === "string" ? json["token_type"] : undefined,
     },
-  }
+  };
 }
 
 export async function fetchGithubLogin(githubToken: string): Promise<string | undefined> {
   const response = await fetch(COPILOT_USER_URL, {
     headers: {
-      'Authorization': `token ${githubToken}`,
-      'Accept': 'application/vnd.github+json',
-      'User-Agent': USER_AGENT,
+      Authorization: `token ${githubToken}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": USER_AGENT,
     },
-  })
-  if (!response.ok) return undefined
-  const json = await response.json() as { login?: string }
-  return typeof json.login === 'string' ? json.login : undefined
+  });
+  if (!response.ok) return undefined;
+  const json = (await response.json()) as { login?: string };
+  return typeof json.login === "string" ? json.login : undefined;
 }
 
 export async function exchangeForCopilotToken(githubToken: string): Promise<CopilotApiToken> {
   const response = await fetch(COPILOT_TOKEN_URL, {
     headers: {
-      'Authorization': `token ${githubToken}`,
-      'Accept': 'application/json',
-      'User-Agent': USER_AGENT,
-      'Editor-Version': EDITOR_VERSION,
-      'Editor-Plugin-Version': EDITOR_PLUGIN_VERSION,
+      Authorization: `token ${githubToken}`,
+      Accept: "application/json",
+      "User-Agent": USER_AGENT,
+      "Editor-Version": EDITOR_VERSION,
+      "Editor-Plugin-Version": EDITOR_PLUGIN_VERSION,
     },
-  })
+  });
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    throw new Error(`Copilot token exchange failed: HTTP ${response.status} ${text.slice(0, 300)}`)
+    const text = await response.text().catch(() => "");
+    throw new Error(`Copilot token exchange failed: HTTP ${response.status} ${text.slice(0, 300)}`);
   }
-  const json = await response.json() as {
-    token?: string
-    expires_at?: number
-    refresh_in?: number
-    endpoints?: { api?: string }
-  }
-  if (!json.token) throw new Error('Copilot token exchange response missing token')
+  const json = (await response.json()) as {
+    token?: string;
+    expires_at?: number;
+    refresh_in?: number;
+    endpoints?: { api?: string };
+  };
+  if (!json.token) throw new Error("Copilot token exchange response missing token");
   // expires_at is a unix epoch in seconds; fall back to refresh_in (seconds from now) or 25min.
-  const nowSec = Math.floor(Date.now() / 1000)
-  const expiresAtSec = typeof json.expires_at === 'number' && json.expires_at > nowSec
-    ? json.expires_at
-    : nowSec + (typeof json.refresh_in === 'number' ? json.refresh_in : 25 * 60)
+  const nowSec = Math.floor(Date.now() / 1000);
+  const expiresAtSec =
+    typeof json.expires_at === "number" && json.expires_at > nowSec
+      ? json.expires_at
+      : nowSec + (typeof json.refresh_in === "number" ? json.refresh_in : 25 * 60);
   return {
     token: json.token,
     expiresAt: expiresAtSec * 1000,
-    endpoint: json.endpoints?.api ?? 'https://api.individual.githubcopilot.com',
-  }
+    endpoint: json.endpoints?.api ?? "https://api.individual.githubcopilot.com",
+  };
 }
 
 export function isCopilotLoggedIn(oauth: ProviderOAuthConfig | undefined): boolean {
-  return !!oauth?.accessToken
+  return !!oauth?.accessToken;
 }
 
 export function shouldRefreshCopilotToken(oauth: ProviderOAuthConfig | undefined): boolean {
-  if (!oauth?.copilotToken || !oauth.copilotExpiresAt) return true
+  if (!oauth?.copilotToken || !oauth.copilotExpiresAt) return true;
   // Refresh 2 minutes before expiry to absorb skew.
-  return oauth.copilotExpiresAt - Date.now() < 2 * 60 * 1000
+  return oauth.copilotExpiresAt - Date.now() < 2 * 60 * 1000;
 }
 
 export function copilotEditorHeaders(): Record<string, string> {
   return {
-    'Editor-Version': EDITOR_VERSION,
-    'Editor-Plugin-Version': EDITOR_PLUGIN_VERSION,
-    'Copilot-Integration-Id': 'vscode-chat',
-    'User-Agent': USER_AGENT,
+    "Editor-Version": EDITOR_VERSION,
+    "Editor-Plugin-Version": EDITOR_PLUGIN_VERSION,
+    "Copilot-Integration-Id": "vscode-chat",
+    "User-Agent": USER_AGENT,
     // Required by /v1/messages and harmless for /chat/completions. Without
     // this header GitHub may rate-limit aggressively or reject the request.
-    'X-GitHub-Api-Version': GITHUB_API_VERSION,
+    "X-GitHub-Api-Version": GITHUB_API_VERSION,
     // GitHub uses this for billing/rate-limit accounting. "agent" matches the
     // Claude Code use case (multi-turn tool-calling agent).
-    'X-Initiator': 'agent',
+    "X-Initiator": "agent",
     // Opt into the "always-on" preview-features header that the VS Code extension sends.
-    'Openai-Intent': 'conversation-edits',
-  }
+    "Openai-Intent": "conversation-edits",
+  };
 }

--- a/packages/daemon/src/proxy/providers/copilot-catalog.ts
+++ b/packages/daemon/src/proxy/providers/copilot-catalog.ts
@@ -1,53 +1,53 @@
-import type { ModelInfo } from '../../core/anthropic/types.js'
-import { copilotEditorHeaders } from './copilot-auth.js'
+import type { ModelInfo } from "../../core/anthropic/types.js";
+import { copilotEditorHeaders } from "./copilot-auth.js";
 
 interface CopilotApiModel {
-  id: string
-  name?: string
-  vendor?: string
+  id: string;
+  name?: string;
+  vendor?: string;
   capabilities?: {
-    type?: string
-    family?: string
-    supports?: { tool_calls?: boolean; streaming?: boolean }
-  }
-  model_picker_enabled?: boolean
-  policy?: { state?: string; terms?: string }
-  preview?: boolean
-  supported_endpoints?: string[] | null
+    type?: string;
+    family?: string;
+    supports?: { tool_calls?: boolean; streaming?: boolean };
+  };
+  model_picker_enabled?: boolean;
+  policy?: { state?: string; terms?: string };
+  preview?: boolean;
+  supported_endpoints?: string[] | null;
 }
 
 export interface CopilotModel {
-  id: string
-  displayName: string
+  id: string;
+  displayName: string;
 }
 
 export async function listCopilotModels(
   copilotToken: string,
   endpoint: string,
 ): Promise<CopilotModel[]> {
-  const url = `${endpoint.replace(/\/$/, '')}/models`
+  const url = `${endpoint.replace(/\/$/, "")}/models`;
   const response = await fetch(url, {
     headers: {
-      'Authorization': `Bearer ${copilotToken}`,
-      'Accept': 'application/json',
+      Authorization: `Bearer ${copilotToken}`,
+      Accept: "application/json",
       ...copilotEditorHeaders(),
     },
-  })
+  });
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    throw new Error(`Copilot model list failed: HTTP ${response.status} ${text.slice(0, 300)}`)
+    const text = await response.text().catch(() => "");
+    throw new Error(`Copilot model list failed: HTTP ${response.status} ${text.slice(0, 300)}`);
   }
-  const json = await response.json() as { data?: CopilotApiModel[] }
-  const data = Array.isArray(json.data) ? json.data : []
-  const seen = new Set<string>()
-  const result: CopilotModel[] = []
+  const json = (await response.json()) as { data?: CopilotApiModel[] };
+  const data = Array.isArray(json.data) ? json.data : [];
+  const seen = new Set<string>();
+  const result: CopilotModel[] = [];
   for (const model of data) {
-    if (!isAvailableForAccount(model)) continue
-    if (seen.has(model.id)) continue
-    seen.add(model.id)
-    result.push({ id: model.id, displayName: model.name ?? model.id })
+    if (!isAvailableForAccount(model)) continue;
+    if (seen.has(model.id)) continue;
+    seen.add(model.id);
+    result.push({ id: model.id, displayName: model.name ?? model.id });
   }
-  return result
+  return result;
 }
 
 // Mirrors opencode/VS Code Copilot extension behavior: only surface models the
@@ -56,25 +56,28 @@ export async function listCopilotModels(
 // preview/internal models) and `policy.state` (any value other than "enabled"
 // means the user has not accepted terms or the model is disabled for the plan).
 function isAvailableForAccount(model: CopilotApiModel): boolean {
-  if (model.capabilities?.type !== 'chat') return false
-  if (model.model_picker_enabled !== true) return false
+  if (model.capabilities?.type !== "chat") return false;
+  if (model.model_picker_enabled !== true) return false;
   // Some models gate behind terms-of-use; only "enabled" means the account accepted.
-  if (model.policy && model.policy.state && model.policy.state !== 'enabled') return false
+  if (model.policy && model.policy.state && model.policy.state !== "enabled") return false;
   // Preview models are visible in the API but hidden in the picker by opencode/VSCode.
-  if (model.preview === true) return false
+  if (model.preview === true) return false;
   // Codex-style models only expose /responses; our transport speaks /chat/completions,
   // so they would 404 anyway. Models without supported_endpoints declared default to /chat/completions.
-  if (Array.isArray(model.supported_endpoints) && !model.supported_endpoints.includes('/chat/completions')) {
-    return false
+  if (
+    Array.isArray(model.supported_endpoints) &&
+    !model.supported_endpoints.includes("/chat/completions")
+  ) {
+    return false;
   }
-  return true
+  return true;
 }
 
 export function toCopilotModelInfo(model: CopilotModel): ModelInfo {
   return {
-    type: 'model' as const,
+    type: "model" as const,
     id: `anthropic/copilot/${model.id}`,
     display_name: `GitHub Copilot · ${model.displayName}`,
     created_at: new Date(0).toISOString(),
-  }
+  };
 }

--- a/packages/daemon/src/proxy/providers/copilot-chat-stream.ts
+++ b/packages/daemon/src/proxy/providers/copilot-chat-stream.ts
@@ -7,7 +7,7 @@ import {
   sseMessageStart,
   sseMessageStop,
   ssePing,
-} from '../../core/sse/writer.js'
+} from "../../core/sse/writer.js";
 
 export function transformCopilotChatStream(
   body: ReadableStream<Uint8Array>,
@@ -15,116 +15,127 @@ export function transformCopilotChatStream(
   model: string,
   inputTokens: number,
 ): ReadableStream<string> {
-  let buffer = ''
-  let outputTokens = 0
-  let blockStarted = false
-  const toolCallBuffers = new Map<number, { id: string; name: string }>()
-  const textBlockIndex = 0
-  let finished = false
-  const decoder = new TextDecoder()
+  let buffer = "";
+  let outputTokens = 0;
+  let blockStarted = false;
+  const toolCallBuffers = new Map<number, { id: string; name: string }>();
+  const textBlockIndex = 0;
+  let finished = false;
+  const decoder = new TextDecoder();
 
   return new ReadableStream<string>({
     async start(controller) {
-      const reader = body.getReader()
-      const enq = (chunk: string) => controller.enqueue(chunk)
+      const reader = body.getReader();
+      const enq = (chunk: string) => controller.enqueue(chunk);
 
-      enq(ssePing())
-      enq(sseMessageStart(messageId, model, inputTokens))
+      enq(ssePing());
+      enq(sseMessageStart(messageId, model, inputTokens));
 
       try {
         while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
+          const { done, value } = await reader.read();
+          if (done) break;
 
-          buffer += decoder.decode(value, { stream: true })
-          const lines = buffer.split('\n')
-          buffer = lines.pop() ?? ''
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
 
           for (const line of lines) {
-            if (!line.startsWith('data: ')) continue
-            const data = line.slice(6).trim()
-            if (!data || data === '[DONE]') continue
+            if (!line.startsWith("data: ")) continue;
+            const data = line.slice(6).trim();
+            if (!data || data === "[DONE]") continue;
 
-            let chunk: Record<string, unknown>
-            try { chunk = JSON.parse(data) } catch { continue }
-
-            const choices = chunk['choices'] as Array<Record<string, unknown>> | undefined
-            if (!choices?.length) {
-              const usage = chunk['usage'] as Record<string, unknown> | undefined
-              if (usage) outputTokens = (usage['completion_tokens'] as number) ?? outputTokens
-              continue
+            let chunk: Record<string, unknown>;
+            try {
+              chunk = JSON.parse(data);
+            } catch {
+              continue;
             }
 
-            const delta = choices[0]?.['delta'] as Record<string, unknown> | undefined
-            const finishReason = choices[0]?.['finish_reason'] as string | null
+            const choices = chunk["choices"] as Array<Record<string, unknown>> | undefined;
+            if (!choices?.length) {
+              const usage = chunk["usage"] as Record<string, unknown> | undefined;
+              if (usage) outputTokens = (usage["completion_tokens"] as number) ?? outputTokens;
+              continue;
+            }
 
-            const textDelta = delta?.['content'] as string | undefined
+            const delta = choices[0]?.["delta"] as Record<string, unknown> | undefined;
+            const finishReason = choices[0]?.["finish_reason"] as string | null;
+
+            const textDelta = delta?.["content"] as string | undefined;
             if (textDelta) {
               if (!blockStarted) {
-                enq(sseContentBlockStart(textBlockIndex, { type: 'text', text: '' }))
-                blockStarted = true
+                enq(sseContentBlockStart(textBlockIndex, { type: "text", text: "" }));
+                blockStarted = true;
               }
-              enq(sseContentBlockDelta(textBlockIndex, { type: 'text_delta', text: textDelta }))
+              enq(sseContentBlockDelta(textBlockIndex, { type: "text_delta", text: textDelta }));
             }
 
-            const toolCalls = delta?.['tool_calls'] as Array<Record<string, unknown>> | undefined
+            const toolCalls = delta?.["tool_calls"] as Array<Record<string, unknown>> | undefined;
             if (toolCalls) {
               for (const tc of toolCalls) {
-                const idx = tc['index'] as number
+                const idx = tc["index"] as number;
                 if (!toolCallBuffers.has(idx)) {
-                  const fn = tc['function'] as Record<string, unknown>
+                  const fn = tc["function"] as Record<string, unknown>;
                   toolCallBuffers.set(idx, {
-                    id: (tc['id'] as string) ?? `call_${idx}`,
-                    name: (fn?.['name'] as string) ?? '',
-                  })
-                  enq(sseContentBlockStart(textBlockIndex + 1 + idx, {
-                    type: 'tool_use',
-                    id: tc['id'],
-                    name: fn?.['name'],
-                    input: {},
-                  }))
+                    id: (tc["id"] as string) ?? `call_${idx}`,
+                    name: (fn?.["name"] as string) ?? "",
+                  });
+                  enq(
+                    sseContentBlockStart(textBlockIndex + 1 + idx, {
+                      type: "tool_use",
+                      id: tc["id"],
+                      name: fn?.["name"],
+                      input: {},
+                    }),
+                  );
                 }
-                const fn = tc['function'] as Record<string, unknown> | undefined
-                if (fn?.['arguments']) {
-                  enq(sseContentBlockDelta(textBlockIndex + 1 + idx, {
-                    type: 'input_json_delta',
-                    partial_json: fn['arguments'] as string,
-                  }))
+                const fn = tc["function"] as Record<string, unknown> | undefined;
+                if (fn?.["arguments"]) {
+                  enq(
+                    sseContentBlockDelta(textBlockIndex + 1 + idx, {
+                      type: "input_json_delta",
+                      partial_json: fn["arguments"] as string,
+                    }),
+                  );
                 }
               }
             }
 
-            const usage = chunk['usage'] as Record<string, unknown> | undefined
-            if (usage) outputTokens = (usage['completion_tokens'] as number) ?? outputTokens
+            const usage = chunk["usage"] as Record<string, unknown> | undefined;
+            if (usage) outputTokens = (usage["completion_tokens"] as number) ?? outputTokens;
 
             if (finishReason && !finished) {
-              finished = true
-              if (blockStarted) enq(sseContentBlockStop(textBlockIndex))
+              finished = true;
+              if (blockStarted) enq(sseContentBlockStop(textBlockIndex));
               for (const [idx] of toolCallBuffers) {
-                enq(sseContentBlockStop(textBlockIndex + 1 + idx))
+                enq(sseContentBlockStop(textBlockIndex + 1 + idx));
               }
-              const stopReason = finishReason === 'tool_calls' ? 'tool_use'
-                : finishReason === 'length' ? 'max_tokens'
-                : 'end_turn'
-              enq(sseMessageDelta(stopReason, outputTokens))
-              enq(sseMessageStop())
+              const stopReason =
+                finishReason === "tool_calls"
+                  ? "tool_use"
+                  : finishReason === "length"
+                    ? "max_tokens"
+                    : "end_turn";
+              enq(sseMessageDelta(stopReason, outputTokens));
+              enq(sseMessageStop());
             }
           }
         }
 
         if (!finished) {
-          if (blockStarted) enq(sseContentBlockStop(textBlockIndex))
+          if (blockStarted) enq(sseContentBlockStop(textBlockIndex));
           for (const [idx] of toolCallBuffers) {
-            enq(sseContentBlockStop(textBlockIndex + 1 + idx))
+            enq(sseContentBlockStop(textBlockIndex + 1 + idx));
           }
-          enq(sseMessageDelta('end_turn', outputTokens))
-          enq(sseMessageStop())
+          enq(sseMessageDelta("end_turn", outputTokens));
+          enq(sseMessageStop());
         }
       } catch (err) {
-        enq(sseError('api_error', String(err)))
+        enq(sseError("api_error", String(err)));
       } finally {
-        controller.close()
+        controller.close();
       }
     },
-  })
+  });
 }

--- a/packages/daemon/src/proxy/providers/copilot-native-anthropic.ts
+++ b/packages/daemon/src/proxy/providers/copilot-native-anthropic.ts
@@ -1,13 +1,13 @@
-import type { MessagesRequest } from '../../core/anthropic/types.js'
-import { postProviderStream } from './api-client.js'
-import type { StreamResult } from './base.js'
+import type { MessagesRequest } from "../../core/anthropic/types.js";
+import { postProviderStream } from "./api-client.js";
+import type { StreamResult } from "./base.js";
 
 interface NativeAnthropicStreamOptions {
-  req: MessagesRequest
-  providerModel: string
-  endpoint: string
-  headers: Record<string, string>
-  timeoutMs?: number
+  req: MessagesRequest;
+  providerModel: string;
+  endpoint: string;
+  headers: Record<string, string>;
+  timeoutMs?: number;
 }
 
 export async function streamCopilotNativeAnthropic({
@@ -21,54 +21,59 @@ export async function streamCopilotNativeAnthropic({
     url: `${endpoint}/v1/messages`,
     headers: {
       ...headers,
-      'anthropic-version': '2023-06-01',
+      "anthropic-version": "2023-06-01",
     },
     body: buildCopilotAnthropicBody(req, providerModel),
     timeoutMs,
-  })
+  });
 
-  if ('error' in result) return { error: result.error }
+  if ("error" in result) return { error: result.error };
 
-  return { stream: decodeNativeAnthropicStream(result.body) }
+  return { stream: decodeNativeAnthropicStream(result.body) };
 }
 
-export function buildCopilotAnthropicBody(req: MessagesRequest, providerModel: string): Record<string, unknown> {
+export function buildCopilotAnthropicBody(
+  req: MessagesRequest,
+  providerModel: string,
+): Record<string, unknown> {
   const body: Record<string, unknown> = {
     model: providerModel,
     messages: req.messages,
     max_tokens: req.max_tokens,
     stream: true,
-  }
+  };
 
-  if (req.system !== undefined) body.system = req.system
-  if (req.tools !== undefined) body.tools = req.tools
-  if (req.tool_choice !== undefined) body.tool_choice = req.tool_choice
-  if (req.temperature !== undefined) body.temperature = req.temperature
-  if (req.top_p !== undefined) body.top_p = req.top_p
-  if (req.top_k !== undefined) body.top_k = req.top_k
-  if (req.thinking !== undefined) body.thinking = req.thinking
-  if (req.metadata !== undefined) body.metadata = req.metadata
-  if (req.stop_sequences !== undefined) body.stop_sequences = req.stop_sequences
+  if (req.system !== undefined) body.system = req.system;
+  if (req.tools !== undefined) body.tools = req.tools;
+  if (req.tool_choice !== undefined) body.tool_choice = req.tool_choice;
+  if (req.temperature !== undefined) body.temperature = req.temperature;
+  if (req.top_p !== undefined) body.top_p = req.top_p;
+  if (req.top_k !== undefined) body.top_k = req.top_k;
+  if (req.thinking !== undefined) body.thinking = req.thinking;
+  if (req.metadata !== undefined) body.metadata = req.metadata;
+  if (req.stop_sequences !== undefined) body.stop_sequences = req.stop_sequences;
 
-  return body
+  return body;
 }
 
 function decodeNativeAnthropicStream(body: ReadableStream<Uint8Array>): ReadableStream<string> {
-  const decoder = new TextDecoder()
+  const decoder = new TextDecoder();
   return new ReadableStream<string>({
     async start(controller) {
-      const reader = body.getReader()
+      const reader = body.getReader();
       try {
         while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
-          controller.enqueue(decoder.decode(value, { stream: true }))
+          const { done, value } = await reader.read();
+          if (done) break;
+          controller.enqueue(decoder.decode(value, { stream: true }));
         }
       } catch (err) {
-        controller.enqueue(`event: error\ndata: ${JSON.stringify({ type: 'error', error: { type: 'api_error', message: String(err) } })}\n\n`)
+        controller.enqueue(
+          `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: String(err) } })}\n\n`,
+        );
       } finally {
-        controller.close()
+        controller.close();
       }
     },
-  })
+  });
 }

--- a/packages/daemon/src/proxy/providers/copilot.ts
+++ b/packages/daemon/src/proxy/providers/copilot.ts
@@ -1,119 +1,137 @@
-import { randomUUID } from 'node:crypto'
-import { saveConfig } from '../../config/index.js'
-import type { Config, ProviderConfig } from '../../config/schema.js'
-import type { MessagesRequest, ModelInfo } from '../../core/anthropic/types.js'
-import { anthropicToOpenAI } from '../../core/anthropic/conversion.js'
-import { BaseProvider, type StreamResult } from './base.js'
-import { postProviderStream } from './api-client.js'
+import { randomUUID } from "node:crypto";
+import { saveConfig } from "../../config/index.js";
+import type { Config, ProviderConfig } from "../../config/schema.js";
+import { anthropicToOpenAI } from "../../core/anthropic/conversion.js";
+import type { MessagesRequest, ModelInfo } from "../../core/anthropic/types.js";
+import { postProviderStream } from "./api-client.js";
+import { BaseProvider, type StreamResult } from "./base.js";
 import {
   copilotEditorHeaders,
   exchangeForCopilotToken,
   isCopilotLoggedIn,
   shouldRefreshCopilotToken,
-} from './copilot-auth.js'
-import { listCopilotModels, toCopilotModelInfo } from './copilot-catalog.js'
-import { transformCopilotChatStream } from './copilot-chat-stream.js'
-import { streamCopilotNativeAnthropic } from './copilot-native-anthropic.js'
-import { stripGatewayProviderPrefix } from './model-prefix.js'
+} from "./copilot-auth.js";
+import { listCopilotModels, toCopilotModelInfo } from "./copilot-catalog.js";
+import { transformCopilotChatStream } from "./copilot-chat-stream.js";
+import { streamCopilotNativeAnthropic } from "./copilot-native-anthropic.js";
+import { stripGatewayProviderPrefix } from "./model-prefix.js";
 
 export class CopilotProvider extends BaseProvider {
-  constructor(config: ProviderConfig, private readonly rootConfig: Config) {
-    super(config)
+  constructor(
+    config: ProviderConfig,
+    private readonly rootConfig: Config,
+  ) {
+    super(config);
   }
 
-  get id() { return 'copilot' }
-  get label() { return 'GitHub Copilot' }
+  get id() {
+    return "copilot";
+  }
+  get label() {
+    return "GitHub Copilot";
+  }
 
   async streamResponse(req: MessagesRequest, inputTokens: number): Promise<StreamResult> {
     try {
-      await this.ensureFreshCopilotToken()
+      await this.ensureFreshCopilotToken();
     } catch (err) {
-      return { error: { status: 401, message: err instanceof Error ? err.message : String(err) } }
+      return { error: { status: 401, message: err instanceof Error ? err.message : String(err) } };
     }
 
-    const providerModel = this.resolveModel(req.model)
+    const providerModel = this.resolveModel(req.model);
 
     // Native Anthropic protocol on Copilot for claude-* models — preserves
     // tool_use / thinking / citation blocks instead of round-tripping through
     // OpenAI Chat Completions. Avoids fidelity loss for our biggest target
     // (Claude Code talking to Claude through Copilot).
-    if (providerModel.startsWith('claude-')) {
+    if (providerModel.startsWith("claude-")) {
       return streamCopilotNativeAnthropic({
         req,
         providerModel,
         endpoint: this.endpoint(),
         headers: this.copilotHeaders(),
         timeoutMs: this.requestTimeoutMs(),
-      })
+      });
     }
 
-    const openaiReq = anthropicToOpenAI(req, providerModel)
+    const openaiReq = anthropicToOpenAI(req, providerModel);
 
     const result = await postProviderStream({
       url: `${this.endpoint()}/chat/completions`,
       headers: this.copilotHeaders(),
       body: openaiReq,
       timeoutMs: this.requestTimeoutMs(),
-    })
+    });
 
-    if ('error' in result) return { error: result.error }
+    if ("error" in result) return { error: result.error };
 
-    const messageId = `msg_${randomUUID().replace(/-/g, '')}`
-    return { stream: transformCopilotChatStream(result.body, messageId, req.model, inputTokens) }
+    const messageId = `msg_${randomUUID().replace(/-/g, "")}`;
+    return { stream: transformCopilotChatStream(result.body, messageId, req.model, inputTokens) };
   }
 
   async listModels(): Promise<ModelInfo[]> {
-    await this.ensureFreshCopilotToken()
-    const oauth = this.config.oauth!
-    const models = await listCopilotModels(oauth.copilotToken!, this.endpoint())
-    return models.map(toCopilotModelInfo)
+    await this.ensureFreshCopilotToken();
+    const oauth = this.config.oauth!;
+    const models = await listCopilotModels(oauth.copilotToken!, this.endpoint());
+    return models.map(toCopilotModelInfo);
   }
 
-  override async testConnection(): Promise<{ ok: boolean; latencyMs: number; modelCount?: number; error?: string }> {
-    const start = Date.now()
+  override async testConnection(): Promise<{
+    ok: boolean;
+    latencyMs: number;
+    modelCount?: number;
+    error?: string;
+  }> {
+    const start = Date.now();
     try {
-      await this.ensureFreshCopilotToken()
-      const models = await this.listEnabledModels()
-      return { ok: true, latencyMs: Date.now() - start, modelCount: models.length }
+      await this.ensureFreshCopilotToken();
+      const models = await this.listEnabledModels();
+      return { ok: true, latencyMs: Date.now() - start, modelCount: models.length };
     } catch (err) {
-      return { ok: false, latencyMs: Date.now() - start, error: err instanceof Error ? err.message : String(err) }
+      return {
+        ok: false,
+        latencyMs: Date.now() - start,
+        error: err instanceof Error ? err.message : String(err),
+      };
     }
   }
 
   private async ensureFreshCopilotToken(): Promise<void> {
     if (!isCopilotLoggedIn(this.config.oauth)) {
-      throw new Error('GitHub Copilot is not logged in')
+      throw new Error("GitHub Copilot is not logged in");
     }
-    if (!shouldRefreshCopilotToken(this.config.oauth)) return
+    if (!shouldRefreshCopilotToken(this.config.oauth)) return;
 
-    const exchanged = await exchangeForCopilotToken(this.config.oauth!.accessToken!)
+    const exchanged = await exchangeForCopilotToken(this.config.oauth!.accessToken!);
     this.config.oauth = {
       ...this.config.oauth,
       copilotToken: exchanged.token,
       copilotExpiresAt: exchanged.expiresAt,
       copilotEndpoint: exchanged.endpoint,
-    }
-    this.config.authType = 'oauth'
-    this.config.enabled = true
-    saveConfig(this.rootConfig)
+    };
+    this.config.authType = "oauth";
+    this.config.enabled = true;
+    saveConfig(this.rootConfig);
   }
 
   private endpoint(): string {
-    return (this.config.oauth?.copilotEndpoint
-      ?? this.config.baseUrl
-      ?? 'https://api.individual.githubcopilot.com').replace(/\/$/, '')
+    return (
+      this.config.oauth?.copilotEndpoint ??
+      this.config.baseUrl ??
+      "https://api.individual.githubcopilot.com"
+    ).replace(/\/$/, "");
   }
 
   private copilotHeaders(): Record<string, string> {
     return {
-      'Content-Type': 'application/json',
-      'Accept': 'text/event-stream',
-      'Authorization': `Bearer ${this.config.oauth?.copilotToken ?? ''}`,
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+      Authorization: `Bearer ${this.config.oauth?.copilotToken ?? ""}`,
       ...copilotEditorHeaders(),
-    }
+    };
   }
 
   private resolveModel(requestedModel: string): string {
-    return stripGatewayProviderPrefix(requestedModel, this.id)
+    return stripGatewayProviderPrefix(requestedModel, this.id);
   }
 }

--- a/packages/daemon/src/proxy/providers/deepseek.ts
+++ b/packages/daemon/src/proxy/providers/deepseek.ts
@@ -1,18 +1,22 @@
-import { AnthropicMessagesTransport } from './transport-anthropic.js'
-import type { ModelInfo } from '../../core/anthropic/types.js'
-import { fetchProviderJson, mapProviderModels } from './api-client.js'
+import type { ModelInfo } from "../../core/anthropic/types.js";
+import { fetchProviderJson, mapProviderModels } from "./api-client.js";
+import { AnthropicMessagesTransport } from "./transport-anthropic.js";
 
 export class DeepSeekProvider extends AnthropicMessagesTransport {
-  get id() { return 'deepseek' }
-  get label() { return 'DeepSeek' }
+  get id() {
+    return "deepseek";
+  }
+  get label() {
+    return "DeepSeek";
+  }
 
   override async listModels(): Promise<ModelInfo[]> {
-    const url = this.baseUrl().replace(/\/anthropic\/?$/, '') + '/models'
+    const url = this.baseUrl().replace(/\/anthropic\/?$/, "") + "/models";
     const json = await fetchProviderJson<{ data?: Array<{ id: string; created?: number }> }>({
       url,
-      headers: { 'Authorization': this.authHeader() },
+      headers: { Authorization: this.authHeader() },
       timeoutMs: this.requestTimeoutMs(),
-    })
-    return mapProviderModels(json.data ?? [], this.id, this.label)
+    });
+    return mapProviderModels(json.data ?? [], this.id, this.label);
   }
 }

--- a/packages/daemon/src/proxy/providers/google.ts
+++ b/packages/daemon/src/proxy/providers/google.ts
@@ -2,36 +2,40 @@
 // Base URL: https://generativelanguage.googleapis.com/v1beta/openai/
 // Auth: static API key from Google AI Studio (aistudio.google.com)
 
-import { OpenAIChatTransport } from './transport-openai.js'
-import type { ModelInfo } from '../../core/anthropic/types.js'
-import { fetchProviderJson, mapProviderModels } from './api-client.js'
+import type { ModelInfo } from "../../core/anthropic/types.js";
+import { fetchProviderJson, mapProviderModels } from "./api-client.js";
+import { OpenAIChatTransport } from "./transport-openai.js";
 
 export class GoogleProvider extends OpenAIChatTransport {
-  get id() { return 'google' }
-  get label() { return 'Google AI' }
+  get id() {
+    return "google";
+  }
+  get label() {
+    return "Google AI";
+  }
 
   protected resolveModel(requestedModel: string): string {
     // Strip "google/" prefix if routing injected it
-    const parts = requestedModel.split('/')
-    if (parts[0] === 'google') return parts.slice(1).join('/')
-    return requestedModel
+    const parts = requestedModel.split("/");
+    if (parts[0] === "google") return parts.slice(1).join("/");
+    return requestedModel;
   }
 
   override async listModels(): Promise<ModelInfo[]> {
     if (this.requiresApiKey() && !this.hasApiKey()) {
-      throw new Error(this.missingApiKeyMessage())
+      throw new Error(this.missingApiKeyMessage());
     }
 
     // The OpenAI-compat /models endpoint returns the standard {data:[]} shape
-    const url = `${this.baseUrl()}/models`
+    const url = `${this.baseUrl()}/models`;
     const json = await fetchProviderJson<{ data?: Array<{ id: string; created?: number }> }>({
       url,
       headers: {
-        'Authorization': this.authHeader(),
+        Authorization: this.authHeader(),
         ...this.extraHeaders(),
       },
       timeoutMs: this.requestTimeoutMs(),
-    })
-    return mapProviderModels(json.data ?? [], this.id, this.label)
+    });
+    return mapProviderModels(json.data ?? [], this.id, this.label);
   }
 }

--- a/packages/daemon/src/proxy/providers/kimi.ts
+++ b/packages/daemon/src/proxy/providers/kimi.ts
@@ -1,12 +1,16 @@
-import { OpenAIChatTransport } from './transport-openai.js'
+import { OpenAIChatTransport } from "./transport-openai.js";
 
 export class KimiProvider extends OpenAIChatTransport {
-  get id() { return 'kimi' }
-  get label() { return 'Kimi (Moonshot)' }
+  get id() {
+    return "kimi";
+  }
+  get label() {
+    return "Kimi (Moonshot)";
+  }
 
   protected resolveModel(requestedModel: string): string {
-    const parts = requestedModel.split('/')
-    if (parts[0] === 'kimi') return parts.slice(1).join('/')
-    return requestedModel
+    const parts = requestedModel.split("/");
+    if (parts[0] === "kimi") return parts.slice(1).join("/");
+    return requestedModel;
   }
 }

--- a/packages/daemon/src/proxy/providers/llamacpp.ts
+++ b/packages/daemon/src/proxy/providers/llamacpp.ts
@@ -1,10 +1,14 @@
-import { AnthropicMessagesTransport } from './transport-anthropic.js'
+import { AnthropicMessagesTransport } from "./transport-anthropic.js";
 
 export class LlamaCppProvider extends AnthropicMessagesTransport {
-  get id() { return 'llamacpp' }
-  get label() { return 'llama.cpp' }
+  get id() {
+    return "llamacpp";
+  }
+  get label() {
+    return "llama.cpp";
+  }
 
   protected override requiresApiKey(): boolean {
-    return false
+    return false;
   }
 }

--- a/packages/daemon/src/proxy/providers/lmstudio.ts
+++ b/packages/daemon/src/proxy/providers/lmstudio.ts
@@ -1,10 +1,14 @@
-import { AnthropicMessagesTransport } from './transport-anthropic.js'
+import { AnthropicMessagesTransport } from "./transport-anthropic.js";
 
 export class LMStudioProvider extends AnthropicMessagesTransport {
-  get id() { return 'lmstudio' }
-  get label() { return 'LM Studio' }
+  get id() {
+    return "lmstudio";
+  }
+  get label() {
+    return "LM Studio";
+  }
 
   protected override requiresApiKey(): boolean {
-    return false
+    return false;
   }
 }

--- a/packages/daemon/src/proxy/providers/model-prefix.ts
+++ b/packages/daemon/src/proxy/providers/model-prefix.ts
@@ -1,9 +1,9 @@
 export function stripGatewayProviderPrefix(requestedModel: string, providerId: string): string {
-  if (requestedModel.startsWith('anthropic/')) {
-    return requestedModel.slice('anthropic/'.length)
+  if (requestedModel.startsWith("anthropic/")) {
+    return requestedModel.slice("anthropic/".length);
   }
   if (requestedModel.startsWith(`${providerId}/`)) {
-    return requestedModel.slice(providerId.length + 1)
+    return requestedModel.slice(providerId.length + 1);
   }
-  return requestedModel
+  return requestedModel;
 }

--- a/packages/daemon/src/proxy/providers/nvidia-nim.ts
+++ b/packages/daemon/src/proxy/providers/nvidia-nim.ts
@@ -1,13 +1,17 @@
-import { OpenAIChatTransport } from './transport-openai.js'
+import { OpenAIChatTransport } from "./transport-openai.js";
 
 export class NvidiaNimProvider extends OpenAIChatTransport {
-  get id() { return 'nvidia_nim' }
-  get label() { return 'NVIDIA NIM' }
+  get id() {
+    return "nvidia_nim";
+  }
+  get label() {
+    return "NVIDIA NIM";
+  }
 
   protected resolveModel(requestedModel: string): string {
     // If routing sent us "nvidia_nim/some-model", strip the prefix
-    const parts = requestedModel.split('/')
-    if (parts[0] === 'nvidia_nim') return parts.slice(1).join('/')
-    return requestedModel
+    const parts = requestedModel.split("/");
+    if (parts[0] === "nvidia_nim") return parts.slice(1).join("/");
+    return requestedModel;
   }
 }

--- a/packages/daemon/src/proxy/providers/ollama.ts
+++ b/packages/daemon/src/proxy/providers/ollama.ts
@@ -1,16 +1,20 @@
-import { AnthropicMessagesTransport } from './transport-anthropic.js'
+import { AnthropicMessagesTransport } from "./transport-anthropic.js";
 
 export class OllamaProvider extends AnthropicMessagesTransport {
-  get id() { return 'ollama' }
-  get label() { return 'Ollama' }
+  get id() {
+    return "ollama";
+  }
+  get label() {
+    return "Ollama";
+  }
 
   protected override baseUrl(): string {
     // Ollama needs the /v1 appended — base config is just host:port
-    const url = (this.config.baseUrl ?? 'http://localhost:11434').replace(/\/$/, '')
-    return url.endsWith('/v1') ? url : `${url}/v1`
+    const url = (this.config.baseUrl ?? "http://localhost:11434").replace(/\/$/, "");
+    return url.endsWith("/v1") ? url : `${url}/v1`;
   }
 
   protected override requiresApiKey(): boolean {
-    return false
+    return false;
   }
 }

--- a/packages/daemon/src/proxy/providers/openai-account-auth.test.ts
+++ b/packages/daemon/src/proxy/providers/openai-account-auth.test.ts
@@ -1,23 +1,27 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { exchangeAuthorizationCode } from './openai-account-auth.js'
+import assert from "node:assert/strict";
+import test from "node:test";
+import { exchangeAuthorizationCode } from "./openai-account-auth.js";
 
-test('exchangeAuthorizationCode explains OpenAI unsupported region token errors', async () => {
-  const originalFetch = globalThis.fetch
-  globalThis.fetch = (async () => new Response(JSON.stringify({
-    error: {
-      code: 'unsupported_country_region_territory',
-      message: 'Country, region, or territory not supported',
-      type: 'request_forbidden',
-    },
-  }), { status: 403 })) as typeof fetch
+test("exchangeAuthorizationCode explains OpenAI unsupported region token errors", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        error: {
+          code: "unsupported_country_region_territory",
+          message: "Country, region, or territory not supported",
+          type: "request_forbidden",
+        },
+      }),
+      { status: 403 },
+    )) as typeof fetch;
 
   try {
     await assert.rejects(
-      () => exchangeAuthorizationCode('code', 'verifier'),
+      () => exchangeAuthorizationCode("code", "verifier"),
       /outbound network is in an unsupported country, region, or territory/,
-    )
+    );
   } finally {
-    globalThis.fetch = originalFetch
+    globalThis.fetch = originalFetch;
   }
-})
+});

--- a/packages/daemon/src/proxy/providers/openai-account-auth.ts
+++ b/packages/daemon/src/proxy/providers/openai-account-auth.ts
@@ -1,165 +1,177 @@
-import { createHash, randomBytes } from 'node:crypto'
-import type { ProviderOAuthConfig } from '../../config/schema.js'
+import { createHash, randomBytes } from "node:crypto";
+import type { ProviderOAuthConfig } from "../../config/schema.js";
 
-export const OPENAI_ACCOUNT_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
-export const OPENAI_ACCOUNT_AUTHORIZE_URL = 'https://auth.openai.com/oauth/authorize'
-export const OPENAI_ACCOUNT_TOKEN_URL = 'https://auth.openai.com/oauth/token'
-export const OPENAI_ACCOUNT_REDIRECT_URI = 'http://localhost:1455/auth/callback'
-export const OPENAI_ACCOUNT_SCOPE = 'openid profile email offline_access'
-const OPENAI_UNSUPPORTED_REGION_CODE = 'unsupported_country_region_territory'
+export const OPENAI_ACCOUNT_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+export const OPENAI_ACCOUNT_AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
+export const OPENAI_ACCOUNT_TOKEN_URL = "https://auth.openai.com/oauth/token";
+export const OPENAI_ACCOUNT_REDIRECT_URI = "http://localhost:1455/auth/callback";
+export const OPENAI_ACCOUNT_SCOPE = "openid profile email offline_access";
+const OPENAI_UNSUPPORTED_REGION_CODE = "unsupported_country_region_territory";
 
 export interface PkcePair {
-  verifier: string
-  challenge: string
+  verifier: string;
+  challenge: string;
 }
 
 export interface OAuthTokenResult {
-  accessToken: string
-  refreshToken: string
-  expiresAt: number
-  accountId?: string
-  planType?: string
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  accountId?: string;
+  planType?: string;
 }
 
 export function createState(): string {
-  return randomBytes(16).toString('hex')
+  return randomBytes(16).toString("hex");
 }
 
 export function createPkcePair(): PkcePair {
-  const verifier = base64Url(randomBytes(32))
-  const challenge = base64Url(createHash('sha256').update(verifier).digest())
-  return { verifier, challenge }
+  const verifier = base64Url(randomBytes(32));
+  const challenge = base64Url(createHash("sha256").update(verifier).digest());
+  return { verifier, challenge };
 }
 
 export function createAuthorizationUrl(pkce: PkcePair, state: string): string {
-  const url = new URL(OPENAI_ACCOUNT_AUTHORIZE_URL)
-  url.searchParams.set('response_type', 'code')
-  url.searchParams.set('client_id', OPENAI_ACCOUNT_CLIENT_ID)
-  url.searchParams.set('redirect_uri', OPENAI_ACCOUNT_REDIRECT_URI)
-  url.searchParams.set('scope', OPENAI_ACCOUNT_SCOPE)
-  url.searchParams.set('code_challenge', pkce.challenge)
-  url.searchParams.set('code_challenge_method', 'S256')
-  url.searchParams.set('state', state)
-  url.searchParams.set('id_token_add_organizations', 'true')
-  url.searchParams.set('codex_cli_simplified_flow', 'true')
-  url.searchParams.set('originator', 'codex_cli_rs')
-  return url.toString()
+  const url = new URL(OPENAI_ACCOUNT_AUTHORIZE_URL);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", OPENAI_ACCOUNT_CLIENT_ID);
+  url.searchParams.set("redirect_uri", OPENAI_ACCOUNT_REDIRECT_URI);
+  url.searchParams.set("scope", OPENAI_ACCOUNT_SCOPE);
+  url.searchParams.set("code_challenge", pkce.challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("state", state);
+  url.searchParams.set("id_token_add_organizations", "true");
+  url.searchParams.set("codex_cli_simplified_flow", "true");
+  url.searchParams.set("originator", "codex_cli_rs");
+  return url.toString();
 }
 
-export async function exchangeAuthorizationCode(code: string, verifier: string): Promise<OAuthTokenResult> {
+export async function exchangeAuthorizationCode(
+  code: string,
+  verifier: string,
+): Promise<OAuthTokenResult> {
   return exchangeToken({
-    grant_type: 'authorization_code',
+    grant_type: "authorization_code",
     client_id: OPENAI_ACCOUNT_CLIENT_ID,
     code,
     code_verifier: verifier,
     redirect_uri: OPENAI_ACCOUNT_REDIRECT_URI,
-  })
+  });
 }
 
 export async function refreshAccessToken(refreshToken: string): Promise<OAuthTokenResult> {
   return exchangeToken({
-    grant_type: 'refresh_token',
+    grant_type: "refresh_token",
     client_id: OPENAI_ACCOUNT_CLIENT_ID,
     refresh_token: refreshToken,
-  })
+  });
 }
 
 export function isOAuthReady(oauth: ProviderOAuthConfig | undefined): boolean {
-  return !!oauth?.accessToken && !!oauth.refreshToken && !!oauth.accountId
+  return !!oauth?.accessToken && !!oauth.refreshToken && !!oauth.accountId;
 }
 
 export function shouldRefresh(oauth: ProviderOAuthConfig | undefined): boolean {
-  if (!oauth?.accessToken || !oauth.refreshToken || !oauth.expiresAt) return true
-  return oauth.expiresAt - Date.now() < 5 * 60 * 1000
+  if (!oauth?.accessToken || !oauth.refreshToken || !oauth.expiresAt) return true;
+  return oauth.expiresAt - Date.now() < 5 * 60 * 1000;
 }
 
-export function decodeOpenAIAccountClaims(accessToken: string): Pick<OAuthTokenResult, 'accountId' | 'planType'> {
-  const payload = decodeJwt(accessToken)
-  const auth = payload?.['https://api.openai.com/auth'] as Record<string, unknown> | undefined
+export function decodeOpenAIAccountClaims(
+  accessToken: string,
+): Pick<OAuthTokenResult, "accountId" | "planType"> {
+  const payload = decodeJwt(accessToken);
+  const auth = payload?.["https://api.openai.com/auth"] as Record<string, unknown> | undefined;
   return {
-    accountId: typeof auth?.['chatgpt_account_id'] === 'string' ? auth['chatgpt_account_id'] : undefined,
-    planType: typeof auth?.['chatgpt_plan_type'] === 'string' ? auth['chatgpt_plan_type'] : undefined,
-  }
+    accountId:
+      typeof auth?.["chatgpt_account_id"] === "string" ? auth["chatgpt_account_id"] : undefined,
+    planType:
+      typeof auth?.["chatgpt_plan_type"] === "string" ? auth["chatgpt_plan_type"] : undefined,
+  };
 }
 
 async function exchangeToken(params: Record<string, string>): Promise<OAuthTokenResult> {
   const response = await fetch(OPENAI_ACCOUNT_TOKEN_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams(params),
-  })
+  });
 
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    throw new Error(formatTokenExchangeError(response.status, text))
+    const text = await response.text().catch(() => "");
+    throw new Error(formatTokenExchangeError(response.status, text));
   }
 
-  const json = await response.json() as {
-    access_token?: string
-    refresh_token?: string
-    expires_in?: number
-  }
-  if (!json.access_token || !json.refresh_token || typeof json.expires_in !== 'number') {
-    throw new Error('OpenAI OAuth token response did not include access_token, refresh_token, and expires_in')
+  const json = (await response.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+  };
+  if (!json.access_token || !json.refresh_token || typeof json.expires_in !== "number") {
+    throw new Error(
+      "OpenAI OAuth token response did not include access_token, refresh_token, and expires_in",
+    );
   }
 
-  const claims = decodeOpenAIAccountClaims(json.access_token)
+  const claims = decodeOpenAIAccountClaims(json.access_token);
   return {
     accessToken: json.access_token,
     refreshToken: json.refresh_token,
     expiresAt: Date.now() + json.expires_in * 1000,
     ...claims,
-  }
+  };
 }
 
 function formatTokenExchangeError(status: number, body: string): string {
-  const openaiError = parseOpenAIError(body)
+  const openaiError = parseOpenAIError(body);
   if (openaiError?.code === OPENAI_UNSUPPORTED_REGION_CODE) {
     return [
-      'OpenAI OAuth token exchange failed:',
-      'OpenAI rejected the daemon token exchange because the outbound network is in an unsupported country, region, or territory.',
-      'Configure the daemon to use a supported outbound proxy/network and try logging in again.',
+      "OpenAI OAuth token exchange failed:",
+      "OpenAI rejected the daemon token exchange because the outbound network is in an unsupported country, region, or territory.",
+      "Configure the daemon to use a supported outbound proxy/network and try logging in again.",
       `(${OPENAI_UNSUPPORTED_REGION_CODE})`,
-    ].join(' ')
+    ].join(" ");
   }
 
   if (openaiError) {
-    const details = [
-      openaiError.code,
-      openaiError.type,
-      openaiError.message,
-    ].filter(Boolean).join(' ')
-    return `OpenAI OAuth token exchange failed: HTTP ${status} ${details}`.trim()
+    const details = [openaiError.code, openaiError.type, openaiError.message]
+      .filter(Boolean)
+      .join(" ");
+    return `OpenAI OAuth token exchange failed: HTTP ${status} ${details}`.trim();
   }
 
-  return `OpenAI OAuth token exchange failed: HTTP ${status} ${body.slice(0, 300)}`
+  return `OpenAI OAuth token exchange failed: HTTP ${status} ${body.slice(0, 300)}`;
 }
 
 function parseOpenAIError(body: string): { code?: string; message?: string; type?: string } | null {
   try {
-    const parsed = JSON.parse(body) as { error?: { code?: unknown; message?: unknown; type?: unknown } }
-    const error = parsed.error
-    if (!error) return null
+    const parsed = JSON.parse(body) as {
+      error?: { code?: unknown; message?: unknown; type?: unknown };
+    };
+    const error = parsed.error;
+    if (!error) return null;
     return {
-      code: typeof error.code === 'string' ? error.code : undefined,
-      message: typeof error.message === 'string' ? error.message : undefined,
-      type: typeof error.type === 'string' ? error.type : undefined,
-    }
+      code: typeof error.code === "string" ? error.code : undefined,
+      message: typeof error.message === "string" ? error.message : undefined,
+      type: typeof error.type === "string" ? error.type : undefined,
+    };
   } catch {
-    return null
+    return null;
   }
 }
 
 function decodeJwt(token: string): Record<string, unknown> | null {
   try {
-    const payload = token.split('.')[1]
-    if (!payload) return null
-    return JSON.parse(Buffer.from(payload, 'base64url').toString('utf-8')) as Record<string, unknown>
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    return JSON.parse(Buffer.from(payload, "base64url").toString("utf-8")) as Record<
+      string,
+      unknown
+    >;
   } catch {
-    return null
+    return null;
   }
 }
 
 function base64Url(input: Buffer): string {
-  return input.toString('base64url')
+  return input.toString("base64url");
 }

--- a/packages/daemon/src/proxy/providers/openai-account-catalog.ts
+++ b/packages/daemon/src/proxy/providers/openai-account-catalog.ts
@@ -1,168 +1,181 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { getConfigPath } from '../../config/index.js'
-import type { ModelInfo } from '../../core/anthropic/types.js'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getConfigPath } from "../../config/index.js";
+import type { ModelInfo } from "../../core/anthropic/types.js";
 
 interface CodexModelEntry {
-  slug: string
-  display_name?: string
-  description?: string
-  visibility?: string
-  supported_in_api?: boolean
-  base_instructions?: string
-  default_reasoning_level?: string
-  priority?: number
+  slug: string;
+  display_name?: string;
+  description?: string;
+  visibility?: string;
+  supported_in_api?: boolean;
+  base_instructions?: string;
+  default_reasoning_level?: string;
+  priority?: number;
 }
 
 interface ModelsDevModel {
-  id: string
-  name?: string
-  release_date?: string
-  last_updated?: string
+  id: string;
+  name?: string;
+  release_date?: string;
+  last_updated?: string;
 }
 
 interface CachedCatalog {
-  fetchedAt: number
-  codexModels: CodexModelEntry[]
-  modelsDevModels: ModelsDevModel[]
+  fetchedAt: number;
+  codexModels: CodexModelEntry[];
+  modelsDevModels: ModelsDevModel[];
 }
 
 export interface OpenAIAccountModel {
-  id: string
-  displayName: string
-  instructions?: string
-  reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh'
-  priority: number
-  createdAt?: string
+  id: string;
+  displayName: string;
+  instructions?: string;
+  reasoningEffort?: "low" | "medium" | "high" | "xhigh";
+  priority: number;
+  createdAt?: string;
 }
 
-const CODEX_MODELS_URL = 'https://raw.githubusercontent.com/openai/codex/main/codex-rs/models-manager/models.json'
-const MODELS_DEV_URL = 'https://models.dev/api.json'
-const CACHE_TTL_MS = 12 * 60 * 60 * 1000
+const CODEX_MODELS_URL =
+  "https://raw.githubusercontent.com/openai/codex/main/codex-rs/models-manager/models.json";
+const MODELS_DEV_URL = "https://models.dev/api.json";
+const CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 
 const FALLBACK_MODELS: OpenAIAccountModel[] = [
-  { id: 'gpt-5.5', displayName: 'GPT-5.5', reasoningEffort: 'medium', priority: 0 },
-  { id: 'gpt-5.4', displayName: 'gpt-5.4', reasoningEffort: 'medium', priority: 2 },
-  { id: 'gpt-5.4-mini', displayName: 'GPT-5.4-Mini', reasoningEffort: 'medium', priority: 4 },
-  { id: 'gpt-5.3-codex', displayName: 'gpt-5.3-codex', reasoningEffort: 'medium', priority: 6 },
-  { id: 'gpt-5.2', displayName: 'gpt-5.2', reasoningEffort: 'medium', priority: 10 },
-  { id: 'gpt-5.2-codex', displayName: 'gpt-5.2-codex', reasoningEffort: 'medium', priority: 20 },
-  { id: 'gpt-5.1-codex-max', displayName: 'gpt-5.1-codex-max', reasoningEffort: 'medium', priority: 30 },
-  { id: 'gpt-5.1-codex', displayName: 'gpt-5.1-codex', reasoningEffort: 'medium', priority: 31 },
-  { id: 'gpt-5.1-codex-mini', displayName: 'gpt-5.1-codex-mini', reasoningEffort: 'medium', priority: 32 },
-  { id: 'gpt-5.1', displayName: 'gpt-5.1', reasoningEffort: 'medium', priority: 33 },
-]
+  { id: "gpt-5.5", displayName: "GPT-5.5", reasoningEffort: "medium", priority: 0 },
+  { id: "gpt-5.4", displayName: "gpt-5.4", reasoningEffort: "medium", priority: 2 },
+  { id: "gpt-5.4-mini", displayName: "GPT-5.4-Mini", reasoningEffort: "medium", priority: 4 },
+  { id: "gpt-5.3-codex", displayName: "gpt-5.3-codex", reasoningEffort: "medium", priority: 6 },
+  { id: "gpt-5.2", displayName: "gpt-5.2", reasoningEffort: "medium", priority: 10 },
+  { id: "gpt-5.2-codex", displayName: "gpt-5.2-codex", reasoningEffort: "medium", priority: 20 },
+  {
+    id: "gpt-5.1-codex-max",
+    displayName: "gpt-5.1-codex-max",
+    reasoningEffort: "medium",
+    priority: 30,
+  },
+  { id: "gpt-5.1-codex", displayName: "gpt-5.1-codex", reasoningEffort: "medium", priority: 31 },
+  {
+    id: "gpt-5.1-codex-mini",
+    displayName: "gpt-5.1-codex-mini",
+    reasoningEffort: "medium",
+    priority: 32,
+  },
+  { id: "gpt-5.1", displayName: "gpt-5.1", reasoningEffort: "medium", priority: 33 },
+];
 
 const FALLBACK_INSTRUCTIONS = [
-  'You are Codex, a coding agent running in claude-code-provider-gateway.',
-  'Help the user complete software engineering tasks accurately and pragmatically.',
-  'When tools are available, use valid function calls that match the provided schemas.',
-].join('\n')
+  "You are Codex, a coding agent running in claude-code-provider-gateway.",
+  "Help the user complete software engineering tasks accurately and pragmatically.",
+  "When tools are available, use valid function calls that match the provided schemas.",
+].join("\n");
 
-let catalogPromise: Promise<CachedCatalog> | null = null
+let catalogPromise: Promise<CachedCatalog> | null = null;
 
-export async function listOpenAIAccountModels(extraModels: string[] = []): Promise<OpenAIAccountModel[]> {
-  const catalog = await loadCatalog()
-  const official = normalizeCodexModels(catalog.codexModels)
+export async function listOpenAIAccountModels(
+  extraModels: string[] = [],
+): Promise<OpenAIAccountModel[]> {
+  const catalog = await loadCatalog();
+  const official = normalizeCodexModels(catalog.codexModels);
 
   // Only fall back to supplemental/hardcoded lists when official discovery returns nothing.
-  let base: OpenAIAccountModel[]
+  let base: OpenAIAccountModel[];
   if (official.length > 0) {
-    base = official
+    base = official;
   } else {
-    const supplemental = normalizeModelsDev(catalog.modelsDevModels, [])
-    base = supplemental.length > 0 ? supplemental : [...FALLBACK_MODELS]
+    const supplemental = normalizeModelsDev(catalog.modelsDevModels, []);
+    base = supplemental.length > 0 ? supplemental : [...FALLBACK_MODELS];
   }
 
-  const merged = mergeModels(base)
+  const merged = mergeModels(base);
 
   for (const extra of extraModels) {
-    const id = extra.trim()
-    if (!id || merged.some(model => model.id === id)) continue
+    const id = extra.trim();
+    if (!id || merged.some((model) => model.id === id)) continue;
     merged.push({
       id,
       displayName: id,
       instructions: bestInstructionsForModel(id, merged),
       reasoningEffort: bestReasoningEffortForModel(id, merged),
       priority: 1000 + merged.length,
-    })
+    });
   }
 
-  return merged
+  return merged;
 }
 
 export async function getCodexInstructions(modelId: string): Promise<string> {
-  const models = await listOpenAIAccountModels()
-  return bestInstructionsForModel(modelId, models) ?? FALLBACK_INSTRUCTIONS
+  const models = await listOpenAIAccountModels();
+  return bestInstructionsForModel(modelId, models) ?? FALLBACK_INSTRUCTIONS;
 }
 
 export async function getReasoningEffort(
   modelId: string,
-): Promise<'low' | 'medium' | 'high' | 'xhigh'> {
-  const models = await listOpenAIAccountModels()
-  return bestReasoningEffortForModel(modelId, models) ?? 'medium'
+): Promise<"low" | "medium" | "high" | "xhigh"> {
+  const models = await listOpenAIAccountModels();
+  return bestReasoningEffortForModel(modelId, models) ?? "medium";
 }
 
 export function toModelInfo(model: OpenAIAccountModel): ModelInfo {
   return {
-    type: 'model' as const,
+    type: "model" as const,
     id: `anthropic/openai_account/${model.id}`,
     display_name: `OpenAI Account · ${model.displayName}`,
     created_at: model.createdAt ?? new Date(0).toISOString(),
-  }
+  };
 }
 
 async function loadCatalog(): Promise<CachedCatalog> {
-  if (!catalogPromise) catalogPromise = loadCatalogInner()
-  return catalogPromise
+  if (!catalogPromise) catalogPromise = loadCatalogInner();
+  return catalogPromise;
 }
 
 async function loadCatalogInner(): Promise<CachedCatalog> {
-  const cached = readCache()
-  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) return cached
+  const cached = readCache();
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) return cached;
 
-  const fresh = await fetchCatalog().catch(() => null)
+  const fresh = await fetchCatalog().catch(() => null);
   if (fresh) {
-    writeCache(fresh)
-    return fresh
+    writeCache(fresh);
+    return fresh;
   }
 
-  return cached ?? { fetchedAt: 0, codexModels: [], modelsDevModels: [] }
+  return cached ?? { fetchedAt: 0, codexModels: [], modelsDevModels: [] };
 }
 
 async function fetchCatalog(): Promise<CachedCatalog> {
   const [codexModels, modelsDevModels] = await Promise.all([
     fetchCodexModels().catch(() => []),
     fetchModelsDevOpenAI().catch(() => []),
-  ])
-  return { fetchedAt: Date.now(), codexModels, modelsDevModels }
+  ]);
+  return { fetchedAt: Date.now(), codexModels, modelsDevModels };
 }
 
 async function fetchCodexModels(): Promise<CodexModelEntry[]> {
-  const response = await fetch(CODEX_MODELS_URL)
-  if (!response.ok) throw new Error(`Codex model catalog failed: HTTP ${response.status}`)
-  const json = await response.json() as { models?: CodexModelEntry[] }
-  return Array.isArray(json.models) ? json.models : []
+  const response = await fetch(CODEX_MODELS_URL);
+  if (!response.ok) throw new Error(`Codex model catalog failed: HTTP ${response.status}`);
+  const json = (await response.json()) as { models?: CodexModelEntry[] };
+  return Array.isArray(json.models) ? json.models : [];
 }
 
 async function fetchModelsDevOpenAI(): Promise<ModelsDevModel[]> {
-  const response = await fetch(MODELS_DEV_URL)
-  if (!response.ok) throw new Error(`models.dev catalog failed: HTTP ${response.status}`)
-  const json = await response.json() as { openai?: { models?: Record<string, ModelsDevModel> } }
-  return Object.values(json.openai?.models ?? {})
+  const response = await fetch(MODELS_DEV_URL);
+  if (!response.ok) throw new Error(`models.dev catalog failed: HTTP ${response.status}`);
+  const json = (await response.json()) as { openai?: { models?: Record<string, ModelsDevModel> } };
+  return Object.values(json.openai?.models ?? {});
 }
 
 function normalizeCodexModels(models: CodexModelEntry[]): OpenAIAccountModel[] {
   return models
-    .filter(model => model.visibility === 'list' && model.supported_in_api !== false)
-    .filter(model => model.slug.startsWith('gpt-'))
-    .map(model => ({
+    .filter((model) => model.visibility === "list" && model.supported_in_api !== false)
+    .filter((model) => model.slug.startsWith("gpt-"))
+    .map((model) => ({
       id: model.slug,
       displayName: model.display_name ?? model.slug,
       instructions: model.base_instructions,
       reasoningEffort: normalizeReasoningEffort(model.default_reasoning_level),
-      priority: typeof model.priority === 'number' ? model.priority : 100,
-    }))
+      priority: typeof model.priority === "number" ? model.priority : 100,
+    }));
 }
 
 function normalizeModelsDev(
@@ -170,7 +183,7 @@ function normalizeModelsDev(
   official: OpenAIAccountModel[],
 ): OpenAIAccountModel[] {
   return models
-    .filter(model => isLikelyCodexAccountModel(model.id))
+    .filter((model) => isLikelyCodexAccountModel(model.id))
     .map((model, index) => ({
       id: model.id,
       displayName: model.name ?? model.id,
@@ -178,92 +191,99 @@ function normalizeModelsDev(
       reasoningEffort: bestReasoningEffortForModel(model.id, official),
       priority: 200 + index,
       createdAt: dateToIso(model.release_date ?? model.last_updated),
-    }))
+    }));
 }
 
 function mergeModels(models: OpenAIAccountModel[]): OpenAIAccountModel[] {
-  const seen = new Set<string>()
+  const seen = new Set<string>();
   return models
     .sort((a, b) => a.priority - b.priority || a.id.localeCompare(b.id))
-    .filter(model => {
-      if (seen.has(model.id)) return false
-      seen.add(model.id)
-      return true
-    })
+    .filter((model) => {
+      if (seen.has(model.id)) return false;
+      seen.add(model.id);
+      return true;
+    });
 }
 
 function bestInstructionsForModel(
   modelId: string,
   models: OpenAIAccountModel[],
 ): string | undefined {
-  return bestModelMatch(modelId, models)?.instructions
+  return bestModelMatch(modelId, models)?.instructions;
 }
 
 function bestReasoningEffortForModel(
   modelId: string,
   models: OpenAIAccountModel[],
-): 'low' | 'medium' | 'high' | 'xhigh' | undefined {
-  return bestModelMatch(modelId, models)?.reasoningEffort
+): "low" | "medium" | "high" | "xhigh" | undefined {
+  return bestModelMatch(modelId, models)?.reasoningEffort;
 }
 
-function bestModelMatch(modelId: string, models: OpenAIAccountModel[]): OpenAIAccountModel | undefined {
-  const exact = models.find(model => model.id === modelId && model.instructions)
-  if (exact) return exact
+function bestModelMatch(
+  modelId: string,
+  models: OpenAIAccountModel[],
+): OpenAIAccountModel | undefined {
+  const exact = models.find((model) => model.id === modelId && model.instructions);
+  if (exact) return exact;
 
-  const family = modelFamilyPrefix(modelId)
-  return models.find(model => model.id.startsWith(family) && model.instructions)
-    ?? models.find(model => model.id === 'gpt-5.5' && model.instructions)
-    ?? models.find(model => model.instructions)
+  const family = modelFamilyPrefix(modelId);
+  return (
+    models.find((model) => model.id.startsWith(family) && model.instructions) ??
+    models.find((model) => model.id === "gpt-5.5" && model.instructions) ??
+    models.find((model) => model.instructions)
+  );
 }
 
 function modelFamilyPrefix(modelId: string): string {
-  const match = /^gpt-\d+(?:\.\d+)?/.exec(modelId)
-  return match?.[0] ?? modelId
+  const match = /^gpt-\d+(?:\.\d+)?/.exec(modelId);
+  return match?.[0] ?? modelId;
 }
 
 function isLikelyCodexAccountModel(id: string): boolean {
-  return /^gpt-5(?:[.-]|$)/.test(id)
-    && !id.includes('audio')
-    && !id.includes('image')
-    && !id.includes('transcribe')
-    && !id.includes('tts')
+  return (
+    /^gpt-5(?:[.-]|$)/.test(id) &&
+    !id.includes("audio") &&
+    !id.includes("image") &&
+    !id.includes("transcribe") &&
+    !id.includes("tts")
+  );
 }
 
-function normalizeReasoningEffort(value: unknown): 'low' | 'medium' | 'high' | 'xhigh' | undefined {
-  return value === 'low' || value === 'medium' || value === 'high' || value === 'xhigh'
+function normalizeReasoningEffort(value: unknown): "low" | "medium" | "high" | "xhigh" | undefined {
+  return value === "low" || value === "medium" || value === "high" || value === "xhigh"
     ? value
-    : undefined
+    : undefined;
 }
 
 function dateToIso(value: string | undefined): string | undefined {
-  if (!value) return undefined
-  const date = new Date(value)
-  return Number.isNaN(date.valueOf()) ? undefined : date.toISOString()
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.valueOf()) ? undefined : date.toISOString();
 }
 
 function readCache(): CachedCatalog | null {
   try {
-    const path = cachePath()
-    if (!existsSync(path)) return null
-    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as CachedCatalog
-    if (!Array.isArray(parsed.codexModels) || !Array.isArray(parsed.modelsDevModels)) return null
-    return parsed
+    const path = cachePath();
+    if (!existsSync(path)) return null;
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as CachedCatalog;
+    if (!Array.isArray(parsed.codexModels) || !Array.isArray(parsed.modelsDevModels)) return null;
+    return parsed;
   } catch {
-    return null
+    return null;
   }
 }
 
 function writeCache(catalog: CachedCatalog): void {
   try {
-    const path = cachePath()
-    const dir = dirname(path)
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
-    writeFileSync(path, JSON.stringify(catalog, null, 2), 'utf-8')
+    const path = cachePath();
+    const dir = dirname(path);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(path, JSON.stringify(catalog, null, 2), "utf-8");
   } catch {
     // Cache writes are best-effort; model listing must still work.
   }
 }
 
 function cachePath(): string {
-  return join(dirname(getConfigPath()), 'openai-account-catalog.json')
+  return join(dirname(getConfigPath()), "openai-account-catalog.json");
 }

--- a/packages/daemon/src/proxy/providers/openai-account-responses.ts
+++ b/packages/daemon/src/proxy/providers/openai-account-responses.ts
@@ -1,36 +1,36 @@
-import type { ContentBlock, MessagesRequest } from '../../core/anthropic/types.js'
-import { getCodexInstructions, getReasoningEffort } from './openai-account-catalog.js'
+import type { ContentBlock, MessagesRequest } from "../../core/anthropic/types.js";
+import { getCodexInstructions, getReasoningEffort } from "./openai-account-catalog.js";
 
 export interface ResponsesRequest {
-  model: string
-  input: ResponsesInputItem[]
-  instructions: string
-  stream: true
-  temperature?: number
-  top_p?: number
-  tools?: ResponsesTool[]
-  tool_choice?: 'auto' | 'required' | { type: 'function'; name: string }
-  store: false
-  reasoning: { effort: 'low' | 'medium' | 'high' | 'xhigh'; summary: 'auto' }
-  text: { verbosity: 'medium' }
-  include: string[]
+  model: string;
+  input: ResponsesInputItem[];
+  instructions: string;
+  stream: true;
+  temperature?: number;
+  top_p?: number;
+  tools?: ResponsesTool[];
+  tool_choice?: "auto" | "required" | { type: "function"; name: string };
+  store: false;
+  reasoning: { effort: "low" | "medium" | "high" | "xhigh"; summary: "auto" };
+  text: { verbosity: "medium" };
+  include: string[];
 }
 
 type ResponsesInputItem =
-  | { type: 'message'; role: 'developer' | 'user' | 'assistant'; content: ResponsesContentPart[] }
-  | { type: 'function_call'; call_id: string; name: string; arguments: string }
-  | { type: 'function_call_output'; call_id: string; output: string }
+  | { type: "message"; role: "developer" | "user" | "assistant"; content: ResponsesContentPart[] }
+  | { type: "function_call"; call_id: string; name: string; arguments: string }
+  | { type: "function_call_output"; call_id: string; output: string };
 
 type ResponsesContentPart =
-  | { type: 'input_text'; text: string }
-  | { type: 'output_text'; text: string }
-  | { type: 'input_image'; image_url: string }
+  | { type: "input_text"; text: string }
+  | { type: "output_text"; text: string }
+  | { type: "input_image"; image_url: string };
 
 interface ResponsesTool {
-  type: 'function'
-  name: string
-  description?: string
-  parameters: Record<string, unknown>
+  type: "function";
+  name: string;
+  description?: string;
+  parameters: Record<string, unknown>;
 }
 
 export async function buildOpenAIAccountResponsesRequest(
@@ -43,120 +43,130 @@ export async function buildOpenAIAccountResponsesRequest(
     instructions: await getCodexInstructions(model),
     stream: true,
     store: false,
-    reasoning: { effort: await getReasoningEffort(model), summary: 'auto' },
-    text: { verbosity: 'medium' },
-    include: ['reasoning.encrypted_content'],
-  }
+    reasoning: { effort: await getReasoningEffort(model), summary: "auto" },
+    text: { verbosity: "medium" },
+    include: ["reasoning.encrypted_content"],
+  };
 
-  if (req.temperature !== undefined) body.temperature = req.temperature
-  if (req.top_p !== undefined) body.top_p = req.top_p
-  if (req.tools?.length) applyTools(req, body)
+  if (req.temperature !== undefined) body.temperature = req.temperature;
+  if (req.top_p !== undefined) body.top_p = req.top_p;
+  if (req.tools?.length) applyTools(req, body);
 
-  return body
+  return body;
 }
 
 function toResponsesInput(req: MessagesRequest): ResponsesInputItem[] {
-  const input: ResponsesInputItem[] = []
-  const system = typeof req.system === 'string'
-    ? req.system
-    : req.system?.map(part => part.text).join('\n')
+  const input: ResponsesInputItem[] = [];
+  const system =
+    typeof req.system === "string" ? req.system : req.system?.map((part) => part.text).join("\n");
 
   if (system) {
-    input.push({ type: 'message', role: 'developer', content: [{ type: 'input_text', text: system }] })
+    input.push({
+      type: "message",
+      role: "developer",
+      content: [{ type: "input_text", text: system }],
+    });
   }
 
   for (const message of req.messages) {
-    if (typeof message.content === 'string') {
+    if (typeof message.content === "string") {
       input.push({
-        type: 'message',
+        type: "message",
         role: message.role,
-        content: [{ type: message.role === 'assistant' ? 'output_text' : 'input_text', text: message.content }],
-      })
-      continue
+        content: [
+          {
+            type: message.role === "assistant" ? "output_text" : "input_text",
+            text: message.content,
+          },
+        ],
+      });
+      continue;
     }
 
-    if (message.role === 'assistant') {
-      pushAssistantContent(input, message.content)
-      continue
+    if (message.role === "assistant") {
+      pushAssistantContent(input, message.content);
+      continue;
     }
 
-    pushUserContent(input, message.content)
+    pushUserContent(input, message.content);
   }
 
-  return input
+  return input;
 }
 
 function pushAssistantContent(input: ResponsesInputItem[], content: ContentBlock[]): void {
   const text = content
-    .filter(block => block.type === 'text')
-    .map(block => block.text)
-    .join('')
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("");
 
-  if (text) input.push({ type: 'message', role: 'assistant', content: [{ type: 'output_text', text }] })
+  if (text)
+    input.push({ type: "message", role: "assistant", content: [{ type: "output_text", text }] });
 
   for (const block of content) {
-    if (block.type === 'tool_use') {
+    if (block.type === "tool_use") {
       input.push({
-        type: 'function_call',
+        type: "function_call",
         call_id: block.id,
         name: block.name,
         arguments: JSON.stringify(block.input),
-      })
+      });
     }
   }
 }
 
 function pushUserContent(input: ResponsesInputItem[], content: ContentBlock[]): void {
-  const contentParts = userContentToResponses(content)
-  if (contentParts.length) input.push({ type: 'message', role: 'user', content: contentParts })
+  const contentParts = userContentToResponses(content);
+  if (contentParts.length) input.push({ type: "message", role: "user", content: contentParts });
 
   for (const block of content) {
-    if (block.type === 'tool_result') {
+    if (block.type === "tool_result") {
       input.push({
-        type: 'function_call_output',
+        type: "function_call_output",
         call_id: block.tool_use_id,
         output: toolResultText(block.content),
-      })
+      });
     }
   }
 }
 
 function userContentToResponses(content: ContentBlock[]): ResponsesContentPart[] {
-  const parts: ResponsesContentPart[] = []
+  const parts: ResponsesContentPart[] = [];
   for (const block of content) {
-    if (block.type === 'text') parts.push({ type: 'input_text', text: block.text })
-    if (block.type === 'image') {
-      const imageUrl = block.source.type === 'base64'
-        ? `data:${block.source.media_type};base64,${block.source.data}`
-        : block.source.url
-      parts.push({ type: 'input_image', image_url: imageUrl })
+    if (block.type === "text") parts.push({ type: "input_text", text: block.text });
+    if (block.type === "image") {
+      const imageUrl =
+        block.source.type === "base64"
+          ? `data:${block.source.media_type};base64,${block.source.data}`
+          : block.source.url;
+      parts.push({ type: "input_image", image_url: imageUrl });
     }
-    if (block.type === 'document' && block.source.type === 'text') {
-      parts.push({ type: 'input_text', text: block.source.text })
+    if (block.type === "document" && block.source.type === "text") {
+      parts.push({ type: "input_text", text: block.source.text });
     }
   }
-  return parts
+  return parts;
 }
 
 function applyTools(req: MessagesRequest, body: ResponsesRequest): void {
-  body.tools = req.tools!.map(tool => ({
-    type: 'function',
+  body.tools = req.tools!.map((tool) => ({
+    type: "function",
     name: tool.name,
     description: tool.description,
     parameters: tool.input_schema,
-  }))
+  }));
 
-  if (req.tool_choice?.type === 'auto') body.tool_choice = 'auto'
-  if (req.tool_choice?.type === 'any') body.tool_choice = 'required'
-  if (req.tool_choice?.type === 'tool' && req.tool_choice.name) {
-    body.tool_choice = { type: 'function', name: req.tool_choice.name }
+  if (req.tool_choice?.type === "auto") body.tool_choice = "auto";
+  if (req.tool_choice?.type === "any") body.tool_choice = "required";
+  if (req.tool_choice?.type === "tool" && req.tool_choice.name) {
+    body.tool_choice = { type: "function", name: req.tool_choice.name };
   }
 }
 
 function toolResultText(content: string | ContentBlock[]): string {
-  if (typeof content === 'string') return content
+  if (typeof content === "string") return content;
   return content
-    .filter(block => block.type === 'text')
-    .map(block => block.text)
-    .join('')
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("");
 }

--- a/packages/daemon/src/proxy/providers/openai-account-stream.ts
+++ b/packages/daemon/src/proxy/providers/openai-account-stream.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto'
+import { randomUUID } from "node:crypto";
 import {
   sseContentBlockDelta,
   sseContentBlockStart,
@@ -8,7 +8,7 @@ import {
   sseMessageStart,
   sseMessageStop,
   ssePing,
-} from '../../core/sse/writer.js'
+} from "../../core/sse/writer.js";
 
 export function transformOpenAIAccountResponsesStream(
   body: ReadableStream<Uint8Array>,
@@ -16,110 +16,121 @@ export function transformOpenAIAccountResponsesStream(
   model: string,
   inputTokens: number,
 ): ReadableStream<string> {
-  let buffer = ''
-  let textBlockIndex = -1
-  let nextAvailableIndex = 0
-  let outputTokens = 0
-  let finished = false
-  const toolBlocks = new Map<string, { index: number; id: string; name: string }>()
-  const decoder = new TextDecoder()
+  let buffer = "";
+  let textBlockIndex = -1;
+  let nextAvailableIndex = 0;
+  let outputTokens = 0;
+  let finished = false;
+  const toolBlocks = new Map<string, { index: number; id: string; name: string }>();
+  const decoder = new TextDecoder();
 
   return new ReadableStream<string>({
     async start(controller) {
-      const reader = body.getReader()
-      const enq = (chunk: string) => controller.enqueue(chunk)
+      const reader = body.getReader();
+      const enq = (chunk: string) => controller.enqueue(chunk);
 
-      enq(ssePing())
-      enq(sseMessageStart(messageId, model, inputTokens))
+      enq(ssePing());
+      enq(sseMessageStart(messageId, model, inputTokens));
 
       const closeOpenBlocks = () => {
-        if (textBlockIndex !== -1) enq(sseContentBlockStop(textBlockIndex))
-        for (const tool of toolBlocks.values()) enq(sseContentBlockStop(tool.index))
-      }
+        if (textBlockIndex !== -1) enq(sseContentBlockStop(textBlockIndex));
+        for (const tool of toolBlocks.values()) enq(sseContentBlockStop(tool.index));
+      };
 
       try {
         while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
+          const { done, value } = await reader.read();
+          if (done) break;
 
-          buffer += decoder.decode(value, { stream: true })
-          const lines = buffer.split('\n')
-          buffer = lines.pop() ?? ''
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
 
           for (const line of lines) {
-            if (!line.startsWith('data: ')) continue
-            const data = line.slice(6).trim()
-            if (!data || data === '[DONE]') continue
+            if (!line.startsWith("data: ")) continue;
+            const data = line.slice(6).trim();
+            if (!data || data === "[DONE]") continue;
 
-            let event: Record<string, unknown>
-            try { event = JSON.parse(data) } catch { continue }
-            const type = String(event['type'] ?? '')
+            let event: Record<string, unknown>;
+            try {
+              event = JSON.parse(data);
+            } catch {
+              continue;
+            }
+            const type = String(event["type"] ?? "");
 
-            if (type === 'response.output_text.delta') {
-              const delta = typeof event['delta'] === 'string' ? event['delta'] : ''
-              if (!delta) continue
+            if (type === "response.output_text.delta") {
+              const delta = typeof event["delta"] === "string" ? event["delta"] : "";
+              if (!delta) continue;
               if (textBlockIndex === -1) {
-                textBlockIndex = nextAvailableIndex++
-                enq(sseContentBlockStart(textBlockIndex, { type: 'text', text: '' }))
+                textBlockIndex = nextAvailableIndex++;
+                enq(sseContentBlockStart(textBlockIndex, { type: "text", text: "" }));
               }
-              enq(sseContentBlockDelta(textBlockIndex, { type: 'text_delta', text: delta }))
+              enq(sseContentBlockDelta(textBlockIndex, { type: "text_delta", text: delta }));
             }
 
-            if (type === 'response.output_item.added') {
-              const item = event['item'] as Record<string, unknown> | undefined
-              if (item?.['type'] === 'function_call') {
-                const callKey = String(item['id'] ?? item['call_id'] ?? randomUUID())
+            if (type === "response.output_item.added") {
+              const item = event["item"] as Record<string, unknown> | undefined;
+              if (item?.["type"] === "function_call") {
+                const callKey = String(item["id"] ?? item["call_id"] ?? randomUUID());
                 if (!toolBlocks.has(callKey)) {
-                  const blockIndex = nextAvailableIndex++
+                  const blockIndex = nextAvailableIndex++;
                   toolBlocks.set(callKey, {
                     index: blockIndex,
-                    id: String(item['call_id'] ?? callKey),
-                    name: String(item['name'] ?? ''),
-                  })
-                  enq(sseContentBlockStart(blockIndex, {
-                    type: 'tool_use',
-                    id: String(item['call_id'] ?? callKey),
-                    name: String(item['name'] ?? ''),
-                    input: {},
-                  }))
+                    id: String(item["call_id"] ?? callKey),
+                    name: String(item["name"] ?? ""),
+                  });
+                  enq(
+                    sseContentBlockStart(blockIndex, {
+                      type: "tool_use",
+                      id: String(item["call_id"] ?? callKey),
+                      name: String(item["name"] ?? ""),
+                      input: {},
+                    }),
+                  );
                 }
               }
             }
 
-            if (type === 'response.function_call_arguments.delta') {
-              const itemId = String(event['item_id'] ?? event['output_index'] ?? '')
-              const tool = toolBlocks.get(itemId) ?? Array.from(toolBlocks.values()).at(-1)
-              const delta = typeof event['delta'] === 'string' ? event['delta'] : ''
+            if (type === "response.function_call_arguments.delta") {
+              const itemId = String(event["item_id"] ?? event["output_index"] ?? "");
+              const tool = toolBlocks.get(itemId) ?? Array.from(toolBlocks.values()).at(-1);
+              const delta = typeof event["delta"] === "string" ? event["delta"] : "";
               if (tool && delta) {
-                enq(sseContentBlockDelta(tool.index, { type: 'input_json_delta', partial_json: delta }))
+                enq(
+                  sseContentBlockDelta(tool.index, {
+                    type: "input_json_delta",
+                    partial_json: delta,
+                  }),
+                );
               }
             }
 
-            if (type === 'response.completed') {
-              const response = event['response'] as Record<string, unknown> | undefined
-              const usage = response?.['usage'] as Record<string, unknown> | undefined
-              outputTokens = numberValue(usage?.['output_tokens']) ?? outputTokens
-              finished = true
+            if (type === "response.completed") {
+              const response = event["response"] as Record<string, unknown> | undefined;
+              const usage = response?.["usage"] as Record<string, unknown> | undefined;
+              outputTokens = numberValue(usage?.["output_tokens"]) ?? outputTokens;
+              finished = true;
             }
           }
         }
 
-        closeOpenBlocks()
-        enq(sseMessageDelta(toolBlocks.size ? 'tool_use' : 'end_turn', outputTokens))
-        enq(sseMessageStop())
+        closeOpenBlocks();
+        enq(sseMessageDelta(toolBlocks.size ? "tool_use" : "end_turn", outputTokens));
+        enq(sseMessageStop());
       } catch (err) {
-        closeOpenBlocks()
-        enq(sseError('api_error', String(err)))
+        closeOpenBlocks();
+        enq(sseError("api_error", String(err)));
       } finally {
         if (!finished && textBlockIndex === -1 && toolBlocks.size === 0) {
-          enq(sseError('api_error', 'OpenAI Account stream ended without a completed response'))
+          enq(sseError("api_error", "OpenAI Account stream ended without a completed response"));
         }
-        controller.close()
+        controller.close();
       }
     },
-  })
+  });
 }
 
 function numberValue(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }

--- a/packages/daemon/src/proxy/providers/openai-account.ts
+++ b/packages/daemon/src/proxy/providers/openai-account.ts
@@ -1,94 +1,109 @@
-import { randomUUID } from 'node:crypto'
-import { saveConfig } from '../../config/index.js'
-import type { Config, ProviderConfig } from '../../config/schema.js'
-import type { MessagesRequest, ModelInfo } from '../../core/anthropic/types.js'
-import { BaseProvider, type StreamResult } from './base.js'
-import { postProviderStream } from './api-client.js'
-import { stripGatewayProviderPrefix } from './model-prefix.js'
-import { isOAuthReady, refreshAccessToken, shouldRefresh } from './openai-account-auth.js'
-import {
-  listOpenAIAccountModels,
-  toModelInfo,
-} from './openai-account-catalog.js'
-import { buildOpenAIAccountResponsesRequest } from './openai-account-responses.js'
-import { transformOpenAIAccountResponsesStream } from './openai-account-stream.js'
+import { randomUUID } from "node:crypto";
+import { saveConfig } from "../../config/index.js";
+import type { Config, ProviderConfig } from "../../config/schema.js";
+import type { MessagesRequest, ModelInfo } from "../../core/anthropic/types.js";
+import { postProviderStream } from "./api-client.js";
+import { BaseProvider, type StreamResult } from "./base.js";
+import { stripGatewayProviderPrefix } from "./model-prefix.js";
+import { isOAuthReady, refreshAccessToken, shouldRefresh } from "./openai-account-auth.js";
+import { listOpenAIAccountModels, toModelInfo } from "./openai-account-catalog.js";
+import { buildOpenAIAccountResponsesRequest } from "./openai-account-responses.js";
+import { transformOpenAIAccountResponsesStream } from "./openai-account-stream.js";
 
 export class OpenAIAccountProvider extends BaseProvider {
-  constructor(config: ProviderConfig, private readonly rootConfig: Config) {
-    super(config)
+  constructor(
+    config: ProviderConfig,
+    private readonly rootConfig: Config,
+  ) {
+    super(config);
   }
 
-  get id() { return 'openai_account' }
-  get label() { return 'OpenAI Account' }
+  get id() {
+    return "openai_account";
+  }
+  get label() {
+    return "OpenAI Account";
+  }
 
   async streamResponse(req: MessagesRequest, inputTokens: number): Promise<StreamResult> {
     try {
-      await this.ensureFreshToken()
+      await this.ensureFreshToken();
     } catch (err) {
-      return { error: { status: 401, message: err instanceof Error ? err.message : String(err) } }
+      return { error: { status: 401, message: err instanceof Error ? err.message : String(err) } };
     }
 
-    const model = this.resolveModel(req.model)
+    const model = this.resolveModel(req.model);
     const result = await postProviderStream({
       url: `${this.baseUrl()}/codex/responses`,
       headers: this.codexHeaders(),
       body: await buildOpenAIAccountResponsesRequest(req, model),
       timeoutMs: this.requestTimeoutMs(),
-    })
+    });
 
-    if ('error' in result) return { error: result.error }
+    if ("error" in result) return { error: result.error };
 
-    const messageId = `msg_${randomUUID().replace(/-/g, '')}`
-    return { stream: transformOpenAIAccountResponsesStream(result.body, messageId, req.model, inputTokens) }
+    const messageId = `msg_${randomUUID().replace(/-/g, "")}`;
+    return {
+      stream: transformOpenAIAccountResponsesStream(result.body, messageId, req.model, inputTokens),
+    };
   }
 
   async listModels(): Promise<ModelInfo[]> {
-    return (await listOpenAIAccountModels(this.config.models)).map(toModelInfo)
+    return (await listOpenAIAccountModels(this.config.models)).map(toModelInfo);
   }
 
-  override async testConnection(): Promise<{ ok: boolean; latencyMs: number; modelCount?: number; error?: string }> {
-    const start = Date.now()
+  override async testConnection(): Promise<{
+    ok: boolean;
+    latencyMs: number;
+    modelCount?: number;
+    error?: string;
+  }> {
+    const start = Date.now();
     try {
-      await this.ensureFreshToken()
-      const models = await this.listEnabledModels()
-      return { ok: true, latencyMs: Date.now() - start, modelCount: models.length }
+      await this.ensureFreshToken();
+      const models = await this.listEnabledModels();
+      return { ok: true, latencyMs: Date.now() - start, modelCount: models.length };
     } catch (err) {
-      return { ok: false, latencyMs: Date.now() - start, error: err instanceof Error ? err.message : String(err) }
+      return {
+        ok: false,
+        latencyMs: Date.now() - start,
+        error: err instanceof Error ? err.message : String(err),
+      };
     }
   }
 
   private async ensureFreshToken(): Promise<void> {
     if (!isOAuthReady(this.config.oauth)) {
-      throw new Error('OpenAI Account is not logged in')
+      throw new Error("OpenAI Account is not logged in");
     }
-    if (!shouldRefresh(this.config.oauth)) return
+    if (!shouldRefresh(this.config.oauth)) return;
 
-    const refreshed = await refreshAccessToken(this.config.oauth!.refreshToken!)
+    const refreshed = await refreshAccessToken(this.config.oauth!.refreshToken!);
     this.config.oauth = {
       accessToken: refreshed.accessToken,
       refreshToken: refreshed.refreshToken,
       expiresAt: refreshed.expiresAt,
       accountId: refreshed.accountId ?? this.config.oauth?.accountId,
       planType: refreshed.planType ?? this.config.oauth?.planType,
-    }
-    this.config.authType = 'oauth'
-    this.config.enabled = true
-    saveConfig(this.rootConfig)
+    };
+    this.config.authType = "oauth";
+    this.config.enabled = true;
+    saveConfig(this.rootConfig);
   }
 
   private codexHeaders(): Record<string, string> {
-    const oauth = this.config.oauth
+    const oauth = this.config.oauth;
     return {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${oauth?.accessToken ?? ''}`,
-      'OpenAI-Beta': 'responses=experimental',
-      'chatgpt-account-id': oauth?.accountId ?? '',
-      'originator': 'codex_cli_rs',
-      'Accept': 'text/event-stream',
-    }
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${oauth?.accessToken ?? ""}`,
+      "OpenAI-Beta": "responses=experimental",
+      "chatgpt-account-id": oauth?.accountId ?? "",
+      originator: "codex_cli_rs",
+      Accept: "text/event-stream",
+    };
   }
 
   private resolveModel(requestedModel: string): string {
-    return stripGatewayProviderPrefix(requestedModel, this.id)
+    return stripGatewayProviderPrefix(requestedModel, this.id);
   }
 }

--- a/packages/daemon/src/proxy/providers/openrouter.ts
+++ b/packages/daemon/src/proxy/providers/openrouter.ts
@@ -1,10 +1,14 @@
-import { AnthropicMessagesTransport } from './transport-anthropic.js'
+import { AnthropicMessagesTransport } from "./transport-anthropic.js";
 
 export class OpenRouterProvider extends AnthropicMessagesTransport {
-  get id() { return 'openrouter' }
-  get label() { return 'OpenRouter' }
+  get id() {
+    return "openrouter";
+  }
+  get label() {
+    return "OpenRouter";
+  }
 
   protected override extraHeaders(): Record<string, string> {
-    return { 'HTTP-Referer': 'https://github.com/claude-code-provider-gateway' }
+    return { "HTTP-Referer": "https://github.com/claude-code-provider-gateway" };
   }
 }

--- a/packages/daemon/src/proxy/providers/registry.ts
+++ b/packages/daemon/src/proxy/providers/registry.ts
@@ -1,64 +1,64 @@
-import type { Config, ProviderId, ProviderConfig } from '../../config/schema.js'
-import { PROVIDER_IDS } from '../../config/schema.js'
-import type { BaseProvider } from './base.js'
-import { NvidiaNimProvider } from './nvidia-nim.js'
-import { OpenRouterProvider } from './openrouter.js'
-import { DeepSeekProvider } from './deepseek.js'
-import { KimiProvider } from './kimi.js'
-import { GoogleProvider } from './google.js'
-import { OllamaProvider } from './ollama.js'
-import { LMStudioProvider } from './lmstudio.js'
-import { LlamaCppProvider } from './llamacpp.js'
-import { OpenAIAccountProvider } from './openai-account.js'
-import { CopilotProvider } from './copilot.js'
+import type { Config, ProviderConfig, ProviderId } from "../../config/schema.js";
+import { PROVIDER_IDS } from "../../config/schema.js";
+import type { BaseProvider } from "./base.js";
+import { CopilotProvider } from "./copilot.js";
+import { DeepSeekProvider } from "./deepseek.js";
+import { GoogleProvider } from "./google.js";
+import { KimiProvider } from "./kimi.js";
+import { LlamaCppProvider } from "./llamacpp.js";
+import { LMStudioProvider } from "./lmstudio.js";
+import { NvidiaNimProvider } from "./nvidia-nim.js";
+import { OllamaProvider } from "./ollama.js";
+import { OpenAIAccountProvider } from "./openai-account.js";
+import { OpenRouterProvider } from "./openrouter.js";
 
-type ProviderConstructor = new (config: ProviderConfig, rootConfig: Config) => BaseProvider
+type ProviderConstructor = new (config: ProviderConfig, rootConfig: Config) => BaseProvider;
 
 const PROVIDER_MAP: Record<ProviderId, ProviderConstructor> = {
   openai_account: OpenAIAccountProvider,
   copilot: CopilotProvider,
   nvidia_nim: NvidiaNimProvider,
-  openrouter:  OpenRouterProvider,
-  deepseek:    DeepSeekProvider,
-  kimi:        KimiProvider,
-  google:      GoogleProvider,
-  ollama:      OllamaProvider,
-  lmstudio:    LMStudioProvider,
-  llamacpp:    LlamaCppProvider,
-}
+  openrouter: OpenRouterProvider,
+  deepseek: DeepSeekProvider,
+  kimi: KimiProvider,
+  google: GoogleProvider,
+  ollama: OllamaProvider,
+  lmstudio: LMStudioProvider,
+  llamacpp: LlamaCppProvider,
+};
 
 export class ProviderRegistry {
-  private cache = new Map<ProviderId, BaseProvider>()
+  private cache = new Map<ProviderId, BaseProvider>();
 
   constructor(private config: Config) {}
 
   get(id: ProviderId): BaseProvider | null {
-    const providerConfig = this.config.providers[id]
-    if (!providerConfig?.enabled) return null
+    const providerConfig = this.config.providers[id];
+    if (!providerConfig?.enabled) return null;
 
     if (!this.cache.has(id)) {
-      const Ctor = PROVIDER_MAP[id]
-      this.cache.set(id, new Ctor(providerConfig, this.config))
+      const Ctor = PROVIDER_MAP[id];
+      this.cache.set(id, new Ctor(providerConfig, this.config));
     }
 
-    return this.cache.get(id)!
+    return this.cache.get(id)!;
   }
 
   getActive(): BaseProvider | null {
-    return this.get(this.config.activeProvider)
+    return this.get(this.config.activeProvider);
   }
 
   updateConfig(config: Config): void {
-    this.config = config
-    this.cache.clear()
+    this.config = config;
+    this.cache.clear();
   }
 
   all(): Array<{ id: ProviderId; provider: BaseProvider }> {
-    const result: Array<{ id: ProviderId; provider: BaseProvider }> = []
+    const result: Array<{ id: ProviderId; provider: BaseProvider }> = [];
     for (const id of PROVIDER_IDS) {
-      const p = this.get(id)
-      if (p) result.push({ id, provider: p })
+      const p = this.get(id);
+      if (p) result.push({ id, provider: p });
     }
-    return result
+    return result;
   }
 }

--- a/packages/daemon/src/proxy/providers/transport-anthropic.ts
+++ b/packages/daemon/src/proxy/providers/transport-anthropic.ts
@@ -1,40 +1,46 @@
 // Transport base for providers that speak native Anthropic Messages API
 // (OpenRouter, DeepSeek, Ollama, LM Studio, llama.cpp)
 
-import { randomUUID } from 'node:crypto'
-import { BaseProvider } from './base.js'
-import type { MessagesRequest, ModelInfo } from '../../core/anthropic/types.js'
-import type { StreamResult } from './base.js'
-import { fetchProviderJson, mapProviderModels, postProviderStream } from './api-client.js'
+import { randomUUID } from "node:crypto";
+import type { MessagesRequest, ModelInfo } from "../../core/anthropic/types.js";
 import {
-  sseMessageStart, sseContentBlockStart, sseContentBlockDelta,
-  sseContentBlockStop, sseMessageDelta, sseMessageStop, ssePing, sseError,
-} from '../../core/sse/writer.js'
+  sseContentBlockDelta,
+  sseContentBlockStart,
+  sseContentBlockStop,
+  sseError,
+  sseMessageDelta,
+  sseMessageStart,
+  sseMessageStop,
+  ssePing,
+} from "../../core/sse/writer.js";
+import { fetchProviderJson, mapProviderModels, postProviderStream } from "./api-client.js";
+import type { StreamResult } from "./base.js";
+import { BaseProvider } from "./base.js";
 
 export abstract class AnthropicMessagesTransport extends BaseProvider {
   async streamResponse(req: MessagesRequest, inputTokens: number): Promise<StreamResult> {
     if (this.requiresApiKey() && !this.hasApiKey()) {
-      return { error: { status: 401, message: this.missingApiKeyMessage() } }
+      return { error: { status: 401, message: this.missingApiKeyMessage() } };
     }
 
     const result = await postProviderStream({
       url: `${this.baseUrl()}/messages`,
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': this.authHeader(),
-        'anthropic-version': '2023-06-01',
+        "Content-Type": "application/json",
+        Authorization: this.authHeader(),
+        "anthropic-version": "2023-06-01",
         ...this.extraHeaders(),
       },
       body: { ...req, stream: true },
       timeoutMs: this.requestTimeoutMs(),
-    })
+    });
 
-    if ('error' in result) return { error: result.error }
+    if ("error" in result) return { error: result.error };
 
-    const messageId = `msg_${randomUUID().replace(/-/g, '')}`
-    const model = req.model
-    const stream = this.transformStream(result.body, messageId, model, inputTokens)
-    return { stream }
+    const messageId = `msg_${randomUUID().replace(/-/g, "")}`;
+    const model = req.model;
+    const stream = this.transformStream(result.body, messageId, model, inputTokens);
+    return { stream };
   }
 
   private transformStream(
@@ -43,94 +49,100 @@ export abstract class AnthropicMessagesTransport extends BaseProvider {
     model: string,
     inputTokens: number,
   ): ReadableStream<string> {
-    let buffer = ''
-    let outputTokens = 0
-    let started = false
-    let stopped = false
+    let buffer = "";
+    let outputTokens = 0;
+    let started = false;
+    let stopped = false;
 
-    const decoder = new TextDecoder()
+    const decoder = new TextDecoder();
 
     return new ReadableStream<string>({
       async start(controller) {
-        const reader = body.getReader()
+        const reader = body.getReader();
 
-        const enq = (chunk: string) => controller.enqueue(chunk)
+        const enq = (chunk: string) => controller.enqueue(chunk);
 
         try {
           while (true) {
-            const { done, value } = await reader.read()
-            if (done) break
+            const { done, value } = await reader.read();
+            if (done) break;
 
-            buffer += decoder.decode(value, { stream: true })
-            const lines = buffer.split('\n')
-            buffer = lines.pop() ?? ''
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop() ?? "";
 
             for (const line of lines) {
-              if (line.startsWith('event: ')) continue
-              if (!line.startsWith('data: ')) continue
+              if (line.startsWith("event: ")) continue;
+              if (!line.startsWith("data: ")) continue;
 
-              const data = line.slice(6).trim()
-              if (data === '[DONE]') continue
+              const data = line.slice(6).trim();
+              if (data === "[DONE]") continue;
 
-              let evt: Record<string, unknown>
-              try { evt = JSON.parse(data) } catch { continue }
-
-              const type = evt['type'] as string
-
-              if (!started) {
-                enq(ssePing())
-                enq(sseMessageStart(messageId, model, inputTokens))
-                started = true
+              let evt: Record<string, unknown>;
+              try {
+                evt = JSON.parse(data);
+              } catch {
+                continue;
               }
 
-              if (type === 'content_block_start') {
-                enq(sseContentBlockStart(evt['index'] as number, evt['content_block']))
-              } else if (type === 'content_block_delta') {
-                enq(sseContentBlockDelta(evt['index'] as number, evt['delta']))
-              } else if (type === 'content_block_stop') {
-                enq(sseContentBlockStop(evt['index'] as number))
-              } else if (type === 'message_delta') {
-                const delta = evt['delta'] as Record<string, unknown>
-                const usage = evt['usage'] as Record<string, unknown> | undefined
-                outputTokens = (usage?.['output_tokens'] as number) ?? outputTokens
-                enq(sseMessageDelta((delta?.['stop_reason'] as string) ?? null, outputTokens))
-              } else if (type === 'message_stop') {
-                enq(sseMessageStop())
-                stopped = true
+              const type = evt["type"] as string;
+
+              if (!started) {
+                enq(ssePing());
+                enq(sseMessageStart(messageId, model, inputTokens));
+                started = true;
+              }
+
+              if (type === "content_block_start") {
+                enq(sseContentBlockStart(evt["index"] as number, evt["content_block"]));
+              } else if (type === "content_block_delta") {
+                enq(sseContentBlockDelta(evt["index"] as number, evt["delta"]));
+              } else if (type === "content_block_stop") {
+                enq(sseContentBlockStop(evt["index"] as number));
+              } else if (type === "message_delta") {
+                const delta = evt["delta"] as Record<string, unknown>;
+                const usage = evt["usage"] as Record<string, unknown> | undefined;
+                outputTokens = (usage?.["output_tokens"] as number) ?? outputTokens;
+                enq(sseMessageDelta((delta?.["stop_reason"] as string) ?? null, outputTokens));
+              } else if (type === "message_stop") {
+                enq(sseMessageStop());
+                stopped = true;
               }
             }
           }
 
           if (!started) {
-            enq(sseMessageStart(messageId, model, inputTokens))
+            enq(sseMessageStart(messageId, model, inputTokens));
           }
           if (!stopped) {
-            enq(sseMessageStop())
+            enq(sseMessageStop());
           }
         } catch (err) {
-          enq(sseError('api_error', String(err)))
+          enq(sseError("api_error", String(err)));
         } finally {
-          controller.close()
+          controller.close();
         }
       },
-    })
+    });
   }
 
   async listModels(): Promise<ModelInfo[]> {
     if (this.requiresApiKey() && !this.hasApiKey()) {
-      throw new Error(this.missingApiKeyMessage())
+      throw new Error(this.missingApiKeyMessage());
     }
 
-    const url = `${this.baseUrl()}/models`
-    const json = await fetchProviderJson<{ data?: Array<{ id: string; name?: string; created?: number }> }>({
+    const url = `${this.baseUrl()}/models`;
+    const json = await fetchProviderJson<{
+      data?: Array<{ id: string; name?: string; created?: number }>;
+    }>({
       url,
-      headers: { 'Authorization': this.authHeader(), ...this.extraHeaders() },
+      headers: { Authorization: this.authHeader(), ...this.extraHeaders() },
       timeoutMs: this.requestTimeoutMs(),
-    })
-    return mapProviderModels(json.data ?? [], this.id, this.label)
+    });
+    return mapProviderModels(json.data ?? [], this.id, this.label);
   }
 
   protected extraHeaders(): Record<string, string> {
-    return {}
+    return {};
   }
 }

--- a/packages/daemon/src/proxy/providers/transport-openai.ts
+++ b/packages/daemon/src/proxy/providers/transport-openai.ts
@@ -1,45 +1,51 @@
 // Transport base for providers that speak OpenAI Chat Completions format
 // (NVIDIA NIM, Kimi)
 
-import { randomUUID } from 'node:crypto'
-import { BaseProvider } from './base.js'
-import { anthropicToOpenAI } from '../../core/anthropic/conversion.js'
-import type { MessagesRequest, ModelInfo } from '../../core/anthropic/types.js'
-import type { StreamResult } from './base.js'
-import { fetchProviderJson, mapProviderModels, postProviderStream } from './api-client.js'
+import { randomUUID } from "node:crypto";
+import { anthropicToOpenAI } from "../../core/anthropic/conversion.js";
+import type { MessagesRequest, ModelInfo } from "../../core/anthropic/types.js";
 import {
-  sseMessageStart, sseContentBlockStart, sseContentBlockDelta,
-  sseContentBlockStop, sseMessageDelta, sseMessageStop, ssePing, sseError,
-} from '../../core/sse/writer.js'
+  sseContentBlockDelta,
+  sseContentBlockStart,
+  sseContentBlockStop,
+  sseError,
+  sseMessageDelta,
+  sseMessageStart,
+  sseMessageStop,
+  ssePing,
+} from "../../core/sse/writer.js";
+import { fetchProviderJson, mapProviderModels, postProviderStream } from "./api-client.js";
+import type { StreamResult } from "./base.js";
+import { BaseProvider } from "./base.js";
 
 export abstract class OpenAIChatTransport extends BaseProvider {
   // Subclasses set the actual model name to send to the provider
-  protected abstract resolveModel(requestedModel: string): string
+  protected abstract resolveModel(requestedModel: string): string;
 
   async streamResponse(req: MessagesRequest, inputTokens: number): Promise<StreamResult> {
     if (this.requiresApiKey() && !this.hasApiKey()) {
-      return { error: { status: 401, message: this.missingApiKeyMessage() } }
+      return { error: { status: 401, message: this.missingApiKeyMessage() } };
     }
 
-    const providerModel = this.resolveModel(req.model)
-    const openaiReq = anthropicToOpenAI(req, providerModel)
+    const providerModel = this.resolveModel(req.model);
+    const openaiReq = anthropicToOpenAI(req, providerModel);
 
     const result = await postProviderStream({
       url: `${this.baseUrl()}/chat/completions`,
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': this.authHeader(),
+        "Content-Type": "application/json",
+        Authorization: this.authHeader(),
         ...this.extraHeaders(),
       },
       body: openaiReq,
       timeoutMs: this.requestTimeoutMs(),
-    })
+    });
 
-    if ('error' in result) return { error: result.error }
+    if ("error" in result) return { error: result.error };
 
-    const messageId = `msg_${randomUUID().replace(/-/g, '')}`
-    const stream = this.transformOpenAIStream(result.body, messageId, req.model, inputTokens)
-    return { stream }
+    const messageId = `msg_${randomUUID().replace(/-/g, "")}`;
+    const stream = this.transformOpenAIStream(result.body, messageId, req.model, inputTokens);
+    return { stream };
   }
 
   private transformOpenAIStream(
@@ -48,139 +54,154 @@ export abstract class OpenAIChatTransport extends BaseProvider {
     model: string,
     inputTokens: number,
   ): ReadableStream<string> {
-    let buffer = ''
-    let outputTokens = 0
-    let blockStarted = false
-    let toolCallBuffers: Map<number, { id: string; name: string; args: string }> = new Map()
-    let textBlockIndex = 0
-    let toolBlockOffset = 0
-    let finished = false
+    let buffer = "";
+    let outputTokens = 0;
+    let blockStarted = false;
+    const toolCallBuffers: Map<number, { id: string; name: string; args: string }> = new Map();
+    const textBlockIndex = 0;
+    let finished = false;
 
-    const decoder = new TextDecoder()
+    const decoder = new TextDecoder();
 
     return new ReadableStream<string>({
       async start(controller) {
-        const reader = body.getReader()
-        const enq = (chunk: string) => controller.enqueue(chunk)
+        const reader = body.getReader();
+        const enq = (chunk: string) => controller.enqueue(chunk);
 
-        enq(ssePing())
-        enq(sseMessageStart(messageId, model, inputTokens))
+        enq(ssePing());
+        enq(sseMessageStart(messageId, model, inputTokens));
 
         try {
           while (true) {
-            const { done, value } = await reader.read()
-            if (done) break
+            const { done, value } = await reader.read();
+            if (done) break;
 
-            buffer += decoder.decode(value, { stream: true })
-            const lines = buffer.split('\n')
-            buffer = lines.pop() ?? ''
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop() ?? "";
 
             for (const line of lines) {
-              if (!line.startsWith('data: ')) continue
-              const data = line.slice(6).trim()
-              if (data === '[DONE]') continue
+              if (!line.startsWith("data: ")) continue;
+              const data = line.slice(6).trim();
+              if (data === "[DONE]") continue;
 
-              let chunk: Record<string, unknown>
-              try { chunk = JSON.parse(data) } catch { continue }
+              let chunk: Record<string, unknown>;
+              try {
+                chunk = JSON.parse(data);
+              } catch {
+                continue;
+              }
 
-              const choices = chunk['choices'] as Array<Record<string, unknown>> | undefined
-              if (!choices?.length) continue
+              const choices = chunk["choices"] as Array<Record<string, unknown>> | undefined;
+              if (!choices?.length) continue;
 
-              const delta = choices[0]?.['delta'] as Record<string, unknown> | undefined
-              const finishReason = choices[0]?.['finish_reason'] as string | null
+              const delta = choices[0]?.["delta"] as Record<string, unknown> | undefined;
+              const finishReason = choices[0]?.["finish_reason"] as string | null;
 
               // Text content
-              const textDelta = delta?.['content'] as string | undefined
+              const textDelta = delta?.["content"] as string | undefined;
               if (textDelta) {
                 if (!blockStarted) {
-                  enq(sseContentBlockStart(textBlockIndex, { type: 'text', text: '' }))
-                  blockStarted = true
+                  enq(sseContentBlockStart(textBlockIndex, { type: "text", text: "" }));
+                  blockStarted = true;
                 }
-                enq(sseContentBlockDelta(textBlockIndex, { type: 'text_delta', text: textDelta }))
+                enq(sseContentBlockDelta(textBlockIndex, { type: "text_delta", text: textDelta }));
               }
 
               // Tool calls
-              const toolCalls = delta?.['tool_calls'] as Array<Record<string, unknown>> | undefined
+              const toolCalls = delta?.["tool_calls"] as Array<Record<string, unknown>> | undefined;
               if (toolCalls) {
                 for (const tc of toolCalls) {
-                  const idx = tc['index'] as number
+                  const idx = tc["index"] as number;
                   if (!toolCallBuffers.has(idx)) {
-                    const fn = tc['function'] as Record<string, unknown>
-                    toolCallBuffers.set(idx, { id: tc['id'] as string, name: fn['name'] as string, args: '' })
-                    const blockIdx = textBlockIndex + 1 + idx
-                    toolBlockOffset = blockIdx
-                    enq(sseContentBlockStart(blockIdx, {
-                      type: 'tool_use',
-                      id: tc['id'],
-                      name: (tc['function'] as Record<string, unknown>)['name'],
-                      input: {},
-                    }))
+                    const fn = tc["function"] as Record<string, unknown>;
+                    toolCallBuffers.set(idx, {
+                      id: tc["id"] as string,
+                      name: fn["name"] as string,
+                      args: "",
+                    });
+                    const blockIdx = textBlockIndex + 1 + idx;
+                    enq(
+                      sseContentBlockStart(blockIdx, {
+                        type: "tool_use",
+                        id: tc["id"],
+                        name: (tc["function"] as Record<string, unknown>)["name"],
+                        input: {},
+                      }),
+                    );
                   }
-                  const buf = toolCallBuffers.get(idx)!
-                  const fn = tc['function'] as Record<string, unknown> | undefined
-                  if (fn?.['arguments']) {
-                    buf.args += fn['arguments'] as string
-                    enq(sseContentBlockDelta(textBlockIndex + 1 + idx, {
-                      type: 'input_json_delta',
-                      partial_json: fn['arguments'] as string,
-                    }))
+                  const buf = toolCallBuffers.get(idx)!;
+                  const fn = tc["function"] as Record<string, unknown> | undefined;
+                  if (fn?.["arguments"]) {
+                    buf.args += fn["arguments"] as string;
+                    enq(
+                      sseContentBlockDelta(textBlockIndex + 1 + idx, {
+                        type: "input_json_delta",
+                        partial_json: fn["arguments"] as string,
+                      }),
+                    );
                   }
                 }
               }
 
               // Usage
-              const usage = chunk['usage'] as Record<string, unknown> | undefined
+              const usage = chunk["usage"] as Record<string, unknown> | undefined;
               if (usage) {
-                outputTokens = (usage['completion_tokens'] as number) ?? outputTokens
+                outputTokens = (usage["completion_tokens"] as number) ?? outputTokens;
               }
 
               if (finishReason && !finished) {
-                finished = true
-                if (blockStarted) enq(sseContentBlockStop(textBlockIndex))
+                finished = true;
+                if (blockStarted) enq(sseContentBlockStop(textBlockIndex));
                 for (const [idx] of toolCallBuffers) {
-                  enq(sseContentBlockStop(textBlockIndex + 1 + idx))
+                  enq(sseContentBlockStop(textBlockIndex + 1 + idx));
                 }
-                const stopReason = finishReason === 'tool_calls' ? 'tool_use'
-                  : finishReason === 'length' ? 'max_tokens'
-                  : 'end_turn'
-                enq(sseMessageDelta(stopReason, outputTokens))
-                enq(sseMessageStop())
+                const stopReason =
+                  finishReason === "tool_calls"
+                    ? "tool_use"
+                    : finishReason === "length"
+                      ? "max_tokens"
+                      : "end_turn";
+                enq(sseMessageDelta(stopReason, outputTokens));
+                enq(sseMessageStop());
               }
             }
           }
 
           if (!finished) {
-            if (blockStarted) enq(sseContentBlockStop(textBlockIndex))
+            if (blockStarted) enq(sseContentBlockStop(textBlockIndex));
             for (const [idx] of toolCallBuffers) {
-              enq(sseContentBlockStop(textBlockIndex + 1 + idx))
+              enq(sseContentBlockStop(textBlockIndex + 1 + idx));
             }
-            enq(sseMessageDelta('end_turn', outputTokens))
-            enq(sseMessageStop())
+            enq(sseMessageDelta("end_turn", outputTokens));
+            enq(sseMessageStop());
           }
         } catch (err) {
-          enq(sseError('api_error', String(err)))
+          enq(sseError("api_error", String(err)));
         } finally {
-          controller.close()
+          controller.close();
         }
       },
-    })
+    });
   }
 
   async listModels(): Promise<ModelInfo[]> {
     if (this.requiresApiKey() && !this.hasApiKey()) {
-      throw new Error(this.missingApiKeyMessage())
+      throw new Error(this.missingApiKeyMessage());
     }
 
-    const url = `${this.baseUrl()}/models`
-    const json = await fetchProviderJson<{ data?: Array<{ id: string; name?: string; created?: number }> }>({
+    const url = `${this.baseUrl()}/models`;
+    const json = await fetchProviderJson<{
+      data?: Array<{ id: string; name?: string; created?: number }>;
+    }>({
       url,
-      headers: { 'Authorization': this.authHeader(), ...this.extraHeaders() },
+      headers: { Authorization: this.authHeader(), ...this.extraHeaders() },
       timeoutMs: this.requestTimeoutMs(),
-    })
-    return mapProviderModels(json.data ?? [], this.id, this.label)
+    });
+    return mapProviderModels(json.data ?? [], this.id, this.label);
   }
 
   protected extraHeaders(): Record<string, string> {
-    return {}
+    return {};
   }
 }

--- a/packages/daemon/src/proxy/routes/anthropic-routes.test.ts
+++ b/packages/daemon/src/proxy/routes/anthropic-routes.test.ts
@@ -1,44 +1,44 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { buildDefaultConfig } from '../../config/index.js'
-import { createProxyApp } from '../app.js'
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildDefaultConfig } from "../../config/index.js";
+import { createProxyApp } from "../app.js";
 
-test('Anthropic routes reject invalid API key without changing error contract', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = createProxyApp(config, { loadConfig: () => config })
+test("Anthropic routes reject invalid API key without changing error contract", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = createProxyApp(config, { loadConfig: () => config });
 
-  const response = await app.request('/v1/messages/count_tokens', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer wrong' },
+  const response = await app.request("/v1/messages/count_tokens", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Bearer wrong" },
     body: JSON.stringify({
-      model: 'claude-3-5-sonnet-latest',
-      messages: [{ role: 'user', content: 'hello' }],
+      model: "claude-3-5-sonnet-latest",
+      messages: [{ role: "user", content: "hello" }],
     }),
-  })
+  });
 
-  assert.equal(response.status, 401)
+  assert.equal(response.status, 401);
   assert.deepEqual(await response.json(), {
-    type: 'error',
-    error: { type: 'authentication_error', message: 'Invalid API key' },
-  })
-})
+    type: "error",
+    error: { type: "authentication_error", message: "Invalid API key" },
+  });
+});
 
-test('Anthropic routes keep count_tokens available with valid API key', async () => {
-  const config = buildDefaultConfig()
-  config.server.authToken = 'secret'
-  const app = createProxyApp(config, { loadConfig: () => config })
+test("Anthropic routes keep count_tokens available with valid API key", async () => {
+  const config = buildDefaultConfig();
+  config.server.authToken = "secret";
+  const app = createProxyApp(config, { loadConfig: () => config });
 
-  const response = await app.request('/v1/messages/count_tokens', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer secret' },
+  const response = await app.request("/v1/messages/count_tokens", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Bearer secret" },
     body: JSON.stringify({
-      model: 'claude-3-5-sonnet-latest',
-      messages: [{ role: 'user', content: 'hello' }],
+      model: "claude-3-5-sonnet-latest",
+      messages: [{ role: "user", content: "hello" }],
     }),
-  })
+  });
 
-  assert.equal(response.status, 200)
-  const body = await response.json() as { input_tokens?: number }
-  assert.equal(typeof body.input_tokens, 'number')
-})
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { input_tokens?: number };
+  assert.equal(typeof body.input_tokens, "number");
+});

--- a/packages/daemon/src/proxy/routes/anthropic-routes.ts
+++ b/packages/daemon/src/proxy/routes/anthropic-routes.ts
@@ -1,38 +1,42 @@
-import type { Hono } from 'hono'
-import type { CountTokensRequest, MessagesRequest } from '../../core/anthropic/types.js'
-import { requireAnthropicAuth } from '../middleware/auth.js'
-import type { ProxyRuntime } from '../runtime.js'
-import { MessageService } from '../services/message-service.js'
-import { ModelService } from '../services/model-service.js'
+import type { Hono } from "hono";
+import type { CountTokensRequest, MessagesRequest } from "../../core/anthropic/types.js";
+import { requireAnthropicAuth } from "../middleware/auth.js";
+import type { ProxyRuntime } from "../runtime.js";
+import { MessageService } from "../services/message-service.js";
+import { ModelService } from "../services/model-service.js";
 
 export function registerAnthropicRoutes(app: Hono, runtime: ProxyRuntime): void {
-  const messages = new MessageService(runtime)
-  const models = new ModelService(runtime)
+  const messages = new MessageService(runtime);
+  const models = new ModelService(runtime);
 
-  app.use('/v1/*', requireAnthropicAuth(runtime))
+  app.use("/v1/*", requireAnthropicAuth(runtime));
 
-  app.on(['HEAD', 'OPTIONS'], '/v1/messages', c => new Response(null, { status: 204 }))
-  app.on(['HEAD', 'OPTIONS'], '/v1/messages/count_tokens', c => new Response(null, { status: 204 }))
+  app.on(["HEAD", "OPTIONS"], "/v1/messages", (c) => new Response(null, { status: 204 }));
+  app.on(
+    ["HEAD", "OPTIONS"],
+    "/v1/messages/count_tokens",
+    (c) => new Response(null, { status: 204 }),
+  );
 
-  app.post('/v1/messages/count_tokens', async c => {
-    const req = await c.req.json<CountTokensRequest>()
-    const tokens = messages.countTokens(req as MessagesRequest)
-    return c.json({ input_tokens: tokens })
-  })
+  app.post("/v1/messages/count_tokens", async (c) => {
+    const req = await c.req.json<CountTokensRequest>();
+    const tokens = messages.countTokens(req as MessagesRequest);
+    return c.json({ input_tokens: tokens });
+  });
 
-  app.get('/v1/models', async c => {
-    return c.json(await models.listModels())
-  })
+  app.get("/v1/models", async (c) => {
+    return c.json(await models.listModels());
+  });
 
-  app.post('/v1/messages', async c => {
-    const req = await c.req.json<MessagesRequest>()
-    const result = await messages.createMessage(req)
+  app.post("/v1/messages", async (c) => {
+    const req = await c.req.json<MessagesRequest>();
+    const result = await messages.createMessage(req);
 
-    if (result.kind === 'error') return c.json(result.body, result.status)
+    if (result.kind === "error") return c.json(result.body, result.status);
 
     return new Response(result.stream as unknown as BodyInit, {
       status: result.status,
       headers: result.headers,
-    })
-  })
+    });
+  });
 }

--- a/packages/daemon/src/proxy/routes/status-routes.ts
+++ b/packages/daemon/src/proxy/routes/status-routes.ts
@@ -1,11 +1,15 @@
-import type { Hono } from 'hono'
-import type { ProxyRuntime } from '../runtime.js'
+import type { Hono } from "hono";
+import type { ProxyRuntime } from "../runtime.js";
 
 export function registerStatusRoutes(app: Hono, runtime: ProxyRuntime): void {
-  app.get('/health', c => c.json({ status: 'ok' }))
+  app.get("/health", (c) => c.json({ status: "ok" }));
 
-  app.get('/', c => {
-    const config = runtime.currentConfig()
-    return c.json({ status: 'ok', provider: config.activeProvider, proxy_port: config.server.proxyPort })
-  })
+  app.get("/", (c) => {
+    const config = runtime.currentConfig();
+    return c.json({
+      status: "ok",
+      provider: config.activeProvider,
+      proxy_port: config.server.proxyPort,
+    });
+  });
 }

--- a/packages/daemon/src/proxy/runtime.ts
+++ b/packages/daemon/src/proxy/runtime.ts
@@ -1,31 +1,31 @@
-import type { Config } from '../config/schema.js'
-import { loadConfig } from '../config/index.js'
-import { ProviderRegistry } from './providers/registry.js'
+import { loadConfig } from "../config/index.js";
+import type { Config } from "../config/schema.js";
+import { ProviderRegistry } from "./providers/registry.js";
 
-export type ConfigLoader = () => Config
+export type ConfigLoader = () => Config;
 
 export class ProxyRuntime {
-  private config: Config
-  private readonly registry: ProviderRegistry
+  private config: Config;
+  private readonly registry: ProviderRegistry;
 
   constructor(
     initialConfig: Config,
     private readonly load: ConfigLoader = loadConfig,
   ) {
-    this.config = initialConfig
-    this.registry = new ProviderRegistry(initialConfig)
+    this.config = initialConfig;
+    this.registry = new ProviderRegistry(initialConfig);
   }
 
   currentConfig(): Config {
-    return this.config
+    return this.config;
   }
 
   providers(): ProviderRegistry {
-    return this.registry
+    return this.registry;
   }
 
   reloadConfig(): void {
-    this.config = this.load()
-    this.registry.updateConfig(this.config)
+    this.config = this.load();
+    this.registry.updateConfig(this.config);
   }
 }

--- a/packages/daemon/src/proxy/services/message-service.test.ts
+++ b/packages/daemon/src/proxy/services/message-service.test.ts
@@ -1,51 +1,47 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { buildDefaultConfig } from '../../config/index.js'
-import { ProxyRuntime } from '../runtime.js'
-import { MessageService, shouldUseNativeClaudePassthrough } from './message-service.js'
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildDefaultConfig } from "../../config/index.js";
+import { ProxyRuntime } from "../runtime.js";
+import { MessageService, shouldUseNativeClaudePassthrough } from "./message-service.js";
 
-test('MessageService returns Anthropic not_found_error when routed provider is disabled', async () => {
-  const config = buildDefaultConfig()
-  for (const provider of Object.values(config.providers)) provider.enabled = false
-  const service = new MessageService(new ProxyRuntime(config))
+test("MessageService returns Anthropic not_found_error when routed provider is disabled", async () => {
+  const config = buildDefaultConfig();
+  for (const provider of Object.values(config.providers)) provider.enabled = false;
+  const service = new MessageService(new ProxyRuntime(config));
 
   // Use a non-native model name so the request goes through the routing layer
   // (native claude-* names bypass routing entirely and stream from api.anthropic.com).
   const result = await service.createMessage({
-    model: 'nvidia_nim/some-model',
+    model: "nvidia_nim/some-model",
     max_tokens: 16,
-    messages: [{ role: 'user', content: 'hello' }],
-  })
+    messages: [{ role: "user", content: "hello" }],
+  });
 
-  assert.equal(result.kind, 'error')
-  if (result.kind === 'error') {
-    assert.equal(result.status, 404)
-    assert.equal(result.body.type, 'error')
-    assert.equal(result.body.error.type, 'not_found_error')
+  assert.equal(result.kind, "error");
+  if (result.kind === "error") {
+    assert.equal(result.status, 404);
+    assert.equal(result.body.type, "error");
+    assert.equal(result.body.error.type, "not_found_error");
   }
-})
+});
 
-test('native Claude passthrough is blocked when a ccpg provider is active', () => {
-  const config = buildDefaultConfig()
-  config.activeProvider = 'copilot'
-  config.modelMode = 'all'
-  config.providers.copilot.enabled = true
+test("native Claude passthrough is blocked when a ccpg provider is active", () => {
+  const config = buildDefaultConfig();
+  config.activeProvider = "copilot";
+  config.modelMode = "all";
+  config.providers.copilot.enabled = true;
 
-  assert.equal(
-    shouldUseNativeClaudePassthrough('claude-haiku-4-5-20251001', config, null),
-    false,
-  )
-})
+  assert.equal(shouldUseNativeClaudePassthrough("claude-haiku-4-5-20251001", config, null), false);
+});
 
-test('native Claude passthrough is blocked after a provider-prefixed model is selected', () => {
-  const config = buildDefaultConfig()
+test("native Claude passthrough is blocked after a provider-prefixed model is selected", () => {
+  const config = buildDefaultConfig();
 
   assert.equal(
-    shouldUseNativeClaudePassthrough(
-      'claude-haiku-4-5-20251001',
-      config,
-      { providerId: 'copilot', providerModel: 'gpt-4o' },
-    ),
+    shouldUseNativeClaudePassthrough("claude-haiku-4-5-20251001", config, {
+      providerId: "copilot",
+      providerModel: "gpt-4o",
+    }),
     false,
-  )
-})
+  );
+});

--- a/packages/daemon/src/proxy/services/message-service.ts
+++ b/packages/daemon/src/proxy/services/message-service.ts
@@ -1,32 +1,30 @@
-import type { MessagesRequest } from "../../core/anthropic/types.js";
 import { countRequestTokens } from "../../core/anthropic/tokens.js";
+import type { MessagesRequest } from "../../core/anthropic/types.js";
 import { logger } from "../../observability/log.js";
+import type { TokenSaverStats } from "../../runtime/session-types.js";
 import {
-  recordSessionRequest,
-  setSessionPrimaryModel,
   getSessionPrimaryModel,
   isFirstSessionRequest,
+  recordSessionRequest,
+  setSessionPrimaryModel,
 } from "../../runtime/sessions.js";
 import { recordRequest } from "../../runtime/stats.js";
-import {
-  anthropicError,
-  providerErrorStatus,
-  providerErrorType,
-} from "../errors.js";
 import type { AnthropicErrorResponse, ErrorStatus } from "../errors.js";
+import { anthropicError, providerErrorStatus, providerErrorType } from "../errors.js";
 import { resolveModel } from "../model-router.js";
+import { tryOptimize } from "../optimizations.js";
 import {
   getAnthropicCredentialsStatus,
   streamAnthropicNative,
 } from "../providers/anthropic-passthrough.js";
-import { tryOptimize } from "../optimizations.js";
 import type { ProxyRuntime } from "../runtime.js";
-import { serializePrompt } from "./prompt-serializer.js";
-import { streamResult, streamResultWithCapture } from "./stream-result.js";
 import { injectCaveman } from "../token-savers/caveman.js";
 import { cloneMessagesRequest, compressMessages, formatRtkLog } from "../token-savers/rtk.js";
-import type { TokenSaverStats } from "../../runtime/session-types.js";
+import { serializePrompt } from "./prompt-serializer.js";
+import { streamResult, streamResultWithCapture } from "./stream-result.js";
+
 export { shouldUseNativeClaudePassthrough } from "./native-claude-routing.js";
+
 import { shouldUseNativeClaudePassthrough } from "./native-claude-routing.js";
 
 export type MessageServiceResult =
@@ -48,16 +46,11 @@ export class MessageService {
   async createMessage(req: MessagesRequest): Promise<MessageServiceResult> {
     const started = Date.now();
     const isClaudeTierRequest = /^claude-/i.test(req.model);
-    const optimized = isClaudeTierRequest
-      ? { handled: false as const }
-      : tryOptimize(req);
+    const optimized = isClaudeTierRequest ? { handled: false as const } : tryOptimize(req);
 
     if (optimized.handled) {
       const latency = Date.now() - started;
-      logger.info(
-        "proxy",
-        `→ local optimization for ${req.model} (${latency}ms)`,
-      );
+      logger.info("proxy", `→ local optimization for ${req.model} (${latency}ms)`);
       const resolved = resolveModel(req.model, this.runtime.currentConfig());
       if (resolved.source === "prefix") {
         setSessionPrimaryModel(resolved.providerId, resolved.providerModel);
@@ -134,7 +127,10 @@ export class MessageService {
       };
     }
 
-    const { req: providerReq, stats: tokenSaverStats } = this.applyTokenSavers({ ...cloneMessagesRequest(req), model: providerModel });
+    const { req: providerReq, stats: tokenSaverStats } = this.applyTokenSavers({
+      ...cloneMessagesRequest(req),
+      model: providerModel,
+    });
     const inputTokens = countRequestTokens(providerReq);
     const result = await provider.streamResponse(providerReq, inputTokens);
     const latency = Date.now() - started;
@@ -194,7 +190,9 @@ export class MessageService {
     req: MessagesRequest,
     started: number,
   ): Promise<MessageServiceResult> {
-    const { req: nativeReq, stats: tokenSaverStats } = this.applyTokenSavers(cloneMessagesRequest(req));
+    const { req: nativeReq, stats: tokenSaverStats } = this.applyTokenSavers(
+      cloneMessagesRequest(req),
+    );
     const inputTokens = countRequestTokens(nativeReq);
     const result = await streamAnthropicNative(nativeReq, nativeReq.model, undefined);
     const latency = Date.now() - started;
@@ -258,7 +256,10 @@ export class MessageService {
     return countRequestTokens(transformed);
   }
 
-  private applyTokenSavers(req: MessagesRequest): { req: MessagesRequest; stats: TokenSaverStats | undefined } {
+  private applyTokenSavers(req: MessagesRequest): {
+    req: MessagesRequest;
+    stats: TokenSaverStats | undefined;
+  } {
     const { tokenSavers } = this.runtime.currentConfig();
     const rtkStats = compressMessages(req, tokenSavers.rtkEnabled);
     const rtkLine = formatRtkLog(rtkStats);
@@ -275,7 +276,7 @@ export class MessageService {
       rtkBytesBefore: rtkStats?.bytesBefore ?? 0,
       rtkBytesAfter: rtkStats?.bytesAfter ?? 0,
       rtkHits: rtkStats?.hits.length ?? 0,
-      rtkFilters: rtkStats ? Array.from(new Set(rtkStats.hits.map(hit => hit.filter))) : [],
+      rtkFilters: rtkStats ? Array.from(new Set(rtkStats.hits.map((hit) => hit.filter))) : [],
       cavemanLevel: tokenSavers.cavemanEnabled ? tokenSavers.cavemanLevel : null,
     };
     return { req, stats };

--- a/packages/daemon/src/proxy/services/model-service.test.ts
+++ b/packages/daemon/src/proxy/services/model-service.test.ts
@@ -1,20 +1,20 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { buildDefaultConfig } from '../../config/index.js'
-import { ProxyRuntime } from '../runtime.js'
-import { ModelService } from './model-service.js'
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildDefaultConfig } from "../../config/index.js";
+import { ProxyRuntime } from "../runtime.js";
+import { ModelService } from "./model-service.js";
 
-test('ModelService returns empty model list when active provider is disabled', async () => {
-  const config = buildDefaultConfig()
-  for (const provider of Object.values(config.providers)) provider.enabled = false
-  const service = new ModelService(new ProxyRuntime(config))
+test("ModelService returns empty model list when active provider is disabled", async () => {
+  const config = buildDefaultConfig();
+  for (const provider of Object.values(config.providers)) provider.enabled = false;
+  const service = new ModelService(new ProxyRuntime(config));
 
-  const result = await service.listModels()
+  const result = await service.listModels();
 
   assert.deepEqual(result, {
     data: [],
     has_more: false,
     first_id: null,
     last_id: null,
-  })
-})
+  });
+});

--- a/packages/daemon/src/proxy/services/model-service.ts
+++ b/packages/daemon/src/proxy/services/model-service.ts
@@ -1,32 +1,37 @@
-import type { ModelsListResponse } from '../../core/anthropic/types.js'
-import type { ProxyRuntime } from '../runtime.js'
+import type { ModelsListResponse } from "../../core/anthropic/types.js";
+import type { ProxyRuntime } from "../runtime.js";
 
 export class ModelService {
   constructor(private readonly runtime: ProxyRuntime) {}
 
   async listModels(): Promise<ModelsListResponse> {
-    const config = this.runtime.currentConfig()
-    const registry = this.runtime.providers()
-    const mode = config.modelMode ?? 'single'
+    const config = this.runtime.currentConfig();
+    const registry = this.runtime.providers();
+    const mode = config.modelMode ?? "single";
 
     // Native Claude tiers (Default/Sonnet/Haiku) are NOT advertised here on purpose.
     // Claude Code's /model picker already injects them from its own hardcoded list,
     // and message-service intercepts those model names before routing — adding them
     // here would duplicate every native Claude entry as a redundant "From gateway" row.
-    const data = mode === 'all'
-      ? (await Promise.all(registry.all().map(({ provider }) => provider.listEnabledModels().catch(() => [])))).flat()
-      : await this.listActiveProviderModels()
+    const data =
+      mode === "all"
+        ? (
+            await Promise.all(
+              registry.all().map(({ provider }) => provider.listEnabledModels().catch(() => [])),
+            )
+          ).flat()
+        : await this.listActiveProviderModels();
 
     return {
       data,
       has_more: false,
       first_id: data[0]?.id ?? null,
       last_id: data[data.length - 1]?.id ?? null,
-    }
+    };
   }
 
   private async listActiveProviderModels() {
-    const provider = this.runtime.providers().getActive()
-    return provider ? await provider.listEnabledModels().catch(() => []) : []
+    const provider = this.runtime.providers().getActive();
+    return provider ? await provider.listEnabledModels().catch(() => []) : [];
   }
 }

--- a/packages/daemon/src/proxy/services/native-claude-routing.ts
+++ b/packages/daemon/src/proxy/services/native-claude-routing.ts
@@ -1,23 +1,21 @@
-import type { Config } from '../../config/schema.js'
-import type { ProviderId } from '../../config/schema.js'
-import { isNativeClaudeModel } from '../providers/anthropic-passthrough.js'
+import type { Config, ProviderId } from "../../config/schema.js";
+import { isNativeClaudeModel } from "../providers/anthropic-passthrough.js";
 
-type SessionPrimaryModel = { providerId: ProviderId; providerModel: string } | null
+type SessionPrimaryModel = { providerId: ProviderId; providerModel: string } | null;
 
 export function shouldUseNativeClaudePassthrough(
   requestedModel: string,
   config: Config,
   primaryModel: SessionPrimaryModel,
 ): boolean {
-  if (!isNativeClaudeModel(requestedModel)) return false
-  if (primaryModel) return false
+  if (!isNativeClaudeModel(requestedModel)) return false;
+  if (primaryModel) return false;
 
   // A ccpg provider launch means Claude Code's hardcoded claude-haiku background
   // calls should inherit the gateway route instead of silently hitting Anthropic.
   // This applies to --all too: once the user picks a provider-prefixed model, the
   // primary model below takes over; before that, the active/default route is safer
   // than api.anthropic.com surprises.
-  const activeProviderEnabled =
-    config.providers[config.activeProvider]?.enabled === true
-  return !activeProviderEnabled
+  const activeProviderEnabled = config.providers[config.activeProvider]?.enabled === true;
+  return !activeProviderEnabled;
 }

--- a/packages/daemon/src/proxy/services/prompt-serializer.ts
+++ b/packages/daemon/src/proxy/services/prompt-serializer.ts
@@ -1,47 +1,45 @@
-import type {
-  ContentBlock,
-  MessagesRequest,
-} from '../../core/anthropic/types.js'
+import type { ContentBlock, MessagesRequest } from "../../core/anthropic/types.js";
 
-const PROMPT_SYSTEM_MAX_FIRST = 80000
-const PROMPT_SYSTEM_MAX_REPEAT = 4000
-const PROMPT_TOTAL_MAX = 300000
+const PROMPT_SYSTEM_MAX_FIRST = 80000;
+const PROMPT_SYSTEM_MAX_REPEAT = 4000;
+const PROMPT_TOTAL_MAX = 300000;
 
 export function serializePrompt(req: MessagesRequest, first: boolean): string {
-  const systemMax = first ? PROMPT_SYSTEM_MAX_FIRST : PROMPT_SYSTEM_MAX_REPEAT
-  const parts: string[] = []
+  const systemMax = first ? PROMPT_SYSTEM_MAX_FIRST : PROMPT_SYSTEM_MAX_REPEAT;
+  const parts: string[] = [];
 
-  const system = serializeSystemPrompt(req, systemMax)
-  if (system) parts.push(`[System]\n${system}`)
+  const system = serializeSystemPrompt(req, systemMax);
+  if (system) parts.push(`[System]\n${system}`);
 
   for (const msg of req.messages) {
-    const content = serializeMessageContent(msg.content)
-    if (content) parts.push(`[${msg.role}]\n${content}`)
+    const content = serializeMessageContent(msg.content);
+    if (content) parts.push(`[${msg.role}]\n${content}`);
   }
 
-  return parts.join('\n\n').slice(0, PROMPT_TOTAL_MAX)
+  return parts.join("\n\n").slice(0, PROMPT_TOTAL_MAX);
 }
 
 function serializeSystemPrompt(req: MessagesRequest, maxLength: number): string {
-  if (!req.system) return ''
-  const text = typeof req.system === 'string'
-    ? req.system
-    : req.system
-        .filter(part => part.type === 'text')
-        .map(part => part.text)
-        .join('\n')
+  if (!req.system) return "";
+  const text =
+    typeof req.system === "string"
+      ? req.system
+      : req.system
+          .filter((part) => part.type === "text")
+          .map((part) => part.text)
+          .join("\n");
 
-  return truncate(text, maxLength)
+  return truncate(text, maxLength);
 }
 
-function serializeMessageContent(content: MessagesRequest['messages'][number]['content']): string {
-  if (typeof content === 'string') return content
+function serializeMessageContent(content: MessagesRequest["messages"][number]["content"]): string {
+  if (typeof content === "string") return content;
   return (content as ContentBlock[])
-    .filter(block => block.type === 'text')
-    .map(block => (block as { type: 'text'; text: string }).text)
-    .join('\n')
+    .filter((block) => block.type === "text")
+    .map((block) => (block as { type: "text"; text: string }).text)
+    .join("\n");
 }
 
 function truncate(value: string, maxLength: number): string {
-  return value.length > maxLength ? `${value.slice(0, maxLength)}…` : value
+  return value.length > maxLength ? `${value.slice(0, maxLength)}…` : value;
 }

--- a/packages/daemon/src/proxy/services/stream-result.ts
+++ b/packages/daemon/src/proxy/services/stream-result.ts
@@ -1,75 +1,67 @@
-import { SSE_HEADERS, teeWithCapture } from '../../core/sse/writer.js'
-import { updateSessionRequestResponse } from '../../runtime/sessions.js'
-import { anthropicError } from '../errors.js'
-import type { MessageServiceResult } from './message-service.js'
+import { SSE_HEADERS, teeWithCapture } from "../../core/sse/writer.js";
+import { updateSessionRequestResponse } from "../../runtime/sessions.js";
+import { anthropicError } from "../errors.js";
+import type { MessageServiceResult } from "./message-service.js";
 
-const RESPONSE_CAPTURE_MAX = 4000
+const RESPONSE_CAPTURE_MAX = 4000;
 
-export function streamResult(
-  stream: ReadableStream<string> | undefined,
-): MessageServiceResult {
-  if (!stream) return emptyStreamError()
+export function streamResult(stream: ReadableStream<string> | undefined): MessageServiceResult {
+  if (!stream) return emptyStreamError();
 
   return {
-    kind: 'stream',
+    kind: "stream",
     status: 200,
     stream,
     headers: { ...SSE_HEADERS },
-  }
+  };
 }
 
 export function streamResultWithCapture(
   stream: ReadableStream<string> | undefined,
   logEntryId: string | undefined,
 ): MessageServiceResult {
-  if (!stream) return emptyStreamError()
-  if (!logEntryId) return streamResult(stream)
+  if (!stream) return emptyStreamError();
+  if (!logEntryId) return streamResult(stream);
 
-  const { stream: captured, getCapturedText } = teeWithCapture(stream)
-  const reader = captured.getReader()
+  const { stream: captured, getCapturedText } = teeWithCapture(stream);
+  const reader = captured.getReader();
   const final = new ReadableStream<string>({
     async pull(controller) {
       try {
-        const { done, value } = await reader.read()
+        const { done, value } = await reader.read();
         if (done) {
-          updateCapturedResponse(logEntryId, getCapturedText)
-          controller.close()
-          return
+          updateCapturedResponse(logEntryId, getCapturedText);
+          controller.close();
+          return;
         }
-        controller.enqueue(value)
+        controller.enqueue(value);
       } catch {
-        updateCapturedResponse(logEntryId, getCapturedText)
-        controller.error(new Error('Stream read error'))
+        updateCapturedResponse(logEntryId, getCapturedText);
+        controller.error(new Error("Stream read error"));
       }
     },
     cancel() {
-      updateCapturedResponse(logEntryId, getCapturedText)
-      reader.cancel().catch(() => {})
+      updateCapturedResponse(logEntryId, getCapturedText);
+      reader.cancel().catch(() => {});
     },
-  })
+  });
 
   return {
-    kind: 'stream',
+    kind: "stream",
     status: 200,
     stream: final,
     headers: { ...SSE_HEADERS },
-  }
+  };
 }
 
-function updateCapturedResponse(
-  logEntryId: string,
-  getCapturedText: () => string,
-): void {
-  updateSessionRequestResponse(
-    logEntryId,
-    getCapturedText().slice(0, RESPONSE_CAPTURE_MAX),
-  )
+function updateCapturedResponse(logEntryId: string, getCapturedText: () => string): void {
+  updateSessionRequestResponse(logEntryId, getCapturedText().slice(0, RESPONSE_CAPTURE_MAX));
 }
 
 function emptyStreamError(): MessageServiceResult {
   return {
-    kind: 'error',
+    kind: "error",
     status: 500,
-    body: anthropicError('api_error', 'Provider returned an empty stream'),
-  }
+    body: anthropicError("api_error", "Provider returned an empty stream"),
+  };
 }

--- a/packages/daemon/src/proxy/token-savers/caveman.ts
+++ b/packages/daemon/src/proxy/token-savers/caveman.ts
@@ -1,59 +1,59 @@
-import type { MessagesRequest } from '../../core/anthropic/types.js'
-import type { CavemanLevel } from '../../config/schema.js'
+import type { CavemanLevel } from "../../config/schema.js";
+import type { MessagesRequest } from "../../core/anthropic/types.js";
 
-const SEP = '\n\n'
+const SEP = "\n\n";
 
-type SystemBlock = { type: 'text'; text: string; cache_control?: unknown }
+type SystemBlock = { type: "text"; text: string; cache_control?: unknown };
 
 const SHARED_BOUNDARIES =
-  'Code blocks, file paths, commands, errors, URLs: keep exact. Security warnings, irreversible action confirmations, multi-step ordered sequences: write normal. Resume terse style after.'
+  "Code blocks, file paths, commands, errors, URLs: keep exact. Security warnings, irreversible action confirmations, multi-step ordered sequences: write normal. Resume terse style after.";
 
 const CAVEMAN_PROMPTS: Record<CavemanLevel, string> = {
   lite: [
-    'Respond tersely. Keep grammar and full sentences but drop filler, hedging and pleasantries.',
-    'Pattern: state the thing, the action, the reason. Then next step.',
+    "Respond tersely. Keep grammar and full sentences but drop filler, hedging and pleasantries.",
+    "Pattern: state the thing, the action, the reason. Then next step.",
     SHARED_BOUNDARIES,
-    'Active every response until user asks for normal mode.',
-  ].join(' '),
+    "Active every response until user asks for normal mode.",
+  ].join(" "),
   full: [
-    'Respond like terse caveman. All technical substance stay exact, only fluff die.',
-    'Drop articles, filler, pleasantries, hedging. Fragments OK. Short synonyms.',
-    'Pattern: thing action reason. next step.',
+    "Respond like terse caveman. All technical substance stay exact, only fluff die.",
+    "Drop articles, filler, pleasantries, hedging. Fragments OK. Short synonyms.",
+    "Pattern: thing action reason. next step.",
     SHARED_BOUNDARIES,
-    'Active every response until user asks for normal mode.',
-  ].join(' '),
+    "Active every response until user asks for normal mode.",
+  ].join(" "),
   ultra: [
-    'Respond ultra-terse. Maximum compression. Telegraphic.',
-    'Abbreviate DB/auth/config/req/res/fn/impl, strip conjunctions, use arrows for causality.',
-    'Pattern: thing -> result. fix.',
+    "Respond ultra-terse. Maximum compression. Telegraphic.",
+    "Abbreviate DB/auth/config/req/res/fn/impl, strip conjunctions, use arrows for causality.",
+    "Pattern: thing -> result. fix.",
     SHARED_BOUNDARIES,
-    'Active every response until user asks for normal mode.',
-  ].join(' '),
-}
+    "Active every response until user asks for normal mode.",
+  ].join(" "),
+};
 
 export function injectCaveman(req: MessagesRequest, enabled: boolean, level: CavemanLevel): void {
-  if (!enabled) return
-  const prompt = CAVEMAN_PROMPTS[level]
-  if (!prompt) return
+  if (!enabled) return;
+  const prompt = CAVEMAN_PROMPTS[level];
+  if (!prompt) return;
 
-  if (typeof req.system === 'string') {
-    req.system = req.system ? `${req.system}${SEP}${prompt}` : prompt
-    return
+  if (typeof req.system === "string") {
+    req.system = req.system ? `${req.system}${SEP}${prompt}` : prompt;
+    return;
   }
 
   if (Array.isArray(req.system)) {
-    const block: SystemBlock = { type: 'text', text: prompt }
-    let lastCacheIdx = -1
+    const block: SystemBlock = { type: "text", text: prompt };
+    let lastCacheIdx = -1;
     for (let i = req.system.length - 1; i >= 0; i -= 1) {
       if ((req.system[i] as SystemBlock).cache_control !== undefined) {
-        lastCacheIdx = i
-        break
+        lastCacheIdx = i;
+        break;
       }
     }
-    if (lastCacheIdx >= 0) req.system.splice(lastCacheIdx, 0, block)
-    else req.system.push(block)
-    return
+    if (lastCacheIdx >= 0) req.system.splice(lastCacheIdx, 0, block);
+    else req.system.push(block);
+    return;
   }
 
-  req.system = prompt
+  req.system = prompt;
 }

--- a/packages/daemon/src/proxy/token-savers/rtk.ts
+++ b/packages/daemon/src/proxy/token-savers/rtk.ts
@@ -1,515 +1,567 @@
-import type { ContentBlock, MessagesRequest } from '../../core/anthropic/types.js'
+import type { ContentBlock, MessagesRequest } from "../../core/anthropic/types.js";
 
-const RAW_CAP = 10 * 1024 * 1024
-const MIN_COMPRESS_SIZE = 500
-const DETECT_WINDOW = 1024
-const GIT_DIFF_HUNK_MAX_LINES = 100
-const GREP_PER_FILE_MAX = 10
-const FIND_PER_DIR_MAX = 10
-const FIND_TOTAL_DIR_MAX = 20
-const STATUS_MAX_FILES = 10
-const STATUS_MAX_UNTRACKED = 10
-const DEDUP_LINE_MAX = 2000
-const SMART_TRUNCATE_HEAD = 120
-const SMART_TRUNCATE_TAIL = 60
-const SMART_TRUNCATE_MIN_LINES = 250
-const READ_NUMBERED_MIN_HIT_RATIO = 0.7
-const SEARCH_LIST_PER_DIR_MAX = 10
-const SEARCH_LIST_TOTAL_DIR_MAX = 20
-const TREE_MAX_LINES = 200
+const RAW_CAP = 10 * 1024 * 1024;
+const MIN_COMPRESS_SIZE = 500;
+const DETECT_WINDOW = 1024;
+const GIT_DIFF_HUNK_MAX_LINES = 100;
+const GREP_PER_FILE_MAX = 10;
+const FIND_PER_DIR_MAX = 10;
+const FIND_TOTAL_DIR_MAX = 20;
+const STATUS_MAX_FILES = 10;
+const STATUS_MAX_UNTRACKED = 10;
+const DEDUP_LINE_MAX = 2000;
+const SMART_TRUNCATE_HEAD = 120;
+const SMART_TRUNCATE_TAIL = 60;
+const SMART_TRUNCATE_MIN_LINES = 250;
+const READ_NUMBERED_MIN_HIT_RATIO = 0.7;
+const SEARCH_LIST_PER_DIR_MAX = 10;
+const SEARCH_LIST_TOTAL_DIR_MAX = 20;
+const TREE_MAX_LINES = 200;
 
-type Filter = ((input: string) => string) & { filterName?: string }
+type Filter = ((input: string) => string) & { filterName?: string };
 
 export type RtkCompressionStats = {
-  bytesBefore: number
-  bytesAfter: number
-  hits: Array<{ shape: string; filter: string; saved: number }>
-}
+  bytesBefore: number;
+  bytesAfter: number;
+  hits: Array<{ shape: string; filter: string; saved: number }>;
+};
 
-export function compressMessages(req: MessagesRequest, enabled: boolean): RtkCompressionStats | null {
-  if (!enabled) return null
+export function compressMessages(
+  req: MessagesRequest,
+  enabled: boolean,
+): RtkCompressionStats | null {
+  if (!enabled) return null;
 
-  const stats: RtkCompressionStats = { bytesBefore: 0, bytesAfter: 0, hits: [] }
+  const stats: RtkCompressionStats = { bytesBefore: 0, bytesAfter: 0, hits: [] };
   try {
     for (const message of req.messages) {
-      if (!Array.isArray(message.content)) continue
+      if (!Array.isArray(message.content)) continue;
       for (const block of message.content) {
-        if (block.type !== 'tool_result' || block.is_error === true) continue
-        if (typeof block.content === 'string') {
-          block.content = compressText(block.content, stats, 'claude-string')
+        if (block.type !== "tool_result" || block.is_error === true) continue;
+        if (typeof block.content === "string") {
+          block.content = compressText(block.content, stats, "claude-string");
         } else if (Array.isArray(block.content)) {
           for (const part of block.content) {
-            if (part.type === 'text') {
-              part.text = compressText(part.text, stats, 'claude-array')
+            if (part.type === "text") {
+              part.text = compressText(part.text, stats, "claude-array");
             }
           }
         }
       }
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    console.warn(`[RTK] compressMessages error: ${message}`)
-    return null
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[RTK] compressMessages error: ${message}`);
+    return null;
   }
 
-  return stats
+  return stats;
 }
 
 export function formatRtkLog(stats: RtkCompressionStats | null): string | null {
-  if (!stats?.hits.length) return null
-  const saved = stats.bytesBefore - stats.bytesAfter
-  const pct = stats.bytesBefore > 0 ? ((saved / stats.bytesBefore) * 100).toFixed(1) : '0'
-  const filters = Array.from(new Set(stats.hits.map(hit => hit.filter))).join(',')
-  return `saved ${saved}B / ${stats.bytesBefore}B (${pct}%) via [${filters}] hits=${stats.hits.length}`
+  if (!stats?.hits.length) return null;
+  const saved = stats.bytesBefore - stats.bytesAfter;
+  const pct = stats.bytesBefore > 0 ? ((saved / stats.bytesBefore) * 100).toFixed(1) : "0";
+  const filters = Array.from(new Set(stats.hits.map((hit) => hit.filter))).join(",");
+  return `saved ${saved}B / ${stats.bytesBefore}B (${pct}%) via [${filters}] hits=${stats.hits.length}`;
 }
 
 function compressText(text: string, stats: RtkCompressionStats, shape: string): string {
-  const bytesIn = text.length
-  stats.bytesBefore += bytesIn
+  const bytesIn = text.length;
+  stats.bytesBefore += bytesIn;
 
   if (bytesIn < MIN_COMPRESS_SIZE || bytesIn > RAW_CAP) {
-    stats.bytesAfter += bytesIn
-    return text
+    stats.bytesAfter += bytesIn;
+    return text;
   }
 
-  const filter = autoDetectFilter(text)
+  const filter = autoDetectFilter(text);
   if (!filter) {
-    stats.bytesAfter += bytesIn
-    return text
+    stats.bytesAfter += bytesIn;
+    return text;
   }
 
-  const out = safeApply(filter, text)
+  const out = safeApply(filter, text);
   if (!out || out.length === 0 || out.length >= bytesIn) {
-    stats.bytesAfter += bytesIn
-    return text
+    stats.bytesAfter += bytesIn;
+    return text;
   }
 
-  stats.bytesAfter += out.length
-  stats.hits.push({ shape, filter: filter.filterName ?? filter.name, saved: bytesIn - out.length })
-  return out
+  stats.bytesAfter += out.length;
+  stats.hits.push({ shape, filter: filter.filterName ?? filter.name, saved: bytesIn - out.length });
+  return out;
 }
 
 function safeApply(filter: Filter, text: string): string {
   try {
-    const out = filter(text)
-    return typeof out === 'string' ? out : text
+    const out = filter(text);
+    return typeof out === "string" ? out : text;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    console.warn(`[rtk] warning: filter '${filter.filterName ?? filter.name}' failed; passing through raw output: ${message}`)
-    return text
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `[rtk] warning: filter '${filter.filterName ?? filter.name}' failed; passing through raw output: ${message}`,
+    );
+    return text;
   }
 }
 
 function autoDetectFilter(text: string): Filter | null {
-  const head = text.length > DETECT_WINDOW ? text.slice(0, DETECT_WINDOW) : text
-  if (/^diff --git /m.test(head) || /^@@ /m.test(head)) return gitDiff
-  if (/^On branch |^nothing to commit|^Changes (not |to be )|^Untracked files:/m.test(head) || isMostlyPorcelain(head)) return gitStatus
+  const head = text.length > DETECT_WINDOW ? text.slice(0, DETECT_WINDOW) : text;
+  if (/^diff --git /m.test(head) || /^@@ /m.test(head)) return gitDiff;
+  if (
+    /^On branch |^nothing to commit|^Changes (not |to be )|^Untracked files:/m.test(head) ||
+    isMostlyPorcelain(head)
+  )
+    return gitStatus;
 
-  const lines = head.split('\n')
-  const totalLines = text.split('\n').length
-  const nonEmpty = lines.filter(line => line.trim().length > 0)
-  if (nonEmpty.slice(0, 5).some(isGrepLine)) return grep
-  if (nonEmpty.length >= 3 && nonEmpty.every(isPathLike)) return find
-  if (/[├└]──|│  /.test(head)) return tree
-  if (/^total \d+$/m.test(head) || countMatches(head, /^[-dlbcps][rwx-]{9}/m) >= 3) return ls
-  if (SEARCH_LIST_HEADER_RE.test(head)) return searchList
-  if (totalLines >= SMART_TRUNCATE_MIN_LINES && isLineNumbered(lines)) return readNumbered
-  if (nonEmpty.length >= 5 && hasDuplicateRun(nonEmpty)) return dedupLog
-  if (totalLines >= SMART_TRUNCATE_MIN_LINES) return smartTruncate
-  return null
+  const lines = head.split("\n");
+  const totalLines = text.split("\n").length;
+  const nonEmpty = lines.filter((line) => line.trim().length > 0);
+  if (nonEmpty.slice(0, 5).some(isGrepLine)) return grep;
+  if (nonEmpty.length >= 3 && nonEmpty.every(isPathLike)) return find;
+  if (/[├└]──|│ {2}/.test(head)) return tree;
+  if (/^total \d+$/m.test(head) || countMatches(head, /^[-dlbcps][rwx-]{9}/m) >= 3) return ls;
+  if (SEARCH_LIST_HEADER_RE.test(head)) return searchList;
+  if (totalLines >= SMART_TRUNCATE_MIN_LINES && isLineNumbered(lines)) return readNumbered;
+  if (nonEmpty.length >= 5 && hasDuplicateRun(nonEmpty)) return dedupLog;
+  if (totalLines >= SMART_TRUNCATE_MIN_LINES) return smartTruncate;
+  return null;
 }
 
 function hasDuplicateRun(lines: string[]): boolean {
   for (let i = 1; i < lines.length; i++) {
-    if (lines[i] === lines[i - 1]) return true
+    if (lines[i] === lines[i - 1]) return true;
   }
-  return false
+  return false;
 }
 
 function isGrepLine(line: string): boolean {
-  const first = line.indexOf(':')
-  if (first === -1) return false
-  const second = line.indexOf(':', first + 1)
-  if (second === -1) return false
-  return /^\d+$/.test(line.slice(first + 1, second))
+  const first = line.indexOf(":");
+  if (first === -1) return false;
+  const second = line.indexOf(":", first + 1);
+  if (second === -1) return false;
+  return /^\d+$/.test(line.slice(first + 1, second));
 }
 
 function isPathLike(line: string): boolean {
-  const t = line.trim()
-  if (!t || t.includes(':')) return false
-  return t.startsWith('.') || t.startsWith('/') || t.includes('/')
+  const t = line.trim();
+  if (!t || t.includes(":")) return false;
+  return t.startsWith(".") || t.startsWith("/") || t.includes("/");
 }
 
 function isMostlyPorcelain(head: string): boolean {
-  const lines = head.split('\n').filter(line => line.trim())
-  if (lines.length < 3) return false
-  const hits = lines.filter(line => /^[ MADRCU?!][ MADRCU?!] \S/m.test(line)).length
-  return hits / lines.length >= 0.6
+  const lines = head.split("\n").filter((line) => line.trim());
+  if (lines.length < 3) return false;
+  const hits = lines.filter((line) => /^[ MADRCU?!][ MADRCU?!] \S/m.test(line)).length;
+  return hits / lines.length >= 0.6;
 }
 
 function isLineNumbered(lines: string[]): boolean {
-  let hits = 0
-  let nonEmpty = 0
+  let hits = 0;
+  let nonEmpty = 0;
   for (const line of lines.slice(0, 100)) {
-    if (!line) continue
-    nonEmpty += 1
-    if (READ_NUMBERED_LINE_RE.test(line)) hits += 1
+    if (!line) continue;
+    nonEmpty += 1;
+    if (READ_NUMBERED_LINE_RE.test(line)) hits += 1;
   }
-  return nonEmpty >= 5 && hits / nonEmpty >= READ_NUMBERED_MIN_HIT_RATIO
+  return nonEmpty >= 5 && hits / nonEmpty >= READ_NUMBERED_MIN_HIT_RATIO;
 }
 
 function countMatches(text: string, re: RegExp): number {
-  return text.match(new RegExp(re.source, re.flags.includes('g') ? re.flags : `${re.flags}g`))?.length ?? 0
+  return (
+    text.match(new RegExp(re.source, re.flags.includes("g") ? re.flags : `${re.flags}g`))?.length ??
+    0
+  );
 }
 
 const gitDiff: Filter = (diff: string, maxLines = 500): string => {
-  const result: string[] = []
-  let currentFile = ''
-  let added = 0
-  let removed = 0
-  let inHunk = false
-  let hunkShown = 0
-  let hunkSkipped = 0
-  let wasTruncated = false
+  const result: string[] = [];
+  let currentFile = "";
+  let added = 0;
+  let removed = 0;
+  let inHunk = false;
+  let hunkShown = 0;
+  let hunkSkipped = 0;
+  let wasTruncated = false;
 
-  for (const line of diff.split('\n')) {
-    if (line.startsWith('diff --git')) {
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("diff --git")) {
       if (hunkSkipped > 0) {
-        result.push(`  ... (${hunkSkipped} lines truncated)`)
-        wasTruncated = true
-        hunkSkipped = 0
+        result.push(`  ... (${hunkSkipped} lines truncated)`);
+        wasTruncated = true;
+        hunkSkipped = 0;
       }
-      if (currentFile && (added > 0 || removed > 0)) result.push(`  +${added} -${removed}`)
-      currentFile = line.split(' b/').slice(1).join(' b/') || 'unknown'
-      result.push(`\n${currentFile}`)
-      added = 0
-      removed = 0
-      inHunk = false
-      hunkShown = 0
-    } else if (line.startsWith('@@')) {
+      if (currentFile && (added > 0 || removed > 0)) result.push(`  +${added} -${removed}`);
+      currentFile = line.split(" b/").slice(1).join(" b/") || "unknown";
+      result.push(`\n${currentFile}`);
+      added = 0;
+      removed = 0;
+      inHunk = false;
+      hunkShown = 0;
+    } else if (line.startsWith("@@")) {
       if (hunkSkipped > 0) {
-        result.push(`  ... (${hunkSkipped} lines truncated)`)
-        wasTruncated = true
-        hunkSkipped = 0
+        result.push(`  ... (${hunkSkipped} lines truncated)`);
+        wasTruncated = true;
+        hunkSkipped = 0;
       }
-      inHunk = true
-      hunkShown = 0
-      result.push(`  ${line}`)
+      inHunk = true;
+      hunkShown = 0;
+      result.push(`  ${line}`);
     } else if (inHunk) {
-      if (line.startsWith('+') && !line.startsWith('+++')) {
-        added += 1
-        if (hunkShown < GIT_DIFF_HUNK_MAX_LINES) result.push(`  ${line}`)
-        else hunkSkipped += 1
-        hunkShown += 1
-      } else if (line.startsWith('-') && !line.startsWith('---')) {
-        removed += 1
-        if (hunkShown < GIT_DIFF_HUNK_MAX_LINES) result.push(`  ${line}`)
-        else hunkSkipped += 1
-        hunkShown += 1
-      } else if (hunkShown < GIT_DIFF_HUNK_MAX_LINES && !line.startsWith('\\') && hunkShown > 0) {
-        result.push(`  ${line}`)
-        hunkShown += 1
+      if (line.startsWith("+") && !line.startsWith("+++")) {
+        added += 1;
+        if (hunkShown < GIT_DIFF_HUNK_MAX_LINES) result.push(`  ${line}`);
+        else hunkSkipped += 1;
+        hunkShown += 1;
+      } else if (line.startsWith("-") && !line.startsWith("---")) {
+        removed += 1;
+        if (hunkShown < GIT_DIFF_HUNK_MAX_LINES) result.push(`  ${line}`);
+        else hunkSkipped += 1;
+        hunkShown += 1;
+      } else if (hunkShown < GIT_DIFF_HUNK_MAX_LINES && !line.startsWith("\\") && hunkShown > 0) {
+        result.push(`  ${line}`);
+        hunkShown += 1;
       }
     }
     if (result.length >= maxLines) {
-      result.push('\n... (more changes truncated)')
-      wasTruncated = true
-      break
+      result.push("\n... (more changes truncated)");
+      wasTruncated = true;
+      break;
     }
   }
 
   if (hunkSkipped > 0) {
-    result.push(`  ... (${hunkSkipped} lines truncated)`)
-    wasTruncated = true
+    result.push(`  ... (${hunkSkipped} lines truncated)`);
+    wasTruncated = true;
   }
-  if (currentFile && (added > 0 || removed > 0)) result.push(`  +${added} -${removed}`)
-  if (wasTruncated) result.push('[full diff: rtk git diff --no-compact]')
-  return result.join('\n')
-}
-gitDiff.filterName = 'git-diff'
+  if (currentFile && (added > 0 || removed > 0)) result.push(`  +${added} -${removed}`);
+  if (wasTruncated) result.push("[full diff: rtk git diff --no-compact]");
+  return result.join("\n");
+};
+gitDiff.filterName = "git-diff";
 
 const gitStatus: Filter = (input: string): string => {
-  const stagedFiles: string[] = []
-  const modifiedFiles: string[] = []
-  const untrackedFiles: string[] = []
-  let branch = ''
-  let staged = 0
-  let modified = 0
-  let untracked = 0
-  let conflicts = 0
-  let inStagedSection = false
+  const stagedFiles: string[] = [];
+  const modifiedFiles: string[] = [];
+  const untrackedFiles: string[] = [];
+  let branch = "";
+  let staged = 0;
+  let modified = 0;
+  let untracked = 0;
+  let conflicts = 0;
+  let inStagedSection = false;
 
-  for (const raw of input.split('\n')) {
-    if (!raw.trim()) continue
-    const longBranch = raw.match(/^On branch (\S+)/)
+  for (const raw of input.split("\n")) {
+    if (!raw.trim()) continue;
+    const longBranch = raw.match(/^On branch (\S+)/);
     if (longBranch) {
-      branch = longBranch[1] ?? ''
-      continue
+      branch = longBranch[1] ?? "";
+      continue;
     }
-    if (raw.startsWith('##')) {
-      branch = raw.replace(/^##\s*/, '')
-      continue
+    if (raw.startsWith("##")) {
+      branch = raw.replace(/^##\s*/, "");
+      continue;
     }
-    if (raw.includes('Changes to be committed:')) {
-      inStagedSection = true
-      continue
+    if (raw.includes("Changes to be committed:")) {
+      inStagedSection = true;
+      continue;
     }
-    if (raw.includes('Changes not staged for commit:') || raw.includes('Untracked files:') || raw.includes('Unmerged paths:')) {
-      inStagedSection = false
-      continue
+    if (
+      raw.includes("Changes not staged for commit:") ||
+      raw.includes("Untracked files:") ||
+      raw.includes("Unmerged paths:")
+    ) {
+      inStagedSection = false;
+      continue;
     }
     if (/^[ MADRCU?!][ MADRCU?!] /.test(raw)) {
-      const x = raw[0]
-      const y = raw[1]
-      const file = raw.slice(3)
-      if (raw.slice(0, 2) === '??') {
-        untracked += 1
-        untrackedFiles.push(file)
-        continue
+      const x = raw[0];
+      const y = raw[1];
+      const file = raw.slice(3);
+      if (raw.slice(0, 2) === "??") {
+        untracked += 1;
+        untrackedFiles.push(file);
+        continue;
       }
-      if ('MADRC'.includes(x)) {
-        staged += 1
-        stagedFiles.push(file)
-      } else if (x === 'U') conflicts += 1
-      if (y === 'M' || y === 'D') {
-        modified += 1
-        modifiedFiles.push(file)
+      if ("MADRC".includes(x)) {
+        staged += 1;
+        stagedFiles.push(file);
+      } else if (x === "U") conflicts += 1;
+      if (y === "M" || y === "D") {
+        modified += 1;
+        modifiedFiles.push(file);
       }
-      continue
+      continue;
     }
-    const longMatch = raw.match(/^\s*(modified|new file|deleted|renamed|both modified):\s+(.+)$/)
-    if (!longMatch) continue
-    const kind = longMatch[1]
-    const file = longMatch[2]?.trim() ?? ''
-    if (kind === 'both modified') conflicts += 1
+    const longMatch = raw.match(/^\s*(modified|new file|deleted|renamed|both modified):\s+(.+)$/);
+    if (!longMatch) continue;
+    const kind = longMatch[1];
+    const file = longMatch[2]?.trim() ?? "";
+    if (kind === "both modified") conflicts += 1;
     else if (inStagedSection) {
-      staged += 1
-      stagedFiles.push(file)
+      staged += 1;
+      stagedFiles.push(file);
     } else {
-      modified += 1
-      modifiedFiles.push(file)
+      modified += 1;
+      modifiedFiles.push(file);
     }
   }
 
-  let out = branch ? `* ${branch}\n` : ''
-  out += statusSection('+ Staged', staged, stagedFiles, STATUS_MAX_FILES)
-  out += statusSection('~ Modified', modified, modifiedFiles, STATUS_MAX_FILES)
-  out += statusSection('? Untracked', untracked, untrackedFiles, STATUS_MAX_UNTRACKED)
-  if (conflicts > 0) out += `conflicts: ${conflicts} files\n`
-  if (staged === 0 && modified === 0 && untracked === 0 && conflicts === 0) out += 'clean - nothing to commit\n'
-  return out.replace(/\n+$/, '')
-}
-gitStatus.filterName = 'git-status'
+  let out = branch ? `* ${branch}\n` : "";
+  out += statusSection("+ Staged", staged, stagedFiles, STATUS_MAX_FILES);
+  out += statusSection("~ Modified", modified, modifiedFiles, STATUS_MAX_FILES);
+  out += statusSection("? Untracked", untracked, untrackedFiles, STATUS_MAX_UNTRACKED);
+  if (conflicts > 0) out += `conflicts: ${conflicts} files\n`;
+  if (staged === 0 && modified === 0 && untracked === 0 && conflicts === 0)
+    out += "clean - nothing to commit\n";
+  return out.replace(/\n+$/, "");
+};
+gitStatus.filterName = "git-status";
 
 function statusSection(title: string, count: number, files: string[], max: number): string {
-  if (count <= 0) return ''
-  let out = `${title}: ${count} files\n`
-  for (const file of files.slice(0, max)) out += `   ${file}\n`
-  if (files.length > max) out += `   ... +${files.length - max} more\n`
-  return out
+  if (count <= 0) return "";
+  let out = `${title}: ${count} files\n`;
+  for (const file of files.slice(0, max)) out += `   ${file}\n`;
+  if (files.length > max) out += `   ... +${files.length - max} more\n`;
+  return out;
 }
 
 const grep: Filter = (input: string): string => {
-  const byFile = new Map<string, Array<[string, string]>>()
-  let total = 0
-  for (const line of input.split('\n')) {
-    const first = line.indexOf(':')
-    const second = first === -1 ? -1 : line.indexOf(':', first + 1)
-    if (first === -1 || second === -1) continue
-    const lineNum = line.slice(first + 1, second)
-    if (!/^\d+$/.test(lineNum)) continue
-    const file = line.slice(0, first)
-    total += 1
-    const matches = byFile.get(file) ?? []
-    matches.push([lineNum, line.slice(second + 1)])
-    byFile.set(file, matches)
+  const byFile = new Map<string, Array<[string, string]>>();
+  let total = 0;
+  for (const line of input.split("\n")) {
+    const first = line.indexOf(":");
+    const second = first === -1 ? -1 : line.indexOf(":", first + 1);
+    if (first === -1 || second === -1) continue;
+    const lineNum = line.slice(first + 1, second);
+    if (!/^\d+$/.test(lineNum)) continue;
+    const file = line.slice(0, first);
+    total += 1;
+    const matches = byFile.get(file) ?? [];
+    matches.push([lineNum, line.slice(second + 1)]);
+    byFile.set(file, matches);
   }
-  if (total === 0) return input
-  let out = `${total} matches in ${byFile.size}F:\n\n`
+  if (total === 0) return input;
+  let out = `${total} matches in ${byFile.size}F:\n\n`;
   for (const file of Array.from(byFile.keys()).sort()) {
-    const matches = byFile.get(file) ?? []
-    out += `[file] ${file} (${matches.length}):\n`
-    for (const [lineNum, content] of matches.slice(0, GREP_PER_FILE_MAX)) out += `  ${lineNum.padStart(4)}: ${content.trim()}\n`
-    if (matches.length > GREP_PER_FILE_MAX) out += `  +${matches.length - GREP_PER_FILE_MAX}\n`
-    out += '\n'
+    const matches = byFile.get(file) ?? [];
+    out += `[file] ${file} (${matches.length}):\n`;
+    for (const [lineNum, content] of matches.slice(0, GREP_PER_FILE_MAX))
+      out += `  ${lineNum.padStart(4)}: ${content.trim()}\n`;
+    if (matches.length > GREP_PER_FILE_MAX) out += `  +${matches.length - GREP_PER_FILE_MAX}\n`;
+    out += "\n";
   }
-  return out
-}
-grep.filterName = 'grep'
+  return out;
+};
+grep.filterName = "grep";
 
 const find: Filter = (input: string): string => {
-  const lines = input.split('\n').filter(line => line.trim())
-  if (!lines.length) return input
-  const byDir = new Map<string, string[]>()
+  const lines = input.split("\n").filter((line) => line.trim());
+  if (!lines.length) return input;
+  const byDir = new Map<string, string[]>();
   for (const p of lines) {
-    const slash = p.lastIndexOf('/')
-    const dir = slash === -1 ? '.' : p.slice(0, slash) || '/'
-    const basename = slash === -1 ? p : p.slice(slash + 1)
-    byDir.set(dir, [...(byDir.get(dir) ?? []), basename])
+    const slash = p.lastIndexOf("/");
+    const dir = slash === -1 ? "." : p.slice(0, slash) || "/";
+    const basename = slash === -1 ? p : p.slice(slash + 1);
+    byDir.set(dir, [...(byDir.get(dir) ?? []), basename]);
   }
-  const dirs = Array.from(byDir.keys()).sort()
-  let out = `${lines.length} files in ${dirs.length} dirs:\n\n`
+  const dirs = Array.from(byDir.keys()).sort();
+  let out = `${lines.length} files in ${dirs.length} dirs:\n\n`;
   for (const dir of dirs.slice(0, FIND_TOTAL_DIR_MAX)) {
-    const files = byDir.get(dir) ?? []
-    out += `${dir}/ (${files.length}):\n`
-    for (const file of files.slice(0, FIND_PER_DIR_MAX)) out += `  ${file}\n`
-    if (files.length > FIND_PER_DIR_MAX) out += `  +${files.length - FIND_PER_DIR_MAX}\n`
-    out += '\n'
+    const files = byDir.get(dir) ?? [];
+    out += `${dir}/ (${files.length}):\n`;
+    for (const file of files.slice(0, FIND_PER_DIR_MAX)) out += `  ${file}\n`;
+    if (files.length > FIND_PER_DIR_MAX) out += `  +${files.length - FIND_PER_DIR_MAX}\n`;
+    out += "\n";
   }
-  if (dirs.length > FIND_TOTAL_DIR_MAX) out += `+${dirs.length - FIND_TOTAL_DIR_MAX} more dirs\n`
-  return out
-}
-find.filterName = 'find'
+  if (dirs.length > FIND_TOTAL_DIR_MAX) out += `+${dirs.length - FIND_TOTAL_DIR_MAX} more dirs\n`;
+  return out;
+};
+find.filterName = "find";
 
 const dedupLog: Filter = (input: string): string => {
-  const out: string[] = []
-  let prev: string | null = null
-  let runCount = 0
-  let blankStreak = 0
+  const out: string[] = [];
+  let prev: string | null = null;
+  let runCount = 0;
+  let blankStreak = 0;
   const flushRun = () => {
-    if (prev !== null && runCount > 1) out.push(`  ... (${runCount - 1} duplicate lines)`)
-  }
-  for (const line of input.split('\n')) {
-    if (line.trim() === '') {
-      if (blankStreak < 1) out.push(line)
-      blankStreak += 1
-      flushRun()
-      prev = null
-      runCount = 0
-      continue
+    if (prev !== null && runCount > 1) out.push(`  ... (${runCount - 1} duplicate lines)`);
+  };
+  for (const line of input.split("\n")) {
+    if (line.trim() === "") {
+      if (blankStreak < 1) out.push(line);
+      blankStreak += 1;
+      flushRun();
+      prev = null;
+      runCount = 0;
+      continue;
     }
-    blankStreak = 0
+    blankStreak = 0;
     if (line === prev) {
-      runCount += 1
-      continue
+      runCount += 1;
+      continue;
     }
-    flushRun()
-    out.push(line)
-    prev = line
-    runCount = 1
-    if (out.length >= DEDUP_LINE_MAX) return `${out.join('\n')}\n... (truncated at ${DEDUP_LINE_MAX} lines)`
+    flushRun();
+    out.push(line);
+    prev = line;
+    runCount = 1;
+    if (out.length >= DEDUP_LINE_MAX)
+      return `${out.join("\n")}\n... (truncated at ${DEDUP_LINE_MAX} lines)`;
   }
-  flushRun()
-  return out.join('\n')
-}
-dedupLog.filterName = 'dedup-log'
+  flushRun();
+  return out.join("\n");
+};
+dedupLog.filterName = "dedup-log";
 
-const smartTruncate: Filter = (input: string): string => truncateLines(input, '... +{cut} lines truncated')
-smartTruncate.filterName = 'smart-truncate'
+const smartTruncate: Filter = (input: string): string =>
+  truncateLines(input, "... +{cut} lines truncated");
+smartTruncate.filterName = "smart-truncate";
 
-const READ_NUMBERED_LINE_RE = /^\s*\d+\|/
-const readNumbered: Filter = (input: string): string => truncateLines(input, '... +{cut} lines truncated (file continues)')
-readNumbered.filterName = 'read-numbered'
+const READ_NUMBERED_LINE_RE = /^\s*\d+\|/;
+const readNumbered: Filter = (input: string): string =>
+  truncateLines(input, "... +{cut} lines truncated (file continues)");
+readNumbered.filterName = "read-numbered";
 
 function truncateLines(input: string, marker: string): string {
-  const lines = input.split('\n')
-  if (lines.length < SMART_TRUNCATE_MIN_LINES) return input
-  const head = lines.slice(0, SMART_TRUNCATE_HEAD)
-  const tail = lines.slice(lines.length - SMART_TRUNCATE_TAIL)
-  const cut = lines.length - head.length - tail.length
-  return [...head, marker.replace('{cut}', String(cut)), ...tail].join('\n')
+  const lines = input.split("\n");
+  if (lines.length < SMART_TRUNCATE_MIN_LINES) return input;
+  const head = lines.slice(0, SMART_TRUNCATE_HEAD);
+  const tail = lines.slice(lines.length - SMART_TRUNCATE_TAIL);
+  const cut = lines.length - head.length - tail.length;
+  return [...head, marker.replace("{cut}", String(cut)), ...tail].join("\n");
 }
 
 const tree: Filter = (input: string): string => {
   const filtered = input
-    .split('\n')
-    .filter(line => !(line.includes('director') && line.includes('file')))
-  while (filtered.length > 0 && filtered[0]?.trim() === '') filtered.shift()
-  while (filtered.length > 0 && filtered[filtered.length - 1]?.trim() === '') filtered.pop()
-  if (filtered.length > TREE_MAX_LINES) return `${filtered.slice(0, TREE_MAX_LINES).join('\n')}\n... +${filtered.length - TREE_MAX_LINES} more lines`
-  return filtered.join('\n')
-}
-tree.filterName = 'tree'
+    .split("\n")
+    .filter((line) => !(line.includes("director") && line.includes("file")));
+  while (filtered.length > 0 && filtered[0]?.trim() === "") filtered.shift();
+  while (filtered.length > 0 && filtered[filtered.length - 1]?.trim() === "") filtered.pop();
+  if (filtered.length > TREE_MAX_LINES)
+    return `${filtered.slice(0, TREE_MAX_LINES).join("\n")}\n... +${filtered.length - TREE_MAX_LINES} more lines`;
+  return filtered.join("\n");
+};
+tree.filterName = "tree";
 
-const SEARCH_LIST_HEADER_RE = /^Result of search in '[^']*' \(total (\d+) files?\):/
+const SEARCH_LIST_HEADER_RE = /^Result of search in '[^']*' \(total (\d+) files?\):/;
 const searchList: Filter = (input: string): string => {
-  const lines = input.split('\n')
-  const header = lines[0] ?? ''
-  const paths = lines.slice(1).map(line => line.trim()).filter(line => line.startsWith('- ')).map(line => line.slice(2))
-  if (!paths.length) return input
-  const byDir = new Map<string, string[]>()
+  const lines = input.split("\n");
+  const header = lines[0] ?? "";
+  const paths = lines
+    .slice(1)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "))
+    .map((line) => line.slice(2));
+  if (!paths.length) return input;
+  const byDir = new Map<string, string[]>();
   for (const p of paths) {
-    const slash = p.lastIndexOf('/')
-    const dir = slash === -1 ? '.' : p.slice(0, slash) || '/'
-    const name = slash === -1 ? p : p.slice(slash + 1)
-    byDir.set(dir, [...(byDir.get(dir) ?? []), name])
+    const slash = p.lastIndexOf("/");
+    const dir = slash === -1 ? "." : p.slice(0, slash) || "/";
+    const name = slash === -1 ? p : p.slice(slash + 1);
+    byDir.set(dir, [...(byDir.get(dir) ?? []), name]);
   }
-  const dirs = Array.from(byDir.keys()).sort()
-  let out = `${header}\n${paths.length} files in ${dirs.length} dirs:\n\n`
+  const dirs = Array.from(byDir.keys()).sort();
+  let out = `${header}\n${paths.length} files in ${dirs.length} dirs:\n\n`;
   for (const dir of dirs.slice(0, SEARCH_LIST_TOTAL_DIR_MAX)) {
-    const names = byDir.get(dir) ?? []
-    out += `${dir}/ (${names.length}):\n`
-    for (const name of names.slice(0, SEARCH_LIST_PER_DIR_MAX)) out += `  ${name}\n`
-    if (names.length > SEARCH_LIST_PER_DIR_MAX) out += `  +${names.length - SEARCH_LIST_PER_DIR_MAX}\n`
-    out += '\n'
+    const names = byDir.get(dir) ?? [];
+    out += `${dir}/ (${names.length}):\n`;
+    for (const name of names.slice(0, SEARCH_LIST_PER_DIR_MAX)) out += `  ${name}\n`;
+    if (names.length > SEARCH_LIST_PER_DIR_MAX)
+      out += `  +${names.length - SEARCH_LIST_PER_DIR_MAX}\n`;
+    out += "\n";
   }
-  if (dirs.length > SEARCH_LIST_TOTAL_DIR_MAX) out += `+${dirs.length - SEARCH_LIST_TOTAL_DIR_MAX} more dirs\n`
-  return out.replace(/\n+$/, '')
-}
-searchList.filterName = 'search-list'
+  if (dirs.length > SEARCH_LIST_TOTAL_DIR_MAX)
+    out += `+${dirs.length - SEARCH_LIST_TOTAL_DIR_MAX} more dirs\n`;
+  return out.replace(/\n+$/, "");
+};
+searchList.filterName = "search-list";
 
-const LS_DATE_RE = /\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+(\d{4}|\d{2}:\d{2})\s+/
-const LS_NOISE_DIRS = new Set(['node_modules', '.git', 'target', '__pycache__', '.next', 'dist', 'build', '.venv', 'venv', '.cache', '.idea', '.vscode', '.DS_Store'])
+const LS_DATE_RE =
+  /\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+(\d{4}|\d{2}:\d{2})\s+/;
+const LS_NOISE_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "target",
+  "__pycache__",
+  ".next",
+  "dist",
+  "build",
+  ".venv",
+  "venv",
+  ".cache",
+  ".idea",
+  ".vscode",
+  ".DS_Store",
+]);
 
 const ls: Filter = (input: string): string => {
-  const dirs: string[] = []
-  const files: Array<[string, string]> = []
-  const byExt = new Map<string, number>()
-  for (const line of input.split('\n')) {
-    if (line.startsWith('total ') || !line) continue
-    const parsed = parseLsLine(line)
-    if (!parsed || parsed.name === '.' || parsed.name === '..' || LS_NOISE_DIRS.has(parsed.name)) continue
-    if (parsed.fileType === 'd') dirs.push(parsed.name)
-    else if (parsed.fileType === '-' || parsed.fileType === 'l') {
-      const dot = parsed.name.lastIndexOf('.')
-      const ext = dot > 0 ? parsed.name.slice(dot) : 'no ext'
-      byExt.set(ext, (byExt.get(ext) ?? 0) + 1)
-      files.push([parsed.name, humanSize(parsed.size)])
+  const dirs: string[] = [];
+  const files: Array<[string, string]> = [];
+  const byExt = new Map<string, number>();
+  for (const line of input.split("\n")) {
+    if (line.startsWith("total ") || !line) continue;
+    const parsed = parseLsLine(line);
+    if (!parsed || parsed.name === "." || parsed.name === ".." || LS_NOISE_DIRS.has(parsed.name))
+      continue;
+    if (parsed.fileType === "d") dirs.push(parsed.name);
+    else if (parsed.fileType === "-" || parsed.fileType === "l") {
+      const dot = parsed.name.lastIndexOf(".");
+      const ext = dot > 0 ? parsed.name.slice(dot) : "no ext";
+      byExt.set(ext, (byExt.get(ext) ?? 0) + 1);
+      files.push([parsed.name, humanSize(parsed.size)]);
     }
   }
-  if (dirs.length === 0 && files.length === 0) return input
-  let out = ''
-  for (const dir of dirs) out += `${dir}/\n`
-  for (const [name, size] of files) out += `${name}  ${size}\n`
-  let summary = `\nSummary: ${files.length} files, ${dirs.length} dirs`
+  if (dirs.length === 0 && files.length === 0) return input;
+  let out = "";
+  for (const dir of dirs) out += `${dir}/\n`;
+  for (const [name, size] of files) out += `${name}  ${size}\n`;
+  let summary = `\nSummary: ${files.length} files, ${dirs.length} dirs`;
   if (byExt.size > 0) {
-    const ext = Array.from(byExt.entries()).sort((a, b) => b[1] - a[1])
-    summary += ` (${ext.slice(0, 5).map(([e, c]) => `${c} ${e}`).join(', ')}`
-    if (ext.length > 5) summary += `, +${ext.length - 5} more`
-    summary += ')'
+    const ext = Array.from(byExt.entries()).sort((a, b) => b[1] - a[1]);
+    summary += ` (${ext
+      .slice(0, 5)
+      .map(([e, c]) => `${c} ${e}`)
+      .join(", ")}`;
+    if (ext.length > 5) summary += `, +${ext.length - 5} more`;
+    summary += ")";
   }
-  return out + summary
-}
-ls.filterName = 'ls'
+  return out + summary;
+};
+ls.filterName = "ls";
 
 function parseLsLine(line: string): { fileType: string; size: number; name: string } | null {
-  const match = LS_DATE_RE.exec(line)
-  if (!match) return null
-  const beforeParts = line.slice(0, match.index).split(/\s+/).filter(Boolean)
-  if (beforeParts.length < 4) return null
-  const perms = beforeParts[0] ?? ''
-  let size = 0
+  const match = LS_DATE_RE.exec(line);
+  if (!match) return null;
+  const beforeParts = line.slice(0, match.index).split(/\s+/).filter(Boolean);
+  if (beforeParts.length < 4) return null;
+  const perms = beforeParts[0] ?? "";
+  let size = 0;
   for (let i = beforeParts.length - 1; i >= 0; i -= 1) {
-    const n = Number(beforeParts[i])
+    const n = Number(beforeParts[i]);
     if (Number.isInteger(n) && String(n) === beforeParts[i]) {
-      size = n
-      break
+      size = n;
+      break;
     }
   }
-  return { fileType: perms.charAt(0), size, name: line.slice(match.index + match[0].length) }
+  return { fileType: perms.charAt(0), size, name: line.slice(match.index + match[0].length) };
 }
 
 function humanSize(bytes: number): string {
-  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)}M`
-  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)}K`
-  return `${bytes}B`
+  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)}M`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)}K`;
+  return `${bytes}B`;
 }
 
 export function cloneMessagesRequest(req: MessagesRequest): MessagesRequest {
-  return structuredClone(req) as MessagesRequest
+  return structuredClone(req) as MessagesRequest;
 }
 
-export function extractToolResultText(block: Extract<ContentBlock, { type: 'tool_result' }>): string {
-  if (typeof block.content === 'string') return block.content
-  return block.content.filter(part => part.type === 'text').map(part => part.text).join('\n')
+export function extractToolResultText(
+  block: Extract<ContentBlock, { type: "tool_result" }>,
+): string {
+  if (typeof block.content === "string") return block.content;
+  return block.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
 }

--- a/packages/daemon/src/proxy/token-savers/token-savers.test.ts
+++ b/packages/daemon/src/proxy/token-savers/token-savers.test.ts
@@ -1,104 +1,113 @@
-import assert from 'node:assert/strict'
-import { test } from 'node:test'
-import type { MessagesRequest } from '../../core/anthropic/types.js'
-import { injectCaveman } from './caveman.js'
-import { compressMessages } from './rtk.js'
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { MessagesRequest } from "../../core/anthropic/types.js";
+import { injectCaveman } from "./caveman.js";
+import { compressMessages } from "./rtk.js";
 
-test('RTK compresses large tool_result grep output', () => {
-  const lines = Array.from({ length: 30 }, (_, i) => `src/file-${i % 3}.ts:${i + 1}:const value${i} = true`)
-  const req = baseRequest(lines.join('\n'))
+test("RTK compresses large tool_result grep output", () => {
+  const lines = Array.from(
+    { length: 30 },
+    (_, i) => `src/file-${i % 3}.ts:${i + 1}:const value${i} = true`,
+  );
+  const req = baseRequest(lines.join("\n"));
 
-  const before = toolContent(req).length
-  const stats = compressMessages(req, true)
-  const after = toolContent(req).length
+  const before = toolContent(req).length;
+  const stats = compressMessages(req, true);
+  const after = toolContent(req).length;
 
-  assert.ok(stats)
-  assert.ok(stats.hits.some(hit => hit.filter === 'grep'))
-  assert.ok(after < before)
-  assert.match(toolContent(req), /matches in 3F/)
-})
+  assert.ok(stats);
+  assert.ok(stats.hits.some((hit) => hit.filter === "grep"));
+  assert.ok(after < before);
+  assert.match(toolContent(req), /matches in 3F/);
+});
 
-test('RTK leaves errored tool_result content untouched', () => {
-  const req = baseRequest('src/a.ts:1:value\n'.repeat(80), true)
+test("RTK leaves errored tool_result content untouched", () => {
+  const req = baseRequest("src/a.ts:1:value\n".repeat(80), true);
 
-  const before = toolContent(req)
-  const stats = compressMessages(req, true)
+  const before = toolContent(req);
+  const stats = compressMessages(req, true);
 
-  assert.equal(toolContent(req), before)
-  assert.equal(stats?.hits.length, 0)
-})
+  assert.equal(toolContent(req), before);
+  assert.equal(stats?.hits.length, 0);
+});
 
-test('caveman injects terse guidance into existing system prompt', () => {
-  const req = baseRequest('small')
-  req.system = 'Existing rules.'
+test("caveman injects terse guidance into existing system prompt", () => {
+  const req = baseRequest("small");
+  req.system = "Existing rules.";
 
-  injectCaveman(req, true, 'ultra')
+  injectCaveman(req, true, "ultra");
 
-  assert.equal(typeof req.system, 'string')
-  assert.match(req.system as string, /Existing rules\./)
-  assert.match(req.system as string, /ultra-terse/)
-})
+  assert.equal(typeof req.system, "string");
+  assert.match(req.system as string, /Existing rules\./);
+  assert.match(req.system as string, /ultra-terse/);
+});
 
-test('caveman inserts before last cache_control block to preserve prompt cache', () => {
-  const req = baseRequest('small')
+test("caveman inserts before last cache_control block to preserve prompt cache", () => {
+  const req = baseRequest("small");
   req.system = [
-    { type: 'text', text: 'rule A' },
-    { type: 'text', text: 'rule B', cache_control: { type: 'ephemeral' } } as { type: 'text'; text: string },
-    { type: 'text', text: 'rule C' },
-  ]
+    { type: "text", text: "rule A" },
+    { type: "text", text: "rule B", cache_control: { type: "ephemeral" } } as {
+      type: "text";
+      text: string;
+    },
+    { type: "text", text: "rule C" },
+  ];
 
-  injectCaveman(req, true, 'full')
+  injectCaveman(req, true, "full");
 
-  assert.ok(Array.isArray(req.system))
-  const texts = (req.system as Array<{ text: string }>).map(b => b.text)
-  const cavemanIdx = texts.findIndex(t => /terse caveman/.test(t))
-  const cachedIdx = texts.findIndex(t => t === 'rule B')
-  assert.ok(cavemanIdx >= 0 && cachedIdx >= 0)
-  assert.ok(cavemanIdx < cachedIdx, `caveman (${cavemanIdx}) must come before cached block (${cachedIdx})`)
-})
+  assert.ok(Array.isArray(req.system));
+  const texts = (req.system as Array<{ text: string }>).map((b) => b.text);
+  const cavemanIdx = texts.findIndex((t) => /terse caveman/.test(t));
+  const cachedIdx = texts.findIndex((t) => t === "rule B");
+  assert.ok(cavemanIdx >= 0 && cachedIdx >= 0);
+  assert.ok(
+    cavemanIdx < cachedIdx,
+    `caveman (${cavemanIdx}) must come before cached block (${cachedIdx})`,
+  );
+});
 
-test('caveman appends to system array when no cache_control present', () => {
-  const req = baseRequest('small')
+test("caveman appends to system array when no cache_control present", () => {
+  const req = baseRequest("small");
   req.system = [
-    { type: 'text', text: 'rule A' },
-    { type: 'text', text: 'rule B' },
-  ]
+    { type: "text", text: "rule A" },
+    { type: "text", text: "rule B" },
+  ];
 
-  injectCaveman(req, true, 'lite')
+  injectCaveman(req, true, "lite");
 
-  assert.ok(Array.isArray(req.system))
-  const arr = req.system as Array<{ text: string }>
-  assert.equal(arr.length, 3)
-  assert.match(arr[2]!.text, /terse/)
-})
+  assert.ok(Array.isArray(req.system));
+  const arr = req.system as Array<{ text: string }>;
+  assert.equal(arr.length, 3);
+  assert.match(arr[2]!.text, /terse/);
+});
 
 function baseRequest(toolResult: string, isError = false): MessagesRequest {
   return {
-    model: 'claude-sonnet-4-5',
+    model: "claude-sonnet-4-5",
     max_tokens: 1024,
     messages: [
       {
-        role: 'user',
+        role: "user",
         content: [
           {
-            type: 'tool_result',
-            tool_use_id: 'toolu_123',
+            type: "tool_result",
+            tool_use_id: "toolu_123",
             content: toolResult,
             is_error: isError,
           },
         ],
       },
     ],
-  }
+  };
 }
 
 function toolContent(req: MessagesRequest): string {
-  const content = req.messages[0]?.content
-  assert.ok(Array.isArray(content))
-  const block = content[0]
-  assert.equal(block?.type, 'tool_result')
-  if (block.type !== 'tool_result' || typeof block.content !== 'string') {
-    throw new Error('expected string tool_result content')
+  const content = req.messages[0]?.content;
+  assert.ok(Array.isArray(content));
+  const block = content[0];
+  assert.equal(block?.type, "tool_result");
+  if (block.type !== "tool_result" || typeof block.content !== "string") {
+    throw new Error("expected string tool_result content");
   }
-  return block.content
+  return block.content;
 }

--- a/packages/daemon/src/runtime/daemon.ts
+++ b/packages/daemon/src/runtime/daemon.ts
@@ -1,98 +1,97 @@
-import { serve } from '@hono/node-server'
-import type { Hono } from 'hono'
-import type { Config } from '../config/schema.js'
-import { writePid, removePid } from './process.js'
-import { createProxyApp } from '../proxy/app.js'
-import { createPanelApp } from '../panel/app.js'
-import { logger } from '../observability/log.js'
-import { endSession } from './sessions.js'
+import { serve } from "@hono/node-server";
+import type { Hono } from "hono";
+import type { Config } from "../config/schema.js";
+import { logger } from "../observability/log.js";
+import { createPanelApp } from "../panel/app.js";
+import { createProxyApp } from "../proxy/app.js";
+import { removePid, writePid } from "./process.js";
+import { endSession } from "./sessions.js";
 
 type ManagedServer = ReturnType<typeof serve> & {
-  closeAllConnections: () => void
-}
+  closeAllConnections: () => void;
+};
 
-type ServiceName = 'proxy' | 'panel'
+type ServiceName = "proxy" | "panel";
 
 interface ServerBinding {
-  name: ServiceName
-  port: number
-  app: Hono
-  onReady?: () => void
+  name: ServiceName;
+  port: number;
+  app: Hono;
+  onReady?: () => void;
 }
 
 export function startDaemon(config: Config): void {
-  const runtime = new DaemonRuntime(config)
-  runtime.start()
+  const runtime = new DaemonRuntime(config);
+  runtime.start();
 }
 
 class DaemonRuntime {
-  private readonly ready = new Set<ServiceName>()
-  private servers: ManagedServer[] = []
+  private readonly ready = new Set<ServiceName>();
+  private servers: ManagedServer[] = [];
 
   constructor(private readonly config: Config) {}
 
   start(): void {
     this.servers = [
       this.bind({
-        name: 'proxy',
+        name: "proxy",
         port: this.config.server.proxyPort,
         app: createProxyApp(this.config),
       }),
       this.bind({
-        name: 'panel',
+        name: "panel",
         port: this.config.server.panelPort,
         app: createPanelApp(this.config),
         onReady: () => {
-          const panelPort = process.env['NODE_ENV'] !== 'production'
-            ? 5173
-            : this.config.server.panelPort
-          logger.info('panel', `http://localhost:${panelPort}`)
+          const panelPort =
+            process.env["NODE_ENV"] !== "production" ? 5173 : this.config.server.panelPort;
+          logger.info("panel", `http://localhost:${panelPort}`);
         },
       }),
-    ]
+    ];
 
-    process.on('SIGINT', () => this.shutdown())
-    process.on('SIGTERM', () => this.shutdown())
+    process.on("SIGINT", () => this.shutdown());
+    process.on("SIGTERM", () => this.shutdown());
   }
 
   private bind(binding: ServerBinding): ManagedServer {
     // Local-first: loopback only. The Tauri webview and dev tooling both
     // live on the host machine; nothing legitimate connects from outside.
     const server = serve(
-      { fetch: binding.app.fetch, port: binding.port, hostname: '127.0.0.1' },
+      { fetch: binding.app.fetch, port: binding.port, hostname: "127.0.0.1" },
       () => {
-        logger.info(binding.name, `listening on 127.0.0.1:${binding.port}`)
-        binding.onReady?.()
-        this.markReady(binding.name)
+        logger.info(binding.name, `listening on 127.0.0.1:${binding.port}`);
+        binding.onReady?.();
+        this.markReady(binding.name);
       },
-    ) as ManagedServer
+    ) as ManagedServer;
 
-    server.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code === 'EADDRINUSE') {
-        logger.error(binding.name, `port ${binding.port} already in use`)
-        process.exit(1)
+    server.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "EADDRINUSE") {
+        logger.error(binding.name, `port ${binding.port} already in use`);
+        process.exit(1);
       }
-      logger.error(binding.name, err.message)
-    })
+      logger.error(binding.name, err.message);
+    });
 
-    return server
+    return server;
   }
 
   private markReady(name: ServiceName): void {
-    this.ready.add(name)
-    if (this.ready.size !== 2) return
-    writePid(process.pid)
+    this.ready.add(name);
+    if (this.ready.size !== 2) return;
+    writePid(process.pid);
   }
 
   private shutdown(): void {
-    endSession()
-    removePid()
+    endSession();
+    removePid();
 
     for (const server of this.servers) {
-      server.closeAllConnections()
-      server.close()
+      server.closeAllConnections();
+      server.close();
     }
 
-    process.exit(0)
+    process.exit(0);
   }
 }

--- a/packages/daemon/src/runtime/network.test.ts
+++ b/packages/daemon/src/runtime/network.test.ts
@@ -1,46 +1,46 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import { getGlobalDispatcher, setGlobalDispatcher } from 'undici'
-import { configureOutboundNetwork, mergeLocalNoProxy } from './network.js'
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import { configureOutboundNetwork, mergeLocalNoProxy } from "./network.js";
 
-test('configureOutboundNetwork applies proxy URL and sets NO_PROXY for local hosts', () => {
-  const originalFetch = globalThis.fetch
-  const originalDispatcher = getGlobalDispatcher()
-  const originalNoProxy = process.env.NO_PROXY
-  const originalNoProxyLower = process.env.no_proxy
+test("configureOutboundNetwork applies proxy URL and sets NO_PROXY for local hosts", () => {
+  const originalFetch = globalThis.fetch;
+  const originalDispatcher = getGlobalDispatcher();
+  const originalNoProxy = process.env.NO_PROXY;
+  const originalNoProxyLower = process.env.no_proxy;
 
   try {
-    const applied = configureOutboundNetwork('http://127.0.0.1:7890')
-    assert.equal(applied, true)
-    assert.equal(process.env.NO_PROXY, 'localhost,127.0.0.1,::1')
+    const applied = configureOutboundNetwork("http://127.0.0.1:7890");
+    assert.equal(applied, true);
+    assert.equal(process.env.NO_PROXY, "localhost,127.0.0.1,::1");
   } finally {
-    if (originalNoProxy === undefined) delete process.env.NO_PROXY
-    else process.env.NO_PROXY = originalNoProxy
-    if (originalNoProxyLower === undefined) delete process.env.no_proxy
-    else process.env.no_proxy = originalNoProxyLower
-    globalThis.fetch = originalFetch
-    setGlobalDispatcher(originalDispatcher)
+    if (originalNoProxy === undefined) delete process.env.NO_PROXY;
+    else process.env.NO_PROXY = originalNoProxy;
+    if (originalNoProxyLower === undefined) delete process.env.no_proxy;
+    else process.env.no_proxy = originalNoProxyLower;
+    globalThis.fetch = originalFetch;
+    setGlobalDispatcher(originalDispatcher);
   }
-})
+});
 
-test('configureOutboundNetwork returns false and has no side effects when URL is undefined', () => {
-  const originalFetch = globalThis.fetch
-  const applied = configureOutboundNetwork(undefined)
-  assert.equal(applied, false)
-  assert.equal(globalThis.fetch, originalFetch)
-})
+test("configureOutboundNetwork returns false and has no side effects when URL is undefined", () => {
+  const originalFetch = globalThis.fetch;
+  const applied = configureOutboundNetwork(undefined);
+  assert.equal(applied, false);
+  assert.equal(globalThis.fetch, originalFetch);
+});
 
-test('configureOutboundNetwork returns false and has no side effects when URL is empty string', () => {
-  const originalFetch = globalThis.fetch
-  const applied = configureOutboundNetwork('')
-  assert.equal(applied, false)
-  assert.equal(globalThis.fetch, originalFetch)
-})
+test("configureOutboundNetwork returns false and has no side effects when URL is empty string", () => {
+  const originalFetch = globalThis.fetch;
+  const applied = configureOutboundNetwork("");
+  assert.equal(applied, false);
+  assert.equal(globalThis.fetch, originalFetch);
+});
 
-test('mergeLocalNoProxy preserves existing entries and appends missing local hosts', () => {
-  assert.equal(mergeLocalNoProxy('example.com, localhost'), 'example.com,localhost,127.0.0.1,::1')
-})
+test("mergeLocalNoProxy preserves existing entries and appends missing local hosts", () => {
+  assert.equal(mergeLocalNoProxy("example.com, localhost"), "example.com,localhost,127.0.0.1,::1");
+});
 
-test('mergeLocalNoProxy with undefined returns only local hosts', () => {
-  assert.equal(mergeLocalNoProxy(undefined), 'localhost,127.0.0.1,::1')
-})
+test("mergeLocalNoProxy with undefined returns only local hosts", () => {
+  assert.equal(mergeLocalNoProxy(undefined), "localhost,127.0.0.1,::1");
+});

--- a/packages/daemon/src/runtime/network.ts
+++ b/packages/daemon/src/runtime/network.ts
@@ -1,29 +1,31 @@
-import { EnvHttpProxyAgent, fetch as undiciFetch, setGlobalDispatcher } from 'undici'
+import { EnvHttpProxyAgent, setGlobalDispatcher, fetch as undiciFetch } from "undici";
 
-const LOCAL_NO_PROXY_HOSTS = ['localhost', '127.0.0.1', '::1']
+const LOCAL_NO_PROXY_HOSTS = ["localhost", "127.0.0.1", "::1"];
 
 export function configureOutboundNetwork(proxyUrl?: string): boolean {
-  if (!proxyUrl) return false
+  if (!proxyUrl) return false;
 
-  const noProxy = mergeLocalNoProxy(process.env.NO_PROXY ?? process.env.no_proxy)
-  process.env.NO_PROXY = noProxy
-  process.env.no_proxy = noProxy
+  const noProxy = mergeLocalNoProxy(process.env.NO_PROXY ?? process.env.no_proxy);
+  process.env.NO_PROXY = noProxy;
+  process.env.no_proxy = noProxy;
 
-  setGlobalDispatcher(new EnvHttpProxyAgent({ httpProxy: proxyUrl, httpsProxy: proxyUrl, noProxy }))
-  globalThis.fetch = undiciFetch as unknown as typeof globalThis.fetch
-  return true
+  setGlobalDispatcher(
+    new EnvHttpProxyAgent({ httpProxy: proxyUrl, httpsProxy: proxyUrl, noProxy }),
+  );
+  globalThis.fetch = undiciFetch as unknown as typeof globalThis.fetch;
+  return true;
 }
 
 export function mergeLocalNoProxy(value: string | undefined): string {
-  const entries = (value ?? '')
+  const entries = (value ?? "")
     .split(/[,\s]+/)
-    .map(entry => entry.trim())
-    .filter(Boolean)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
 
-  const seen = new Set(entries.map(entry => entry.toLowerCase()))
+  const seen = new Set(entries.map((entry) => entry.toLowerCase()));
   for (const host of LOCAL_NO_PROXY_HOSTS) {
-    if (!seen.has(host.toLowerCase())) entries.push(host)
+    if (!seen.has(host.toLowerCase())) entries.push(host);
   }
 
-  return entries.join(',')
+  return entries.join(",");
 }

--- a/packages/daemon/src/runtime/process.ts
+++ b/packages/daemon/src/runtime/process.ts
@@ -1,25 +1,25 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs'
-import { dirname } from 'node:path'
-import { getPidPath } from '../config/index.js'
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { getPidPath } from "../config/index.js";
 
 export function writePid(pid: number): void {
-  const path = getPidPath()
-  mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, String(pid), 'utf-8')
+  const path = getPidPath();
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, String(pid), "utf-8");
 }
 
 export function readPid(): number | null {
-  const path = getPidPath()
-  if (!existsSync(path)) return null
-  const raw = readFileSync(path, 'utf-8').trim()
-  const pid = parseInt(raw, 10)
-  return isNaN(pid) ? null : pid
+  const path = getPidPath();
+  if (!existsSync(path)) return null;
+  const raw = readFileSync(path, "utf-8").trim();
+  const pid = parseInt(raw, 10);
+  return isNaN(pid) ? null : pid;
 }
 
 export function removePid(): void {
-  const path = getPidPath()
+  const path = getPidPath();
   try {
-    if (existsSync(path)) unlinkSync(path)
+    if (existsSync(path)) unlinkSync(path);
   } catch {
     // Best-effort cleanup: status checks should not fail because a stale PID
     // file cannot be removed in a restricted environment.
@@ -28,17 +28,17 @@ export function removePid(): void {
 
 export function isRunning(pid: number): boolean {
   try {
-    process.kill(pid, 0)
-    return true
+    process.kill(pid, 0);
+    return true;
   } catch {
-    return false
+    return false;
   }
 }
 
 export function getDaemonStatus(): { running: boolean; pid: number | null } {
-  const pid = readPid()
-  if (pid === null) return { running: false, pid: null }
-  const running = isRunning(pid)
-  if (!running) removePid()
-  return { running, pid: running ? pid : null }
+  const pid = readPid();
+  if (pid === null) return { running: false, pid: null };
+  const running = isRunning(pid);
+  if (!running) removePid();
+  return { running, pid: running ? pid : null };
 }

--- a/packages/daemon/src/runtime/session-stats.ts
+++ b/packages/daemon/src/runtime/session-stats.ts
@@ -3,57 +3,57 @@ import type {
   SessionProviderStat,
   SessionRecord,
   SessionRequestLogEntry,
-} from './session-types.js'
+} from "./session-types.js";
 
-const MAX_REQUEST_LOG = 120
+const MAX_REQUEST_LOG = 120;
 
 export function sessionTotals(s: SessionRecord): { totalRequests: number; totalErrors: number } {
-  const modelStats = Object.values(s.modelStats ?? {})
+  const modelStats = Object.values(s.modelStats ?? {});
   if (modelStats.length > 0) {
     return {
       totalRequests: modelStats.reduce((a, stat) => a + stat.requests, 0),
       totalErrors: modelStats.reduce((a, stat) => a + stat.errors, 0),
-    }
+    };
   }
 
   if ((s.requestLog ?? []).length > 0) {
     return {
       totalRequests: s.requestLog.length,
-      totalErrors: s.requestLog.filter(entry => entry.status === 'error').length,
-    }
+      totalErrors: s.requestLog.filter((entry) => entry.status === "error").length,
+    };
   }
 
-  const providerStats = Object.values(s.providerStats ?? {})
+  const providerStats = Object.values(s.providerStats ?? {});
   return {
     totalRequests: providerStats.reduce((a, stat) => a + stat.requests, 0),
     totalErrors: providerStats.reduce((a, stat) => a + stat.errors, 0),
-  }
+  };
 }
 
 export function normalizeSessionTotals(s: SessionRecord): SessionRecord {
-  const totals = sessionTotals(s)
+  const totals = sessionTotals(s);
   return {
     ...s,
     totalRequests: totals.totalRequests,
     totalErrors: totals.totalErrors,
-  }
+  };
 }
 
 export function applyRequestToSessionStats(
   session: SessionRecord,
   entry: SessionRequestLogEntry,
 ): void {
-  session.requestLog = [...(session.requestLog ?? []), entry].slice(-MAX_REQUEST_LOG)
+  session.requestLog = [...(session.requestLog ?? []), entry].slice(-MAX_REQUEST_LOG);
   session.modelStats = {
     ...(session.modelStats ?? {}),
     [entry.requestedModel]: nextModelStat(session.modelStats?.[entry.requestedModel], entry),
-  }
+  };
   session.providerStats = {
     ...(session.providerStats ?? {}),
     [entry.providerId]: nextProviderStat(session.providerStats?.[entry.providerId], entry),
-  }
-  session.totalRequests += 1
-  session.totalErrors += entry.status === 'error' ? 1 : 0
+  };
+  session.totalRequests += 1;
+  session.totalErrors += entry.status === "error" ? 1 : 0;
 }
 
 function nextModelStat(
@@ -63,16 +63,16 @@ function nextModelStat(
   const next: SessionModelStat = {
     ...(existing ?? emptyModelStat()),
     requests: (existing?.requests ?? 0) + 1,
-    errors: (existing?.errors ?? 0) + (entry.status === 'error' ? 1 : 0),
+    errors: (existing?.errors ?? 0) + (entry.status === "error" ? 1 : 0),
     inputTokens: (existing?.inputTokens ?? 0) + entry.inputTokens,
     totalLatencyMs: (existing?.totalLatencyMs ?? 0) + entry.latencyMs,
     lastActivityAt: entry.timestamp,
     lastProviderId: entry.providerId,
     lastProviderModel: entry.providerModel,
     lastError: entry.error,
-  }
-  next.avgLatencyMs = Math.round(next.totalLatencyMs / next.requests)
-  return next
+  };
+  next.avgLatencyMs = Math.round(next.totalLatencyMs / next.requests);
+  return next;
 }
 
 function nextProviderStat(
@@ -82,13 +82,13 @@ function nextProviderStat(
   const next: SessionProviderStat = {
     ...(existing ?? emptyProviderStat()),
     requests: (existing?.requests ?? 0) + 1,
-    errors: (existing?.errors ?? 0) + (entry.status === 'error' ? 1 : 0),
+    errors: (existing?.errors ?? 0) + (entry.status === "error" ? 1 : 0),
     totalLatencyMs: (existing?.totalLatencyMs ?? 0) + entry.latencyMs,
     lastActivityAt: entry.timestamp,
     lastError: entry.error ?? existing?.lastError ?? null,
-  }
-  next.avgLatencyMs = Math.round(next.totalLatencyMs / next.requests)
-  return next
+  };
+  next.avgLatencyMs = Math.round(next.totalLatencyMs / next.requests);
+  return next;
 }
 
 function emptyModelStat(): SessionModelStat {
@@ -102,7 +102,7 @@ function emptyModelStat(): SessionModelStat {
     lastProviderId: null,
     lastProviderModel: null,
     lastError: null,
-  }
+  };
 }
 
 function emptyProviderStat(): SessionProviderStat {
@@ -113,5 +113,5 @@ function emptyProviderStat(): SessionProviderStat {
     avgLatencyMs: 0,
     lastActivityAt: null,
     lastError: null,
-  }
+  };
 }

--- a/packages/daemon/src/runtime/session-store.ts
+++ b/packages/daemon/src/runtime/session-store.ts
@@ -1,77 +1,75 @@
-import { existsSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs'
-import { appendPrivateFile, writePrivateFile } from '../core/files/private-file.js'
-import {
-  getConfigDir,
-  getCurrentSessionPath,
-  getSessionArchivePath,
-} from '../config/paths.js'
-import type { SessionRecord } from './session-types.js'
-import { normalizeSessionTotals } from './session-stats.js'
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
+import { getConfigDir, getCurrentSessionPath, getSessionArchivePath } from "../config/paths.js";
+import { appendPrivateFile, writePrivateFile } from "../core/files/private-file.js";
+import { normalizeSessionTotals } from "./session-stats.js";
+import type { SessionRecord } from "./session-types.js";
 
-const CURRENT_PATH = getCurrentSessionPath()
-const ARCHIVE_PATH = getSessionArchivePath()
-const MAX_SESSIONS = 200
+const CURRENT_PATH = getCurrentSessionPath();
+const ARCHIVE_PATH = getSessionArchivePath();
+const MAX_SESSIONS = 200;
 
 export function ensureSessionDir(): void {
-  const dir = getConfigDir()
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  const dir = getConfigDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 }
 
 export function currentSessionExists(): boolean {
-  return existsSync(CURRENT_PATH)
+  return existsSync(CURRENT_PATH);
 }
 
 export function readCurrentSession(): SessionRecord {
-  return JSON.parse(readFileSync(CURRENT_PATH, 'utf-8')) as SessionRecord
+  return JSON.parse(readFileSync(CURRENT_PATH, "utf-8")) as SessionRecord;
 }
 
 export function writeCurrentSession(session: SessionRecord): void {
-  writePrivateFile(CURRENT_PATH, JSON.stringify(session))
+  writePrivateFile(CURRENT_PATH, JSON.stringify(session));
 }
 
 export function removeCurrentSession(): void {
-  try { unlinkSync(CURRENT_PATH) } catch {}
+  try {
+    unlinkSync(CURRENT_PATH);
+  } catch {}
 }
 
 export function archiveSession(session: SessionRecord): void {
-  ensureSessionDir()
-  appendPrivateFile(ARCHIVE_PATH, JSON.stringify(session) + '\n')
-  trimArchivedSessions()
+  ensureSessionDir();
+  appendPrivateFile(ARCHIVE_PATH, JSON.stringify(session) + "\n");
+  trimArchivedSessions();
 }
 
 export function clearArchivedSessions(): void {
-  ensureSessionDir()
-  writePrivateFile(ARCHIVE_PATH, '')
+  ensureSessionDir();
+  writePrivateFile(ARCHIVE_PATH, "");
 }
 
 export function listArchivedSessions(): SessionRecord[] {
-  if (!existsSync(ARCHIVE_PATH)) return []
+  if (!existsSync(ARCHIVE_PATH)) return [];
   try {
-    const raw = readFileSync(ARCHIVE_PATH, 'utf-8')
+    const raw = readFileSync(ARCHIVE_PATH, "utf-8");
     return raw
-      .split('\n')
+      .split("\n")
       .filter(Boolean)
       .map(parseArchivedLine)
       .filter((s): s is SessionRecord => s !== null)
-      .reverse()
+      .reverse();
   } catch {
-    return []
+    return [];
   }
 }
 
 function trimArchivedSessions(): void {
   try {
-    const lines = readFileSync(ARCHIVE_PATH, 'utf-8').split('\n').filter(Boolean)
+    const lines = readFileSync(ARCHIVE_PATH, "utf-8").split("\n").filter(Boolean);
     if (lines.length > MAX_SESSIONS) {
-      writePrivateFile(ARCHIVE_PATH, lines.slice(-MAX_SESSIONS).join('\n') + '\n')
+      writePrivateFile(ARCHIVE_PATH, lines.slice(-MAX_SESSIONS).join("\n") + "\n");
     }
   } catch {}
 }
 
 function parseArchivedLine(line: string): SessionRecord | null {
   try {
-    return normalizeSessionTotals(JSON.parse(line) as SessionRecord)
+    return normalizeSessionTotals(JSON.parse(line) as SessionRecord);
   } catch {
-    return null
+    return null;
   }
 }

--- a/packages/daemon/src/runtime/session-types.ts
+++ b/packages/daemon/src/runtime/session-types.ts
@@ -1,65 +1,65 @@
-import type { ProviderId } from '../config/schema.js'
+import type { ProviderId } from "../config/schema.js";
 
 export interface SessionModelStat {
-  requests: number
-  errors: number
-  inputTokens: number
-  totalLatencyMs: number
-  avgLatencyMs: number
-  lastActivityAt: number | null
+  requests: number;
+  errors: number;
+  inputTokens: number;
+  totalLatencyMs: number;
+  avgLatencyMs: number;
+  lastActivityAt: number | null;
   // Strings (not strictly ProviderId) so synthetic flows like "anthropic_native" fit cleanly.
-  lastProviderId: string | null
-  lastProviderModel: string | null
-  lastError: string | null
+  lastProviderId: string | null;
+  lastProviderModel: string | null;
+  lastError: string | null;
 }
 
 export interface SessionProviderStat {
-  requests: number
-  errors: number
-  avgLatencyMs: number
-  totalLatencyMs: number
-  lastActivityAt: number | null
-  lastError: string | null
+  requests: number;
+  errors: number;
+  avgLatencyMs: number;
+  totalLatencyMs: number;
+  lastActivityAt: number | null;
+  lastError: string | null;
 }
 
 export interface SessionRequestLogEntry {
-  id: string
-  timestamp: number
-  requestedModel: string
-  providerId: string
-  providerModel: string
-  inputTokens: number
-  latencyMs: number
-  status: 'ok' | 'error'
-  error: string | null
-  prompt?: string
-  response?: string
-  tokenSavers?: TokenSaverStats
+  id: string;
+  timestamp: number;
+  requestedModel: string;
+  providerId: string;
+  providerModel: string;
+  inputTokens: number;
+  latencyMs: number;
+  status: "ok" | "error";
+  error: string | null;
+  prompt?: string;
+  response?: string;
+  tokenSavers?: TokenSaverStats;
 }
 
 export interface TokenSaverStats {
-  rtkBytesBefore: number
-  rtkBytesAfter: number
-  rtkHits: number
-  rtkFilters: string[]
-  cavemanLevel: 'lite' | 'full' | 'ultra' | null
+  rtkBytesBefore: number;
+  rtkBytesAfter: number;
+  rtkHits: number;
+  rtkFilters: string[];
+  cavemanLevel: "lite" | "full" | "ultra" | null;
 }
 
 export interface SessionRecord {
-  id: string
-  startedAt: number
-  endedAt: number | null
-  durationMs: number
-  status: 'running' | 'completed' | 'crashed'
-  modelMode: 'single' | 'all'
-  activeProvider: ProviderId
-  launchHint: string
-  enabledProviders: ProviderId[]
-  providerStats: Record<string, SessionProviderStat>
-  modelStats: Record<string, SessionModelStat>
-  requestLog: SessionRequestLogEntry[]
-  totalRequests: number
-  totalErrors: number
-  lastHeartbeatAt?: number
-  watchedPid?: number
+  id: string;
+  startedAt: number;
+  endedAt: number | null;
+  durationMs: number;
+  status: "running" | "completed" | "crashed";
+  modelMode: "single" | "all";
+  activeProvider: ProviderId;
+  launchHint: string;
+  enabledProviders: ProviderId[];
+  providerStats: Record<string, SessionProviderStat>;
+  modelStats: Record<string, SessionModelStat>;
+  requestLog: SessionRequestLogEntry[];
+  totalRequests: number;
+  totalErrors: number;
+  lastHeartbeatAt?: number;
+  watchedPid?: number;
 }

--- a/packages/daemon/src/runtime/sessions.ts
+++ b/packages/daemon/src/runtime/sessions.ts
@@ -3,16 +3,14 @@
 //   - current-session.json  → in-progress session, checkpointed every 10s
 //   - sessions.jsonl        → completed sessions, one JSON object per line
 
-import { randomBytes } from 'node:crypto'
-import type { Config, ProviderId } from '../config/schema.js'
-import { logger } from '../observability/log.js'
-import { getUptimeMs } from './stats.js'
-import type { SessionRecord, SessionRequestLogEntry } from './session-types.js'
+import { randomBytes } from "node:crypto";
+import type { Config, ProviderId } from "../config/schema.js";
+import { logger } from "../observability/log.js";
 import {
   applyRequestToSessionStats,
   normalizeSessionTotals,
   sessionTotals,
-} from './session-stats.js'
+} from "./session-stats.js";
 import {
   archiveSession,
   clearArchivedSessions as clearArchive,
@@ -22,7 +20,9 @@ import {
   readCurrentSession,
   removeCurrentSession,
   writeCurrentSession,
-} from './session-store.js'
+} from "./session-store.js";
+import type { SessionRecord, SessionRequestLogEntry } from "./session-types.js";
+import { getUptimeMs } from "./stats.js";
 
 export type {
   SessionModelStat,
@@ -30,160 +30,173 @@ export type {
   SessionRecord,
   SessionRequestLogEntry,
   TokenSaverStats,
-} from './session-types.js'
+} from "./session-types.js";
 
-const HEARTBEAT_TIMEOUT_MS = 60_000
+const HEARTBEAT_TIMEOUT_MS = 60_000;
 
-let current: SessionRecord | null = null
-let checkpointTimer: NodeJS.Timeout | null = null
-let sessionPrimaryModel: { providerId: ProviderId; providerModel: string } | null = null
+let current: SessionRecord | null = null;
+let checkpointTimer: NodeJS.Timeout | null = null;
+let sessionPrimaryModel: { providerId: ProviderId; providerModel: string } | null = null;
 
 export function setSessionPrimaryModel(providerId: ProviderId, providerModel: string): void {
-  sessionPrimaryModel = { providerId, providerModel }
+  sessionPrimaryModel = { providerId, providerModel };
 }
 
 export function getSessionPrimaryModel(): { providerId: ProviderId; providerModel: string } | null {
-  return sessionPrimaryModel
+  return sessionPrimaryModel;
 }
 
 export function isFirstSessionRequest(): boolean {
-  return !current || current.requestLog.length === 0
+  return !current || current.requestLog.length === 0;
 }
 
 export function startSession(config: Config): SessionRecord {
-  ensureSessionDir()
-  recoverCrashedSessionIfNeeded()
+  ensureSessionDir();
+  recoverCrashedSessionIfNeeded();
 
-  sessionPrimaryModel = null
-  current = createSessionRecord(config)
-  writeCurrentSession(current)
-  logger.info('sessions', `started session ${current.id} (mode=${current.modelMode}, launch=${current.launchHint})`)
+  sessionPrimaryModel = null;
+  current = createSessionRecord(config);
+  writeCurrentSession(current);
+  logger.info(
+    "sessions",
+    `started session ${current.id} (mode=${current.modelMode}, launch=${current.launchHint})`,
+  );
 
-  checkpointTimer = setInterval(checkpoint, 10_000)
-  return current
+  checkpointTimer = setInterval(checkpoint, 10_000);
+  return current;
 }
 
-export function attachSessionProcess(sessionId: string | undefined, pid: number | undefined): boolean {
-  if (!current || !sessionId || current.id !== sessionId) return false
-  if (!Number.isInteger(pid) || !pid || pid <= 0) return false
+export function attachSessionProcess(
+  sessionId: string | undefined,
+  pid: number | undefined,
+): boolean {
+  if (!current || !sessionId || current.id !== sessionId) return false;
+  if (!Number.isInteger(pid) || !pid || pid <= 0) return false;
 
-  current.watchedPid = pid
-  current.lastHeartbeatAt = Date.now()
-  persistCurrentSession('attach checkpoint failed')
-  logger.info('sessions', `attached session ${current.id} to pid ${pid}`)
-  return true
+  current.watchedPid = pid;
+  current.lastHeartbeatAt = Date.now();
+  persistCurrentSession("attach checkpoint failed");
+  logger.info("sessions", `attached session ${current.id} to pid ${pid}`);
+  return true;
 }
 
 export function heartbeatSession(sessionId: string | undefined): boolean {
-  if (!current || !sessionId || current.id !== sessionId) return false
-  current.lastHeartbeatAt = Date.now()
-  persistCurrentSession('heartbeat checkpoint failed')
-  return true
+  if (!current || !sessionId || current.id !== sessionId) return false;
+  current.lastHeartbeatAt = Date.now();
+  persistCurrentSession("heartbeat checkpoint failed");
+  return true;
 }
 
-export function recordSessionRequest(entry: Omit<SessionRequestLogEntry, 'id' | 'timestamp'>): string | undefined {
-  if (!current) return undefined
+export function recordSessionRequest(
+  entry: Omit<SessionRequestLogEntry, "id" | "timestamp">,
+): string | undefined {
+  if (!current) return undefined;
 
   const logEntry: SessionRequestLogEntry = {
-    id: `${Date.now().toString(36)}-${randomBytes(3).toString('hex')}`,
+    id: `${Date.now().toString(36)}-${randomBytes(3).toString("hex")}`,
     timestamp: Date.now(),
     ...entry,
     requestedModel: normalizeRequestedModelForLog(entry.requestedModel),
-    prompt: 'prompt' in entry ? (entry as { prompt?: string }).prompt : undefined,
-  }
+    prompt: "prompt" in entry ? (entry as { prompt?: string }).prompt : undefined,
+  };
 
-  applyRequestToSessionStats(current, logEntry)
-  return logEntry.id
+  applyRequestToSessionStats(current, logEntry);
+  return logEntry.id;
 }
 
 export function updateSessionRequestResponse(id: string, response: string): void {
-  if (!current?.requestLog) return
-  const entry = current.requestLog.find(e => e.id === id)
-  if (entry) entry.response = response
+  if (!current?.requestLog) return;
+  const entry = current.requestLog.find((e) => e.id === id);
+  if (entry) entry.response = response;
 }
 
 export function endSession(sessionId?: string): boolean {
-  if (!current) return false
-  if (sessionId && current.id !== sessionId) return false
-  stopCheckpointTimer()
+  if (!current) return false;
+  if (sessionId && current.id !== sessionId) return false;
+  stopCheckpointTimer();
 
-  const totals = sessionTotals(current)
+  const totals = sessionTotals(current);
   const finalized: SessionRecord = {
     ...current,
     endedAt: Date.now(),
     durationMs: Date.now() - current.startedAt,
-    status: 'completed',
+    status: "completed",
     totalRequests: totals.totalRequests,
     totalErrors: totals.totalErrors,
-  }
+  };
 
-  archiveSession(finalized)
-  removeCurrentSession()
-  logger.info('sessions', `ended session ${finalized.id} (${finalized.totalRequests} reqs, ${finalized.totalErrors} errors)`)
-  current = null
-  return true
+  archiveSession(finalized);
+  removeCurrentSession();
+  logger.info(
+    "sessions",
+    `ended session ${finalized.id} (${finalized.totalRequests} reqs, ${finalized.totalErrors} errors)`,
+  );
+  current = null;
+  return true;
 }
 
 export function getCurrentSession(): SessionRecord | null {
   if (current && shouldEndSession(current)) {
-    logger.warn('sessions', `session ${current.id} launcher is no longer alive`)
-    endSession(current.id)
+    logger.warn("sessions", `session ${current.id} launcher is no longer alive`);
+    endSession(current.id);
   }
-  if (!current) return null
+  if (!current) return null;
 
-  const totals = sessionTotals(current)
+  const totals = sessionTotals(current);
   return {
     ...current,
     totalRequests: totals.totalRequests,
     totalErrors: totals.totalErrors,
     durationMs: getUptimeMs(),
-  }
+  };
 }
 
 export function clearArchivedSessions(): void {
   try {
-    clearArchive()
+    clearArchive();
   } catch (err) {
-    logger.error('sessions', `failed to clear history: ${String(err)}`)
-    throw err
+    logger.error("sessions", `failed to clear history: ${String(err)}`);
+    throw err;
   }
 }
 
 export function listArchivedSessions(): SessionRecord[] {
-  return listArchive()
+  return listArchive();
 }
 
 function recoverCrashedSessionIfNeeded(): void {
-  if (!currentSessionExists()) return
+  if (!currentSessionExists()) return;
   try {
-    const prev = readCurrentSession()
+    const prev = readCurrentSession();
     const recovered: SessionRecord = {
       ...normalizeSessionTotals(prev),
       endedAt: prev.endedAt ?? Date.now(),
       durationMs: (prev.endedAt ?? Date.now()) - prev.startedAt,
-      status: 'crashed',
-    }
-    archiveSession(recovered)
-    logger.warn('sessions', `recovered crashed session ${recovered.id}`)
+      status: "crashed",
+    };
+    archiveSession(recovered);
+    logger.warn("sessions", `recovered crashed session ${recovered.id}`);
   } catch (err) {
-    logger.error('sessions', `failed to recover previous session: ${String(err)}`)
+    logger.error("sessions", `failed to recover previous session: ${String(err)}`);
   }
-  removeCurrentSession()
+  removeCurrentSession();
 }
 
 function createSessionRecord(config: Config): SessionRecord {
-  const enabledProviders = (Object.entries(config.providers) as [ProviderId, typeof config.providers[ProviderId]][])
+  const enabledProviders = (
+    Object.entries(config.providers) as [ProviderId, (typeof config.providers)[ProviderId]][]
+  )
     .filter(([, pc]) => pc.enabled)
-    .map(([id]) => id)
-  const launchHint = config.modelMode === 'all' ? 'all' : config.activeProvider
+    .map(([id]) => id);
+  const launchHint = config.modelMode === "all" ? "all" : config.activeProvider;
 
   return {
-    id: randomBytes(8).toString('hex'),
+    id: randomBytes(8).toString("hex"),
     startedAt: Date.now(),
     endedAt: null,
     durationMs: 0,
-    status: 'running',
-    modelMode: config.modelMode ?? 'single',
+    status: "running",
+    modelMode: config.modelMode ?? "single",
     activeProvider: config.activeProvider,
     launchHint,
     enabledProviders,
@@ -193,54 +206,54 @@ function createSessionRecord(config: Config): SessionRecord {
     totalRequests: 0,
     totalErrors: 0,
     lastHeartbeatAt: Date.now(),
-  }
+  };
 }
 
 function checkpoint(): void {
-  if (!current) return
+  if (!current) return;
   if (shouldEndSession(current)) {
-    logger.warn('sessions', `session ${current.id} launcher is no longer alive`)
-    endSession(current.id)
-    return
+    logger.warn("sessions", `session ${current.id} launcher is no longer alive`);
+    endSession(current.id);
+    return;
   }
 
-  const totals = sessionTotals(current)
-  current.totalRequests = totals.totalRequests
-  current.totalErrors = totals.totalErrors
-  current.durationMs = getUptimeMs()
-  persistCurrentSession('checkpoint failed')
+  const totals = sessionTotals(current);
+  current.totalRequests = totals.totalRequests;
+  current.totalErrors = totals.totalErrors;
+  current.durationMs = getUptimeMs();
+  persistCurrentSession("checkpoint failed");
 }
 
 function shouldEndSession(session: SessionRecord): boolean {
-  if (session.watchedPid) return !isProcessAlive(session.watchedPid)
-  return !!session.lastHeartbeatAt && Date.now() - session.lastHeartbeatAt > HEARTBEAT_TIMEOUT_MS
+  if (session.watchedPid) return !isProcessAlive(session.watchedPid);
+  return !!session.lastHeartbeatAt && Date.now() - session.lastHeartbeatAt > HEARTBEAT_TIMEOUT_MS;
 }
 
 function isProcessAlive(pid: number): boolean {
   try {
-    process.kill(pid, 0)
-    return true
+    process.kill(pid, 0);
+    return true;
   } catch (err) {
-    return (err as NodeJS.ErrnoException).code === 'EPERM'
+    return (err as NodeJS.ErrnoException).code === "EPERM";
   }
 }
 
 function persistCurrentSession(errorMessage: string): void {
-  if (!current) return
+  if (!current) return;
   try {
-    writeCurrentSession(current)
+    writeCurrentSession(current);
   } catch (err) {
-    logger.error('sessions', `${errorMessage}: ${String(err)}`)
+    logger.error("sessions", `${errorMessage}: ${String(err)}`);
   }
 }
 
 function stopCheckpointTimer(): void {
-  if (!checkpointTimer) return
-  clearInterval(checkpointTimer)
-  checkpointTimer = null
+  if (!checkpointTimer) return;
+  clearInterval(checkpointTimer);
+  checkpointTimer = null;
 }
 
 function normalizeRequestedModelForLog(model: string): string {
-  if (model.startsWith('anthropic/')) return model.slice('anthropic/'.length)
-  return model
+  if (model.startsWith("anthropic/")) return model.slice("anthropic/".length);
+  return model;
 }

--- a/packages/daemon/src/runtime/stats.ts
+++ b/packages/daemon/src/runtime/stats.ts
@@ -1,53 +1,53 @@
 // Per-provider runtime stats. In-memory, reset on daemon restart.
 
-import type { ProviderId } from '../config/schema.js'
+import type { ProviderId } from "../config/schema.js";
 
 // Stats accept any string identifier so we can record synthetic flows like the
 // native Claude passthrough ("anthropic_native") that aren't configured providers.
-type StatsKey = ProviderId | string
+type StatsKey = ProviderId | string;
 
 export interface ProviderStats {
-  requests: number
-  errors: number
-  totalLatencyMs: number
-  lastActivityAt: number | null   // ms since epoch
-  lastError: string | null
+  requests: number;
+  errors: number;
+  totalLatencyMs: number;
+  lastActivityAt: number | null; // ms since epoch
+  lastError: string | null;
 }
 
-const stats = new Map<StatsKey, ProviderStats>()
-const startedAt = Date.now()
+const stats = new Map<StatsKey, ProviderStats>();
+const startedAt = Date.now();
 
 function ensure(id: StatsKey): ProviderStats {
-  let s = stats.get(id)
+  let s = stats.get(id);
   if (!s) {
-    s = { requests: 0, errors: 0, totalLatencyMs: 0, lastActivityAt: null, lastError: null }
-    stats.set(id, s)
+    s = { requests: 0, errors: 0, totalLatencyMs: 0, lastActivityAt: null, lastError: null };
+    stats.set(id, s);
   }
-  return s
+  return s;
 }
 
 export function recordRequest(id: StatsKey, latencyMs: number, error: string | null) {
-  const s = ensure(id)
-  s.requests++
-  s.totalLatencyMs += latencyMs
-  s.lastActivityAt = Date.now()
+  const s = ensure(id);
+  s.requests++;
+  s.totalLatencyMs += latencyMs;
+  s.lastActivityAt = Date.now();
   if (error) {
-    s.errors++
-    s.lastError = error
+    s.errors++;
+    s.lastError = error;
   }
 }
 
 export function getStats(): Record<string, ProviderStats & { avgLatencyMs: number }> {
-  const out: Record<string, ProviderStats & { avgLatencyMs: number }> = {}
+  const out: Record<string, ProviderStats & { avgLatencyMs: number }> = {};
   for (const [id, s] of stats) {
     out[id] = {
       ...s,
       avgLatencyMs: s.requests > 0 ? Math.round(s.totalLatencyMs / s.requests) : 0,
-    }
+    };
   }
-  return out
+  return out;
 }
 
 export function getUptimeMs(): number {
-  return Date.now() - startedAt
+  return Date.now() - startedAt;
 }

--- a/packages/desktop/src-tauri/scripts/build-appimage.mjs
+++ b/packages/desktop/src-tauri/scripts/build-appimage.mjs
@@ -1,125 +1,129 @@
 #!/usr/bin/env node
+
 // Tauri's AppImage path runs linuxdeploy's GTK plugin. That plugin patches
 // every ELF in the AppDir, including our Bun-compiled daemon sidecar; the
 // patched sidecar can then make ldd segfault. Build normally first, then
 // recover that known failure by restoring the sidecar and invoking the final
 // AppImage plugin directly.
 
-import { copyFileSync, existsSync, rmSync, statSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { spawnSync } from 'node:child_process'
+import { spawnSync } from "node:child_process";
+import { copyFileSync, existsSync, rmSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const srcTauriDir = resolve(__dirname, '..')
-const desktopDir = resolve(srcTauriDir, '..')
-const repoRoot = resolve(srcTauriDir, '../../..')
-const configPath = join(srcTauriDir, 'tauri.conf.json')
-const config = await import(configPath, { with: { type: 'json' } })
-const { productName, version } = config.default
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const srcTauriDir = resolve(__dirname, "..");
+const desktopDir = resolve(srcTauriDir, "..");
+const repoRoot = resolve(srcTauriDir, "../../..");
+const configPath = join(srcTauriDir, "tauri.conf.json");
+const config = await import(configPath, { with: { type: "json" } });
+const { productName, version } = config.default;
 
 const HOST_TARGETS = {
-  'linux x64': {
-    daemonOutput: 'claude-code-provider-gateway-daemon-linux-x64',
-    archName: 'amd64',
+  "linux x64": {
+    daemonOutput: "claude-code-provider-gateway-daemon-linux-x64",
+    archName: "amd64",
   },
-  'linux arm64': {
-    daemonOutput: 'claude-code-provider-gateway-daemon-linux-arm64',
-    archName: 'arm64',
+  "linux arm64": {
+    daemonOutput: "claude-code-provider-gateway-daemon-linux-arm64",
+    archName: "arm64",
   },
-}
+};
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: options.cwd ?? desktopDir,
     env: process.env,
-    encoding: 'utf8',
-    stdio: options.capture ? 'pipe' : 'inherit',
-  })
+    encoding: "utf8",
+    stdio: options.capture ? "pipe" : "inherit",
+  });
 
   if (options.capture) {
-    return result
+    return result;
   }
 
   if (result.status !== 0) {
-    process.exit(result.status ?? 1)
+    process.exit(result.status ?? 1);
   }
-  return result
+  return result;
 }
 
 function assertFile(path, label) {
   if (!existsSync(path) || !statSync(path).isFile()) {
-    throw new Error(`${label} not found: ${path}`)
+    throw new Error(`${label} not found: ${path}`);
   }
 }
 
 function main() {
-  const normal = run('tauri', ['build', '--bundles', 'appimage'], {
+  const normal = run("tauri", ["build", "--bundles", "appimage"], {
     capture: true,
-  })
+  });
 
   if (normal.status === 0) {
-    process.stdout.write(normal.stdout)
-    process.stderr.write(normal.stderr)
-    return
+    process.stdout.write(normal.stdout);
+    process.stderr.write(normal.stderr);
+    return;
   }
 
-  const output = `${normal.stdout}\n${normal.stderr}`
-  if (!output.includes('failed to run') || !output.includes('linuxdeploy')) {
-    process.stdout.write(normal.stdout)
-    process.stderr.write(normal.stderr)
-    process.exit(normal.status ?? 1)
+  const output = `${normal.stdout}\n${normal.stderr}`;
+  if (!output.includes("failed to run") || !output.includes("linuxdeploy")) {
+    process.stdout.write(normal.stdout);
+    process.stderr.write(normal.stderr);
+    process.exit(normal.status ?? 1);
   }
 
-  process.stdout.write(normal.stdout)
-  process.stderr.write(normal.stderr)
-  console.warn('Recovering AppImage build after linuxdeploy sidecar patch failure...')
+  process.stdout.write(normal.stdout);
+  process.stderr.write(normal.stderr);
+  console.warn("Recovering AppImage build after linuxdeploy sidecar patch failure...");
 
-  const target = HOST_TARGETS[`${process.platform} ${process.arch}`]
+  const target = HOST_TARGETS[`${process.platform} ${process.arch}`];
   if (!target) {
-    throw new Error(`Unsupported AppImage host: ${process.platform} ${process.arch}`)
+    throw new Error(`Unsupported AppImage host: ${process.platform} ${process.arch}`);
   }
 
-  const bundleDir = join(srcTauriDir, 'target/release/bundle/appimage')
-  const appDir = join(bundleDir, `${productName}.AppDir`)
-  const sidecarSrc = join(repoRoot, 'packages/daemon/dist-bin', target.daemonOutput)
-  const sidecarDest = join(appDir, 'usr/bin/claude-code-provider-gateway-daemon')
-  const productIcon = join(appDir, `${productName}.png`)
-  const desktopIcon = join(appDir, 'claude-code-provider-gateway-desktop.png')
-  const expectedOutput = join(bundleDir, `${productName}_${version}_${target.archName}.AppImage`)
-  const pluginArchSuffix = target.archName === 'arm64' ? 'aarch64' : 'x86_64'
-  const pluginOutput = join(bundleDir, `${productName.replaceAll(' ', '_')}-${pluginArchSuffix}.AppImage`)
+  const bundleDir = join(srcTauriDir, "target/release/bundle/appimage");
+  const appDir = join(bundleDir, `${productName}.AppDir`);
+  const sidecarSrc = join(repoRoot, "packages/daemon/dist-bin", target.daemonOutput);
+  const sidecarDest = join(appDir, "usr/bin/claude-code-provider-gateway-daemon");
+  const productIcon = join(appDir, `${productName}.png`);
+  const desktopIcon = join(appDir, "claude-code-provider-gateway-desktop.png");
+  const expectedOutput = join(bundleDir, `${productName}_${version}_${target.archName}.AppImage`);
+  const pluginArchSuffix = target.archName === "arm64" ? "aarch64" : "x86_64";
+  const pluginOutput = join(
+    bundleDir,
+    `${productName.replaceAll(" ", "_")}-${pluginArchSuffix}.AppImage`,
+  );
   const appImagePlugin = join(
-    process.env.HOME ?? '',
-    '.cache/tauri/linuxdeploy-plugin-appimage.AppImage',
-  )
+    process.env.HOME ?? "",
+    ".cache/tauri/linuxdeploy-plugin-appimage.AppImage",
+  );
 
-  assertFile(sidecarSrc, 'original Bun sidecar')
-  assertFile(productIcon, 'AppDir product icon')
-  assertFile(appImagePlugin, 'linuxdeploy AppImage plugin')
+  assertFile(sidecarSrc, "original Bun sidecar");
+  assertFile(productIcon, "AppDir product icon");
+  assertFile(appImagePlugin, "linuxdeploy AppImage plugin");
 
-  copyFileSync(sidecarSrc, sidecarDest)
-  copyFileSync(productIcon, desktopIcon)
-  rmSync(expectedOutput, { force: true })
-  rmSync(pluginOutput, { force: true })
+  copyFileSync(sidecarSrc, sidecarDest);
+  copyFileSync(productIcon, desktopIcon);
+  rmSync(expectedOutput, { force: true });
+  rmSync(pluginOutput, { force: true });
 
-  run(appImagePlugin, ['--appimage-extract-and-run', '--appdir', appDir], {
+  run(appImagePlugin, ["--appimage-extract-and-run", "--appdir", appDir], {
     cwd: bundleDir,
-  })
+  });
 
   if (pluginOutput !== expectedOutput && existsSync(pluginOutput)) {
-    rmSync(expectedOutput, { force: true })
-    copyFileSync(pluginOutput, expectedOutput)
-    rmSync(pluginOutput, { force: true })
+    rmSync(expectedOutput, { force: true });
+    copyFileSync(pluginOutput, expectedOutput);
+    rmSync(pluginOutput, { force: true });
   }
 
-  assertFile(expectedOutput, 'AppImage output')
-  console.log(`Finished AppImage at:\n  ${expectedOutput}`)
+  assertFile(expectedOutput, "AppImage output");
+  console.log(`Finished AppImage at:\n  ${expectedOutput}`);
 }
 
 try {
-  main()
+  main();
 } catch (error) {
-  console.error(error instanceof Error ? error.message : error)
-  process.exit(1)
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
 }

--- a/packages/desktop/src-tauri/scripts/build-desktop.mjs
+++ b/packages/desktop/src-tauri/scripts/build-desktop.mjs
@@ -1,21 +1,21 @@
 #!/usr/bin/env node
 
-import { spawnSync } from 'node:child_process'
+import { spawnSync } from "node:child_process";
 
 function run(command, args) {
   const result = spawnSync(command, args, {
     env: process.env,
-    stdio: 'inherit',
-  })
+    stdio: "inherit",
+  });
 
   if (result.status !== 0) {
-    process.exit(result.status ?? 1)
+    process.exit(result.status ?? 1);
   }
 }
 
-if (process.platform === 'linux') {
-  run('tauri', ['build', '--bundles', 'deb,rpm'])
-  run('npm', ['run', 'build:appimage'])
+if (process.platform === "linux") {
+  run("tauri", ["build", "--bundles", "deb,rpm"]);
+  run("npm", ["run", "build:appimage"]);
 } else {
-  run('tauri', ['build'])
+  run("tauri", ["build"]);
 }

--- a/packages/desktop/src-tauri/scripts/prepare-sidecar.mjs
+++ b/packages/desktop/src-tauri/scripts/prepare-sidecar.mjs
@@ -1,78 +1,109 @@
 #!/usr/bin/env node
+
 // Compiles the daemon for the host platform and drops it into Tauri's
 // expected sidecar location (src-tauri/binaries/<basename>-<target-triple>).
 //
 // Single entry-point used by both `tauri dev` and `tauri build` via
 // beforeBuildCommand, plus directly from CI matrices.
 
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { execSync } from 'node:child_process'
+import { execSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const repoRoot = resolve(__dirname, '../../../..')
-const daemonBinDir = join(repoRoot, 'packages/daemon/dist-bin')
-const tauriBinDir = join(__dirname, '..', 'binaries')
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../../..");
+const daemonBinDir = join(repoRoot, "packages/daemon/dist-bin");
+const tauriBinDir = join(__dirname, "..", "binaries");
 
 const HOST_TARGETS = {
-  'linux x64':    { script: 'compile:linux-x64',    output: 'claude-code-provider-gateway-daemon-linux-x64',    triple: 'x86_64-unknown-linux-gnu',  suffix: '' },
-  'linux arm64':  { script: 'compile:linux-arm64',  output: 'claude-code-provider-gateway-daemon-linux-arm64',  triple: 'aarch64-unknown-linux-gnu', suffix: '' },
-  'darwin x64':   { script: 'compile:darwin-x64',   output: 'claude-code-provider-gateway-daemon-darwin-x64',   triple: 'x86_64-apple-darwin',       suffix: '' },
-  'darwin arm64': { script: 'compile:darwin-arm64', output: 'claude-code-provider-gateway-daemon-darwin-arm64', triple: 'aarch64-apple-darwin',      suffix: '' },
-  'win32 x64':    { script: 'compile:win-x64',      output: 'claude-code-provider-gateway-daemon-win-x64.exe',  triple: 'x86_64-pc-windows-msvc',    suffix: '.exe' },
-}
+  "linux x64": {
+    script: "compile:linux-x64",
+    output: "claude-code-provider-gateway-daemon-linux-x64",
+    triple: "x86_64-unknown-linux-gnu",
+    suffix: "",
+  },
+  "linux arm64": {
+    script: "compile:linux-arm64",
+    output: "claude-code-provider-gateway-daemon-linux-arm64",
+    triple: "aarch64-unknown-linux-gnu",
+    suffix: "",
+  },
+  "darwin x64": {
+    script: "compile:darwin-x64",
+    output: "claude-code-provider-gateway-daemon-darwin-x64",
+    triple: "x86_64-apple-darwin",
+    suffix: "",
+  },
+  "darwin arm64": {
+    script: "compile:darwin-arm64",
+    output: "claude-code-provider-gateway-daemon-darwin-arm64",
+    triple: "aarch64-apple-darwin",
+    suffix: "",
+  },
+  "win32 x64": {
+    script: "compile:win-x64",
+    output: "claude-code-provider-gateway-daemon-win-x64.exe",
+    triple: "x86_64-pc-windows-msvc",
+    suffix: ".exe",
+  },
+};
 
 const TARGETS_BY_TRIPLE = Object.fromEntries(
   Object.values(HOST_TARGETS).map((entry) => [entry.triple, entry]),
-)
+);
 
 function findEntry() {
-  const requestedTarget = process.env.CC_GATEWAY_TAURI_TARGET || process.env.CARGO_BUILD_TARGET
+  const requestedTarget = process.env.CC_GATEWAY_TAURI_TARGET || process.env.CARGO_BUILD_TARGET;
   if (requestedTarget) {
-    const entry = TARGETS_BY_TRIPLE[requestedTarget]
+    const entry = TARGETS_BY_TRIPLE[requestedTarget];
     if (!entry) {
-      throw new Error(`Unsupported target: ${requestedTarget}. Supported: ${Object.keys(TARGETS_BY_TRIPLE).join(', ')}`)
+      throw new Error(
+        `Unsupported target: ${requestedTarget}. Supported: ${Object.keys(TARGETS_BY_TRIPLE).join(", ")}`,
+      );
     }
-    return entry
+    return entry;
   }
 
-  const key = `${process.platform} ${process.arch}`
-  const entry = HOST_TARGETS[key]
+  const key = `${process.platform} ${process.arch}`;
+  const entry = HOST_TARGETS[key];
   if (!entry) {
-    throw new Error(`Unsupported host: ${key}. Supported: ${Object.keys(HOST_TARGETS).join(', ')}`)
+    throw new Error(`Unsupported host: ${key}. Supported: ${Object.keys(HOST_TARGETS).join(", ")}`);
   }
-  return entry
+  return entry;
 }
 
 function compileDaemon(scriptName) {
-  console.log(`▶ compiling daemon (${scriptName})`)
+  console.log(`▶ compiling daemon (${scriptName})`);
   execSync(`npm run ${scriptName} -w @claude-code-provider-gateway/daemon`, {
     cwd: repoRoot,
-    stdio: 'inherit',
-  })
+    stdio: "inherit",
+  });
 }
 
 function main() {
-  const entry = findEntry()
-  const src = join(daemonBinDir, entry.output)
+  const entry = findEntry();
+  const src = join(daemonBinDir, entry.output);
 
-  compileDaemon(entry.script)
+  compileDaemon(entry.script);
 
   if (!existsSync(src)) {
-    console.error(`✗ compile finished but binary still missing: ${src}`)
-    process.exit(1)
+    console.error(`✗ compile finished but binary still missing: ${src}`);
+    process.exit(1);
   }
 
-  mkdirSync(tauriBinDir, { recursive: true })
-  const dest = join(tauriBinDir, `claude-code-provider-gateway-daemon-${entry.triple}${entry.suffix}`)
-  copyFileSync(src, dest)
+  mkdirSync(tauriBinDir, { recursive: true });
+  const dest = join(
+    tauriBinDir,
+    `claude-code-provider-gateway-daemon-${entry.triple}${entry.suffix}`,
+  );
+  copyFileSync(src, dest);
 
-  if (process.platform !== 'win32') {
-    execSync(`chmod +x "${dest}"`)
+  if (process.platform !== "win32") {
+    execSync(`chmod +x "${dest}"`);
   }
 
-  console.log(`✓ sidecar ready: ${dest}`)
+  console.log(`✓ sidecar ready: ${dest}`);
 }
 
-main()
+main();

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -35,9 +35,7 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "externalBin": [
-      "binaries/claude-code-provider-gateway-daemon"
-    ]
+    "externalBin": ["binaries/claude-code-provider-gateway-daemon"]
   },
   "plugins": {}
 }

--- a/packages/panel/src/app/routes.tsx
+++ b/packages/panel/src/app/routes.tsx
@@ -1,10 +1,10 @@
 import { Route, Routes } from "react-router-dom";
-import { AppShell } from "../features/shell/AppShell.js";
 import DashboardPage from "../features/dashboard/components/DashboardPage.js";
 import HistoryPage from "../features/history/components/HistoryPage.js";
 import ProvidersPage from "../features/providers/components/ProvidersPage.js";
 import RoutingPage from "../features/routing/components/RoutingPage.js";
 import SettingsPage from "../features/settings/components/SettingsPage.js";
+import { AppShell } from "../features/shell/AppShell.js";
 
 export function AppRoutes() {
   return (

--- a/packages/panel/src/app/theme/ThemeProvider.tsx
+++ b/packages/panel/src/app/theme/ThemeProvider.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from "react";
 import { App, ConfigProvider } from "antd";
+import type { ReactNode } from "react";
 import { antdTheme } from "./antdTheme.js";
 
 export function ThemeProvider({ children }: { children: ReactNode }) {

--- a/packages/panel/src/app/theme/antdTheme.ts
+++ b/packages/panel/src/app/theme/antdTheme.ts
@@ -1,4 +1,4 @@
-import { theme, type ThemeConfig } from "antd";
+import { type ThemeConfig, theme } from "antd";
 
 export const antdTheme: ThemeConfig = {
   algorithm: theme.darkAlgorithm,

--- a/packages/panel/src/features/dashboard/components/DashboardPage.tsx
+++ b/packages/panel/src/features/dashboard/components/DashboardPage.tsx
@@ -1,14 +1,14 @@
-import { useMemo, useState } from "react";
 import { Flex, theme } from "antd";
+import { useMemo, useState } from "react";
 import { PageHeader } from "../../../shared/components/PageHeader.js";
 import { useGatewayStatus } from "../hooks/useGatewayStatus.js";
 import { useLaunchCommands } from "../hooks/useLaunchCommands.js";
 import { useLiveLogs } from "../hooks/useLiveLogs.js";
 import { useShellSetup } from "../hooks/useShellSetup.js";
-import { StatusOverview } from "./StatusOverview.js";
 import { EnabledProvidersCard } from "./EnabledProvidersCard.js";
-import { QuickLaunchCard, ShellSetupCard } from "./ShellSetupCard.js";
 import { LiveLogsPanel } from "./LiveLogsPanel.js";
+import { QuickLaunchCard, ShellSetupCard } from "./ShellSetupCard.js";
+import { StatusOverview } from "./StatusOverview.js";
 
 const DISMISSED_SHELL_SETUP_KEY = "cc-provider-gtw:shell-setup-dismissed";
 
@@ -23,23 +23,24 @@ export default function DashboardPage() {
   );
 
   const hasTerminalConfigured = useMemo(
-    () => setup?.shells.some(shell => shell.installed) ?? false,
+    () => setup?.shells.some((shell) => shell.installed) ?? false,
     [setup],
   );
 
-  const shellSetupCard = setup && status && !setupDismissed ? (
-    <ShellSetupCard
-      setup={setup}
-      panelPort={status.panelPort ?? 6767}
-      defaultOpen={!hasTerminalConfigured}
-      canDismiss={hasTerminalConfigured}
-      onRefresh={refresh}
-      onDismiss={() => {
-        window.localStorage.setItem(DISMISSED_SHELL_SETUP_KEY, "true");
-        setSetupDismissed(true);
-      }}
-    />
-  ) : null;
+  const shellSetupCard =
+    setup && status && !setupDismissed ? (
+      <ShellSetupCard
+        setup={setup}
+        panelPort={status.panelPort ?? 6767}
+        defaultOpen={!hasTerminalConfigured}
+        canDismiss={hasTerminalConfigured}
+        onRefresh={refresh}
+        onDismiss={() => {
+          window.localStorage.setItem(DISMISSED_SHELL_SETUP_KEY, "true");
+          setSetupDismissed(true);
+        }}
+      />
+    ) : null;
 
   return (
     <Flex vertical gap={token.paddingLG}>
@@ -49,12 +50,7 @@ export default function DashboardPage() {
       {!hasTerminalConfigured && shellSetupCard}
       <QuickLaunchCard items={items} error={launchError} />
       {hasTerminalConfigured && shellSetupCard}
-      <LiveLogsPanel
-        logs={logs}
-        paused={paused}
-        onTogglePaused={togglePaused}
-        onClear={clear}
-      />
+      <LiveLogsPanel logs={logs} paused={paused} onTogglePaused={togglePaused} onClear={clear} />
     </Flex>
   );
 }

--- a/packages/panel/src/features/dashboard/components/EnabledProvidersCard.tsx
+++ b/packages/panel/src/features/dashboard/components/EnabledProvidersCard.tsx
@@ -1,8 +1,8 @@
-import { Card, Col, Empty, Row, Space, Tag, Typography, theme } from "antd";
 import { ThunderboltOutlined } from "@ant-design/icons";
+import { Card, Col, Empty, Row, Space, Tag, Typography, theme } from "antd";
 import { Link as RouterLink } from "react-router-dom";
-import { ProviderStatCard } from "./ProviderStatCard.js";
 import type { StatsResponse } from "../types.js";
+import { ProviderStatCard } from "./ProviderStatCard.js";
 
 const { Text } = Typography;
 
@@ -20,17 +20,12 @@ export function EnabledProvidersCard({ stats }: EnabledProvidersCardProps) {
         <Space>
           <ThunderboltOutlined style={{ color: token.colorPrimary }} />
           <span>Current Session — Enabled Providers</span>
-          {stats && (
-            <Tag color={count > 0 ? "processing" : "default"}>
-              {count} enabled
-            </Tag>
-          )}
+          {stats && <Tag color={count > 0 ? "processing" : "default"}>{count} enabled</Tag>}
         </Space>
       }
       extra={
         <Text type="secondary">
-          Stats reset on daemon restart ·{" "}
-          <ThemedLink to="/history">History</ThemedLink>
+          Stats reset on daemon restart · <ThemedLink to="/history">History</ThemedLink>
         </Text>
       }
     >
@@ -39,8 +34,7 @@ export function EnabledProvidersCard({ stats }: EnabledProvidersCardProps) {
           image={Empty.PRESENTED_IMAGE_SIMPLE}
           description={
             <Text type="secondary">
-              No providers enabled.{" "}
-              <ThemedLink to="/providers">Configure providers</ThemedLink>
+              No providers enabled. <ThemedLink to="/providers">Configure providers</ThemedLink>
             </Text>
           }
         />

--- a/packages/panel/src/features/dashboard/components/LiveLogsPanel.tsx
+++ b/packages/panel/src/features/dashboard/components/LiveLogsPanel.tsx
@@ -1,10 +1,6 @@
-import { useEffect, useRef } from "react";
+import { ClearOutlined, PauseCircleOutlined, PlayCircleOutlined } from "@ant-design/icons";
 import { Badge, Button, Card, Flex, Space, Typography, theme } from "antd";
-import {
-  ClearOutlined,
-  PauseCircleOutlined,
-  PlayCircleOutlined,
-} from "@ant-design/icons";
+import { useEffect, useRef } from "react";
 
 const { Text } = Typography;
 
@@ -15,12 +11,7 @@ interface LiveLogsPanelProps {
   onClear: () => void;
 }
 
-export function LiveLogsPanel({
-  logs,
-  paused,
-  onTogglePaused,
-  onClear,
-}: LiveLogsPanelProps) {
+export function LiveLogsPanel({ logs, paused, onTogglePaused, onClear }: LiveLogsPanelProps) {
   const { token } = theme.useToken();
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -80,6 +71,7 @@ export function LiveLogsPanel({
             Waiting for log activity…
           </Text>
         ) : (
+          // biome-ignore lint/suspicious/noArrayIndexKey: log lines are append-only and can repeat exactly.
           logs.map((line, i) => <LogLine key={i} line={line} />)
         )}
       </Flex>

--- a/packages/panel/src/features/dashboard/components/ProviderStatCard.tsx
+++ b/packages/panel/src/features/dashboard/components/ProviderStatCard.tsx
@@ -10,8 +10,7 @@ interface ProviderStatCardProps {
 
 export function ProviderStatCard({ provider: p }: ProviderStatCardProps) {
   const { token } = theme.useToken();
-  const errorRate =
-    p.requests > 0 ? Math.round((p.errors / p.requests) * 100) : 0;
+  const errorRate = p.requests > 0 ? Math.round((p.errors / p.requests) * 100) : 0;
   const lastActivity = p.lastActivityAt ? formatRelative(p.lastActivityAt) : "never";
 
   return (
@@ -30,10 +29,7 @@ export function ProviderStatCard({ provider: p }: ProviderStatCardProps) {
           <Statistic title="Requests" value={p.requests} />
         </Col>
         <Col span={12}>
-          <Statistic
-            title="Avg latency"
-            value={p.requests > 0 ? `${p.avgLatencyMs}ms` : "—"}
-          />
+          <Statistic title="Avg latency" value={p.requests > 0 ? `${p.avgLatencyMs}ms` : "—"} />
         </Col>
       </Row>
       <Flex gap={token.paddingXS} style={{ marginTop: token.paddingSM }}>

--- a/packages/panel/src/features/dashboard/components/ShellSetupCard.tsx
+++ b/packages/panel/src/features/dashboard/components/ShellSetupCard.tsx
@@ -1,31 +1,14 @@
-import { useEffect, useMemo, useState } from "react";
-import {
-  App,
-  Button,
-  Card,
-  Empty,
-  Flex,
-  Space,
-  Tag,
-  Tooltip,
-  Typography,
-  theme,
-} from "antd";
 import {
   CheckCircleFilled,
   CopyOutlined,
   DownloadOutlined,
   LoadingOutlined,
 } from "@ant-design/icons";
+import { App, Button, Card, Empty, Flex, Space, Tag, Tooltip, Typography, theme } from "antd";
+import { useEffect, useMemo, useState } from "react";
 import { useCopyToClipboard } from "../../../shared/hooks/useCopyToClipboard.js";
 import { dashboardService } from "../dashboardService.js";
-import type {
-  InstallResult,
-  LaunchItem,
-  ShellInfo,
-  ShellName,
-  ShellSetup,
-} from "../types.js";
+import type { InstallResult, LaunchItem, ShellInfo, ShellName, ShellSetup } from "../types.js";
 
 const { Text, Paragraph } = Typography;
 
@@ -69,8 +52,8 @@ export function ShellSetupCard({
     }
   };
 
-  const allInstalled = setup.shells.every(s => s.installed || !s.rcExists);
-  const installableShells = setup.shells.filter(s => !s.installed);
+  const allInstalled = setup.shells.every((s) => s.installed || !s.rcExists);
+  const installableShells = setup.shells.filter((s) => !s.installed);
 
   return (
     <Card
@@ -83,7 +66,7 @@ export function ShellSetupCard({
               Dismiss configuration message
             </Button>
           )}
-          <Button type="text" size="small" onClick={() => setOpen(v => !v)}>
+          <Button type="text" size="small" onClick={() => setOpen((v) => !v)}>
             {open ? "Hide" : "Configure"}
           </Button>
         </Space>
@@ -96,7 +79,7 @@ export function ShellSetupCard({
       {open && (
         <Flex vertical gap={token.paddingMD}>
           <Flex wrap gap={token.paddingXS} align="center">
-            {setup.shells.map(shell => (
+            {setup.shells.map((shell) => (
               <ShellInstallButton
                 key={shell.name}
                 shell={shell}
@@ -113,7 +96,7 @@ export function ShellSetupCard({
                 disabled={installingShell !== null && installingShell !== "all"}
                 onClick={() =>
                   handleInstall(
-                    installableShells.map(s => s.name),
+                    installableShells.map((s) => s.name),
                     "all",
                   )
                 }
@@ -123,12 +106,7 @@ export function ShellSetupCard({
             )}
           </Flex>
 
-          <ManualOneLiner
-            setup={setup}
-            panelPort={panelPort}
-            copiedKey={copiedKey}
-            onCopy={copy}
-          />
+          <ManualOneLiner setup={setup} panelPort={panelPort} copiedKey={copiedKey} onCopy={copy} />
         </Flex>
       )}
     </Card>
@@ -151,7 +129,7 @@ export function QuickLaunchCard({ items, error }: QuickLaunchCardProps) {
 }
 
 function HeaderSummary({ shells }: { shells: ShellInfo[] }) {
-  const installed = shells.filter(s => s.installed);
+  const installed = shells.filter((s) => s.installed);
   if (installed.length === 0) {
     return <Tag>Not installed</Tag>;
   }
@@ -159,7 +137,7 @@ function HeaderSummary({ shells }: { shells: ShellInfo[] }) {
     <Space size={4}>
       <CheckCircleFilled style={{ color: "#52c41a" }} />
       <Text type="secondary">
-        Installed in {installed.map(s => SHELL_DISPLAY_NAMES[s.name]).join(", ")}
+        Installed in {installed.map((s) => SHELL_DISPLAY_NAMES[s.name]).join(", ")}
       </Text>
     </Space>
   );
@@ -203,7 +181,7 @@ function AvailableProviders({
         Available in your terminal:
       </Text>
       <Flex wrap gap={token.paddingXS}>
-        {items.map(item => (
+        {items.map((item) => (
           <Tooltip
             key={item.id}
             title={copiedKey === item.id ? "Copied!" : `Click to copy: ${item.cmd}`}
@@ -282,7 +260,7 @@ function ManualOneLiner({
   const [pickedShell, setPickedShell] = useState<ShellName>(
     setup.currentShell ?? setup.shells[0]?.name ?? "bash",
   );
-  const pickedInfo = setup.shells.find(s => s.name === pickedShell);
+  const pickedInfo = setup.shells.find((s) => s.name === pickedShell);
 
   const oneLiner = useMemo(() => {
     if (pickedShell === "powershell") {
@@ -298,7 +276,7 @@ function ManualOneLiner({
           Or paste this in any terminal:
         </Text>
         <Space size={4}>
-          {setup.shells.map(s => (
+          {setup.shells.map((s) => (
             <Tag
               key={s.name}
               color={pickedShell === s.name ? "blue" : undefined}
@@ -349,23 +327,23 @@ function announceResults(
   results: InstallResult[],
   message: ReturnType<typeof App.useApp>["message"],
 ): void {
-  const installed = results.filter(r => r.status === "installed");
-  const updated = results.filter(r => r.status === "updated");
-  const already = results.filter(r => r.status === "already-installed");
-  const errors = results.filter(r => r.status === "error");
+  const installed = results.filter((r) => r.status === "installed");
+  const updated = results.filter((r) => r.status === "updated");
+  const already = results.filter((r) => r.status === "already-installed");
+  const errors = results.filter((r) => r.status === "error");
 
   if (installed.length > 0) {
     message.success(
-      `Added to ${installed.map(r => r.shell).join(", ")} — open a new terminal to use it`,
+      `Added to ${installed.map((r) => r.shell).join(", ")} — open a new terminal to use it`,
     );
   }
   if (updated.length > 0) {
     message.success(
-      `Updated ${updated.map(r => r.shell).join(", ")} — open a new terminal to pick up the new snippet`,
+      `Updated ${updated.map((r) => r.shell).join(", ")} — open a new terminal to pick up the new snippet`,
     );
   }
   if (already.length > 0 && installed.length === 0 && updated.length === 0) {
-    message.info(`Already up to date in ${already.map(r => r.shell).join(", ")}`);
+    message.info(`Already up to date in ${already.map((r) => r.shell).join(", ")}`);
   }
   for (const e of errors) {
     message.error(`${e.shell}: ${e.error ?? "unknown error"}`);

--- a/packages/panel/src/features/dashboard/components/StatusOverview.tsx
+++ b/packages/panel/src/features/dashboard/components/StatusOverview.tsx
@@ -1,5 +1,5 @@
-import { Card, Col, Row, Statistic, theme } from "antd";
 import { CheckCircleFilled, CloseCircleFilled } from "@ant-design/icons";
+import { Card, Col, Row, Statistic, theme } from "antd";
 import { formatUptime } from "../../../shared/utils/time.js";
 import type { GatewayStatus } from "../types.js";
 
@@ -11,11 +11,7 @@ export function StatusOverview({ status }: StatusOverviewProps) {
   const { token } = theme.useToken();
 
   const statusValue = status?.running ? "Running" : status ? "Stopped" : "—";
-  const statusColor = status?.running
-    ? token.colorSuccess
-    : status
-      ? token.colorError
-      : undefined;
+  const statusColor = status?.running ? token.colorSuccess : status ? token.colorError : undefined;
   const statusIcon = status?.running ? (
     <CheckCircleFilled />
   ) : status ? (
@@ -36,10 +32,7 @@ export function StatusOverview({ status }: StatusOverviewProps) {
       </Col>
       <Col span={6}>
         <Card>
-          <Statistic
-            title="Uptime"
-            value={status ? formatUptime(status.uptimeMs) : "—"}
-          />
+          <Statistic title="Uptime" value={status ? formatUptime(status.uptimeMs) : "—"} />
         </Card>
       </Col>
       <Col span={6}>
@@ -49,11 +42,7 @@ export function StatusOverview({ status }: StatusOverviewProps) {
       </Col>
       <Col span={6}>
         <Card>
-          <Statistic
-            title="PID"
-            value={status?.pid?.toString() ?? "—"}
-            groupSeparator=""
-          />
+          <Statistic title="PID" value={status?.pid?.toString() ?? "—"} groupSeparator="" />
         </Card>
       </Col>
     </Row>

--- a/packages/panel/src/features/dashboard/hooks/useGatewayStatus.ts
+++ b/packages/panel/src/features/dashboard/hooks/useGatewayStatus.ts
@@ -10,8 +10,14 @@ export function useGatewayStatus() {
   const [stats, setStats] = useState<StatsResponse | null>(null);
 
   const refresh = useCallback(() => {
-    dashboardService.getStatus().then(setStatus).catch(() => {});
-    dashboardService.getStats().then(setStats).catch(() => {});
+    dashboardService
+      .getStatus()
+      .then(setStatus)
+      .catch(() => {});
+    dashboardService
+      .getStats()
+      .then(setStats)
+      .catch(() => {});
   }, []);
 
   usePolling(refresh, POLL_INTERVAL_MS);

--- a/packages/panel/src/features/dashboard/hooks/useLiveLogs.ts
+++ b/packages/panel/src/features/dashboard/hooks/useLiveLogs.ts
@@ -13,8 +13,7 @@ export function useLiveLogs() {
 
   useSSE<LogEvent>(
     "/api/logs",
-    ({ line }) =>
-      setLogs((prev) => [...prev.slice(-(MAX_LINES - 1)), line]),
+    ({ line }) => setLogs((prev) => [...prev.slice(-(MAX_LINES - 1)), line]),
     { paused },
   );
 

--- a/packages/panel/src/features/history/components/ClearHistoryModal.tsx
+++ b/packages/panel/src/features/history/components/ClearHistoryModal.tsx
@@ -9,12 +9,7 @@ interface ClearHistoryModalProps {
   onConfirm: () => void;
 }
 
-export function ClearHistoryModal({
-  open,
-  loading,
-  onCancel,
-  onConfirm,
-}: ClearHistoryModalProps) {
+export function ClearHistoryModal({ open, loading, onCancel, onConfirm }: ClearHistoryModalProps) {
   return (
     <Modal
       open={open}
@@ -24,22 +19,14 @@ export function ClearHistoryModal({
         <Button key="cancel" onClick={onCancel} disabled={loading}>
           Cancel
         </Button>,
-        <Button
-          key="ok"
-          type="primary"
-          danger
-          loading={loading}
-          onClick={onConfirm}
-          autoFocus
-        >
+        <Button key="ok" type="primary" danger loading={loading} onClick={onConfirm} autoFocus>
           Clear history
         </Button>,
       ]}
       width={440}
     >
       <Text type="secondary">
-        Removes completed and crashed sessions. The currently running session is
-        kept.
+        Removes completed and crashed sessions. The currently running session is kept.
       </Text>
     </Modal>
   );

--- a/packages/panel/src/features/history/components/HistoryHeader.tsx
+++ b/packages/panel/src/features/history/components/HistoryHeader.tsx
@@ -1,5 +1,5 @@
-import { Button, Flex, Space, Typography } from "antd";
 import { DeleteOutlined, ReloadOutlined } from "@ant-design/icons";
+import { Button, Flex, Space, Typography } from "antd";
 import { PageHeader } from "../../../shared/components/PageHeader.js";
 
 const { Text } = Typography;
@@ -34,12 +34,7 @@ export function HistoryHeader({
         <Button icon={<ReloadOutlined />} onClick={onRefresh}>
           Refresh
         </Button>
-        <Button
-          danger
-          icon={<DeleteOutlined />}
-          disabled={!canClear}
-          onClick={onRequestClear}
-        >
+        <Button danger icon={<DeleteOutlined />} disabled={!canClear} onClick={onRequestClear}>
           Clear history
         </Button>
       </Space>

--- a/packages/panel/src/features/history/components/HistoryPage.tsx
+++ b/packages/panel/src/features/history/components/HistoryPage.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
 import { Card, Empty, Flex, Typography, theme } from "antd";
+import { useState } from "react";
 import { useHistory } from "../hooks/useHistory.js";
+import { ClearHistoryModal } from "./ClearHistoryModal.js";
 import { HistoryHeader } from "./HistoryHeader.js";
 import { HistorySummary } from "./HistorySummary.js";
-import { SessionsTable } from "./SessionsTable.js";
-import { ClearHistoryModal } from "./ClearHistoryModal.js";
 import { ProvidersTable } from "./ProvidersTable.js";
+import { SessionsTable } from "./SessionsTable.js";
 
 const { Text } = Typography;
 
@@ -54,9 +54,7 @@ export default function HistoryPage() {
 
       {sessions.length === 0 ? (
         <Card>
-          <Empty
-            description={<Text type="secondary">No sessions recorded yet.</Text>}
-          />
+          <Empty description={<Text type="secondary">No sessions recorded yet.</Text>} />
         </Card>
       ) : (
         <SessionsTable

--- a/packages/panel/src/features/history/components/ProvidersTable.tsx
+++ b/packages/panel/src/features/history/components/ProvidersTable.tsx
@@ -71,9 +71,7 @@ export function ProvidersTable({ rows, title = "Providers" }: ProvidersTableProp
             title: "Last activity",
             key: "la",
             render: ([, s]: Row) => (
-              <Text type="secondary">
-                {s.lastActivityAt ? formatTime(s.lastActivityAt) : "—"}
-              </Text>
+              <Text type="secondary">{s.lastActivityAt ? formatTime(s.lastActivityAt) : "—"}</Text>
             ),
           },
           {
@@ -82,9 +80,7 @@ export function ProvidersTable({ rows, title = "Providers" }: ProvidersTableProp
             ellipsis: true,
             render: ([, s]: Row) => (
               <Tooltip title={s.lastError ?? ""}>
-                <Text type="secondary">
-                  {s.lastError ? s.lastError.slice(0, 60) : "—"}
-                </Text>
+                <Text type="secondary">{s.lastError ? s.lastError.slice(0, 60) : "—"}</Text>
               </Tooltip>
             ),
           },

--- a/packages/panel/src/features/history/components/RequestDetails.tsx
+++ b/packages/panel/src/features/history/components/RequestDetails.tsx
@@ -1,6 +1,6 @@
 import { Descriptions, Flex, Tag, Typography, theme } from "antd";
-import { SectionLabel } from "./SectionLabel.js";
 import type { RequestLogEntry } from "../types.js";
+import { SectionLabel } from "./SectionLabel.js";
 
 const { Text } = Typography;
 
@@ -22,22 +22,13 @@ export function RequestDetails({ entry: r }: RequestDetailsProps) {
         <Descriptions.Item label="Timestamp">
           {new Date(r.timestamp).toLocaleString()}
         </Descriptions.Item>
-        <Descriptions.Item label="Requested Model">
-          {r.requestedModel}
-        </Descriptions.Item>
+        <Descriptions.Item label="Requested Model">{r.requestedModel}</Descriptions.Item>
         <Descriptions.Item label="Provider">{r.providerId}</Descriptions.Item>
-        <Descriptions.Item label="Provider Model">
-          {r.providerModel}
-        </Descriptions.Item>
-        <Descriptions.Item label="Input Tokens">
-          {r.inputTokens}
-        </Descriptions.Item>
+        <Descriptions.Item label="Provider Model">{r.providerModel}</Descriptions.Item>
+        <Descriptions.Item label="Input Tokens">{r.inputTokens}</Descriptions.Item>
         <Descriptions.Item label="Latency (ms)">{r.latencyMs}</Descriptions.Item>
         <Descriptions.Item label="Status">
-          <Tag
-            color={r.status === "ok" ? "success" : "error"}
-            style={{ margin: 0 }}
-          >
+          <Tag color={r.status === "ok" ? "success" : "error"} style={{ margin: 0 }}>
             {r.status}
           </Tag>
         </Descriptions.Item>

--- a/packages/panel/src/features/history/components/RequestLogTable.tsx
+++ b/packages/panel/src/features/history/components/RequestLogTable.tsx
@@ -1,6 +1,6 @@
-import { Flex, Space, Table, Tag, Tooltip, Typography, theme } from "antd";
-import type { TableColumnsType } from "antd";
 import { CaretRightOutlined } from "@ant-design/icons";
+import type { TableColumnsType } from "antd";
+import { Flex, Space, Table, Tag, Tooltip, Typography, theme } from "antd";
 import { formatNumber, formatTime } from "../format.js";
 import { providerLabel } from "../labels.js";
 import type { RequestLogEntry } from "../types.js";
@@ -61,10 +61,7 @@ export function RequestLogTable({ entries }: RequestLogTableProps) {
       width: 80,
       align: "right",
       render: (v: number) => (
-        <Text
-          type="secondary"
-          style={{ fontFamily: "monospace", fontSize: token.fontSizeSM }}
-        >
+        <Text type="secondary" style={{ fontFamily: "monospace", fontSize: token.fontSizeSM }}>
           {formatNumber(v)}
         </Text>
       ),
@@ -76,10 +73,7 @@ export function RequestLogTable({ entries }: RequestLogTableProps) {
       width: 80,
       align: "right",
       render: (v: number) => (
-        <Text
-          type="secondary"
-          style={{ fontFamily: "monospace", fontSize: token.fontSizeSM }}
-        >
+        <Text type="secondary" style={{ fontFamily: "monospace", fontSize: token.fontSizeSM }}>
           {v}ms
         </Text>
       ),
@@ -90,10 +84,7 @@ export function RequestLogTable({ entries }: RequestLogTableProps) {
       key: "s",
       width: 70,
       render: (v: string) => (
-        <Tag
-          color={v === "ok" ? "success" : "error"}
-          style={{ fontFamily: "monospace" }}
-        >
+        <Tag color={v === "ok" ? "success" : "error"} style={{ fontFamily: "monospace" }}>
           {v}
         </Tag>
       ),
@@ -104,27 +95,40 @@ export function RequestLogTable({ entries }: RequestLogTableProps) {
       width: 160,
       render: (_, e) => {
         const ts = e.tokenSavers;
-        if (!ts) return <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>—</Text>;
+        if (!ts)
+          return (
+            <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+              —
+            </Text>
+          );
         const saved = ts.rtkBytesBefore - ts.rtkBytesAfter;
         const pct = ts.rtkBytesBefore > 0 ? ((saved / ts.rtkBytesBefore) * 100).toFixed(0) : "0";
         return (
           <Space size={4} wrap>
             {ts.rtkHits > 0 && (
               <Tooltip title={`RTK saved ${saved}B (${pct}%) via ${ts.rtkFilters.join(", ")}`}>
-                <Tag color="geekblue" style={{ margin: 0, fontFamily: "monospace", fontSize: token.fontSizeSM }}>
+                <Tag
+                  color="geekblue"
+                  style={{ margin: 0, fontFamily: "monospace", fontSize: token.fontSizeSM }}
+                >
                   RTK -{pct}%
                 </Tag>
               </Tooltip>
             )}
             {ts.cavemanLevel && (
               <Tooltip title={`Caveman ${ts.cavemanLevel} injected into system prompt`}>
-                <Tag color="orange" style={{ margin: 0, fontFamily: "monospace", fontSize: token.fontSizeSM }}>
+                <Tag
+                  color="orange"
+                  style={{ margin: 0, fontFamily: "monospace", fontSize: token.fontSizeSM }}
+                >
                   CAVE {ts.cavemanLevel}
                 </Tag>
               </Tooltip>
             )}
             {ts.rtkHits === 0 && !ts.cavemanLevel && (
-              <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>—</Text>
+              <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+                —
+              </Text>
             )}
           </Space>
         );
@@ -135,10 +139,7 @@ export function RequestLogTable({ entries }: RequestLogTableProps) {
       key: "has_resp",
       width: 90,
       render: (_, e) => (
-        <Tag
-          color={e.response ? "success" : "error"}
-          style={{ fontFamily: "monospace" }}
-        >
+        <Tag color={e.response ? "success" : "error"} style={{ fontFamily: "monospace" }}>
           {e.response ? "yes" : "no"}
         </Tag>
       ),
@@ -148,13 +149,9 @@ export function RequestLogTable({ entries }: RequestLogTableProps) {
       key: "has_user",
       width: 95,
       render: (_, e) => {
-        const hasUser =
-          !!e.prompt && e.prompt.toLowerCase().includes("[user]");
+        const hasUser = !!e.prompt && e.prompt.toLowerCase().includes("[user]");
         return (
-          <Tag
-            color={hasUser ? "success" : "error"}
-            style={{ fontFamily: "monospace" }}
-          >
+          <Tag color={hasUser ? "success" : "error"} style={{ fontFamily: "monospace" }}>
             {hasUser ? "yes" : "no"}
           </Tag>
         );

--- a/packages/panel/src/features/history/components/SessionDetails.tsx
+++ b/packages/panel/src/features/history/components/SessionDetails.tsx
@@ -1,8 +1,8 @@
 import { Flex, Typography, theme } from "antd";
+import type { Session } from "../types.js";
 import { ModelsUsedTable } from "./ModelsUsedTable.js";
 import { RequestLogTable } from "./RequestLogTable.js";
 import { SessionMetadataCards } from "./SessionMetadataCards.js";
-import type { Session } from "../types.js";
 
 const { Text } = Typography;
 const RECENT_REQUEST_LIMIT = 40;
@@ -17,9 +17,7 @@ export function SessionDetails({ session }: SessionDetailsProps) {
   const usedModels = Object.entries(session.modelStats ?? {}).sort(
     ([, a], [, b]) => b.requests - a.requests,
   );
-  const requestLog = [...(session.requestLog ?? [])]
-    .reverse()
-    .slice(0, RECENT_REQUEST_LIMIT);
+  const requestLog = [...(session.requestLog ?? [])].reverse().slice(0, RECENT_REQUEST_LIMIT);
 
   return (
     <Flex
@@ -33,10 +31,7 @@ export function SessionDetails({ session }: SessionDetailsProps) {
       {usedModels.length > 0 && <ModelsUsedTable rows={usedModels} />}
       {requestLog.length > 0 && <RequestLogTable entries={requestLog} />}
 
-      <Text
-        type="secondary"
-        style={{ fontFamily: "monospace", fontSize: token.fontSizeSM - 1 }}
-      >
+      <Text type="secondary" style={{ fontFamily: "monospace", fontSize: token.fontSizeSM - 1 }}>
         session id: {session.id}
       </Text>
     </Flex>

--- a/packages/panel/src/features/history/components/SessionsTable.tsx
+++ b/packages/panel/src/features/history/components/SessionsTable.tsx
@@ -1,6 +1,6 @@
-import { Badge, Card, Space, Table, Typography, theme } from "antd";
-import type { TableColumnsType } from "antd";
 import { CaretRightOutlined } from "@ant-design/icons";
+import type { TableColumnsType } from "antd";
+import { Badge, Card, Space, Table, Typography, theme } from "antd";
 import { formatUptime } from "../../../shared/utils/time.js";
 import { commandFor, formatDate, topModel } from "../format.js";
 import { providerLabel } from "../labels.js";
@@ -15,11 +15,7 @@ interface SessionsTableProps {
   onToggleExpanded: (id: string, expanded: boolean) => void;
 }
 
-export function SessionsTable({
-  sessions,
-  expandedKeys,
-  onToggleExpanded,
-}: SessionsTableProps) {
+export function SessionsTable({ sessions, expandedKeys, onToggleExpanded }: SessionsTableProps) {
   const { token } = theme.useToken();
 
   const columns: TableColumnsType<Session> = [
@@ -30,11 +26,7 @@ export function SessionsTable({
       render: (_, s) => (
         <Badge
           status={
-            s.status === "running"
-              ? "processing"
-              : s.status === "crashed"
-                ? "error"
-                : "default"
+            s.status === "running" ? "processing" : s.status === "crashed" ? "error" : "default"
           }
           text={s.status}
         />
@@ -46,15 +38,11 @@ export function SessionsTable({
       ellipsis: true,
       render: (_, s) => (
         <Space direction="vertical" size={2}>
-          <Text
-            style={{ fontFamily: "monospace", color: token.colorSuccessText }}
-          >
+          <Text style={{ fontFamily: "monospace", color: token.colorSuccessText }}>
             {commandFor(s)}
           </Text>
           <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
-            {s.modelMode === "all"
-              ? "all-providers"
-              : `single: ${providerLabel(s.activeProvider)}`}
+            {s.modelMode === "all" ? "all-providers" : `single: ${providerLabel(s.activeProvider)}`}
           </Text>
         </Space>
       ),
@@ -91,9 +79,7 @@ export function SessionsTable({
       key: "duration",
       width: 90,
       render: (_, s) => (
-        <Text style={{ fontFamily: "monospace" }}>
-          {formatUptime(s.durationMs)}
-        </Text>
+        <Text style={{ fontFamily: "monospace" }}>{formatUptime(s.durationMs)}</Text>
       ),
     },
     {
@@ -148,8 +134,7 @@ export function SessionsTable({
         })}
         expandable={{
           expandedRowKeys: expandedKeys,
-          onExpand: (expanded, record) =>
-            onToggleExpanded(record.id, expanded),
+          onExpand: (expanded, record) => onToggleExpanded(record.id, expanded),
           expandedRowRender: (record) => <SessionDetails session={record} />,
           expandIcon: ({ expanded, onExpand, record }) => (
             <CaretRightOutlined

--- a/packages/panel/src/features/history/format.ts
+++ b/packages/panel/src/features/history/format.ts
@@ -24,9 +24,5 @@ export function topModel(session: Session): string | null {
   const models = Object.entries(session.modelStats ?? {}).sort(
     ([, a], [, b]) => b.requests - a.requests,
   );
-  return (
-    models[0]?.[0] ??
-    [...(session.requestLog ?? [])].reverse()[0]?.requestedModel ??
-    null
-  );
+  return models[0]?.[0] ?? [...(session.requestLog ?? [])].reverse()[0]?.requestedModel ?? null;
 }

--- a/packages/panel/src/features/history/hooks/useHistory.ts
+++ b/packages/panel/src/features/history/hooks/useHistory.ts
@@ -60,9 +60,7 @@ export function useHistory() {
   }, []);
 
   const toggleExpanded = useCallback((id: string, expanded: boolean) => {
-    setExpandedKeys((prev) =>
-      expanded ? [...prev, id] : prev.filter((k) => k !== id),
-    );
+    setExpandedKeys((prev) => (expanded ? [...prev, id] : prev.filter((k) => k !== id)));
   }, []);
 
   return {

--- a/packages/panel/src/features/history/types.ts
+++ b/packages/panel/src/features/history/types.ts
@@ -11,11 +11,7 @@ export type ModelStat = SessionModelStat;
 export type RequestLogEntry = SessionRequestLogEntry;
 export type Session = SessionRecord;
 
-export type {
-  GatewayProviderStat,
-  ProviderStat,
-  SessionsResponse,
-};
+export type { GatewayProviderStat, ProviderStat, SessionsResponse };
 
 export interface StatsResponse {
   providers: GatewayProviderStat[];

--- a/packages/panel/src/features/providers/components/ApiKeySection.tsx
+++ b/packages/panel/src/features/providers/components/ApiKeySection.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { Button, Flex, Input, Space, Typography } from "antd";
 import { DeleteOutlined, EditOutlined, KeyOutlined } from "@ant-design/icons";
+import { Button, Flex, Input, Space, Typography } from "antd";
+import { useState } from "react";
 
 const { Text } = Typography;
 
@@ -57,11 +57,7 @@ export function ApiKeySection({
               setDraft("");
             }}
           />
-          <Button
-            danger
-            icon={<DeleteOutlined />}
-            onClick={onRequestRemove}
-          />
+          <Button danger icon={<DeleteOutlined />} onClick={onRequestRemove} />
         </Space>
       ) : (
         <Space.Compact style={{ width: "100%", maxWidth: 480 }}>
@@ -76,11 +72,7 @@ export function ApiKeySection({
               if (e.key === "Escape" && editing) close();
             }}
           />
-          <Button
-            type="primary"
-            disabled={!draft.trim()}
-            onClick={submit}
-          >
+          <Button type="primary" disabled={!draft.trim()} onClick={submit}>
             Save
           </Button>
           {editing && <Button onClick={close}>Cancel</Button>}

--- a/packages/panel/src/features/providers/components/BaseUrlSection.tsx
+++ b/packages/panel/src/features/providers/components/BaseUrlSection.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { Button, Flex, Input, Space, Typography } from "antd";
 import { EditOutlined, LinkOutlined, WarningOutlined } from "@ant-design/icons";
+import { Button, Flex, Input, Space, Typography } from "antd";
+import { useState } from "react";
 
 const { Text } = Typography;
 

--- a/packages/panel/src/features/providers/components/ConfirmModal.tsx
+++ b/packages/panel/src/features/providers/components/ConfirmModal.tsx
@@ -34,15 +34,9 @@ const COPY = {
   },
 } as const;
 
-export function ConfirmModal({
-  action,
-  providers,
-  onCancel,
-  onConfirm,
-}: ConfirmModalProps) {
+export function ConfirmModal({ action, providers, onCancel, onConfirm }: ConfirmModalProps) {
   if (!action) return null;
-  const label =
-    providers.find((p) => p.id === action.providerId)?.label ?? action.providerId;
+  const label = providers.find((p) => p.id === action.providerId)?.label ?? action.providerId;
   const copy = COPY[action.kind];
 
   return (
@@ -54,13 +48,7 @@ export function ConfirmModal({
         <Button key="cancel" onClick={onCancel}>
           Cancel
         </Button>,
-        <Button
-          key="ok"
-          type="primary"
-          danger={copy.danger}
-          onClick={onConfirm}
-          autoFocus
-        >
+        <Button key="ok" type="primary" danger={copy.danger} onClick={onConfirm} autoFocus>
           {copy.okText}
         </Button>,
       ]}

--- a/packages/panel/src/features/providers/components/CopilotDevicePrompt.tsx
+++ b/packages/panel/src/features/providers/components/CopilotDevicePrompt.tsx
@@ -1,8 +1,8 @@
-import { Badge, Button, Flex, Space, Typography, theme } from "antd";
 import { CheckOutlined } from "@ant-design/icons";
+import { Badge, Button, Flex, Space, Typography, theme } from "antd";
 import { useCopyToClipboard } from "../../../shared/hooks/useCopyToClipboard.js";
-import type { CopilotFlow } from "../types.js";
 import { openExternal } from "../../../shared/openExternal.js";
+import type { CopilotFlow } from "../types.js";
 
 const { Text, Link } = Typography;
 
@@ -52,7 +52,10 @@ export function CopilotDevicePrompt({ flow, onCancel }: CopilotDevicePromptProps
         Step 2 — Approve access on{" "}
         <Link
           href={flow.verificationUri}
-          onClick={(e) => { e.preventDefault(); openExternal(flow.verificationUri); }}
+          onClick={(e) => {
+            e.preventDefault();
+            openExternal(flow.verificationUri);
+          }}
         >
           {flow.verificationUri}
         </Link>

--- a/packages/panel/src/features/providers/components/ExtraModelsSection.tsx
+++ b/packages/panel/src/features/providers/components/ExtraModelsSection.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { Button, Flex, Input, Space, Tag, Typography } from "antd";
 import { PlusOutlined } from "@ant-design/icons";
+import { Button, Flex, Input, Space, Tag, Typography } from "antd";
+import { useState } from "react";
 
 const { Text } = Typography;
 
@@ -10,11 +10,7 @@ interface ExtraModelsSectionProps {
   onRemove: (model: string) => void;
 }
 
-export function ExtraModelsSection({
-  models,
-  onAdd,
-  onRemove,
-}: ExtraModelsSectionProps) {
+export function ExtraModelsSection({ models, onAdd, onRemove }: ExtraModelsSectionProps) {
   const [draft, setDraft] = useState("");
   const trimmed = draft.trim();
   const alreadyAdded = models.includes(trimmed);

--- a/packages/panel/src/features/providers/components/ModelSelector.tsx
+++ b/packages/panel/src/features/providers/components/ModelSelector.tsx
@@ -1,25 +1,9 @@
+import { CaretDownOutlined, CaretRightOutlined, SearchOutlined } from "@ant-design/icons";
+import { Button, Checkbox, Col, Flex, Input, Row, Space, Spin, Tag, Typography, theme } from "antd";
 import { useMemo, useState } from "react";
-import {
-  Button,
-  Checkbox,
-  Col,
-  Flex,
-  Input,
-  Row,
-  Space,
-  Spin,
-  Tag,
-  Typography,
-  theme,
-} from "antd";
-import {
-  CaretDownOutlined,
-  CaretRightOutlined,
-  SearchOutlined,
-} from "@ant-design/icons";
 import { useProviderModels } from "../hooks/useProviderModels.js";
-import { stripModelPrefix } from "../utils.js";
 import type { ModelInfo } from "../types.js";
+import { stripModelPrefix } from "../utils.js";
 
 const { Text } = Typography;
 
@@ -49,9 +33,7 @@ export function ModelSelector({
   const visible = useMemo(() => {
     if (!models) return [];
     if (!query) return models;
-    return models.filter((m) =>
-      stripModelPrefix(m.display_name).toLowerCase().includes(query),
-    );
+    return models.filter((m) => stripModelPrefix(m.display_name).toLowerCase().includes(query));
   }, [models, query]);
 
   const allDisabled = total > 0 && disabledSet.size === total;
@@ -70,9 +52,7 @@ export function ModelSelector({
   };
 
   const toggleAll = () => {
-    onDisabledModelsChange(
-      disabledSet.size === 0 ? (models ?? []).map((m) => m.id) : [],
-    );
+    onDisabledModelsChange(disabledSet.size === 0 ? (models ?? []).map((m) => m.id) : []);
   };
 
   return (
@@ -103,9 +83,7 @@ export function ModelSelector({
             </Space>
           )}
 
-          {!loading && models?.length === 0 && (
-            <Text type="secondary">No models found</Text>
-          )}
+          {!loading && models?.length === 0 && <Text type="secondary">No models found</Text>}
 
           {!loading && models && models.length > 0 && (
             <ModelGrid
@@ -185,10 +163,7 @@ function ModelGrid({
         }}
       >
         {visible.length === 0 ? (
-          <Text
-            type="secondary"
-            style={{ padding: `${token.paddingXS}px ${token.paddingSM}px` }}
-          >
+          <Text type="secondary" style={{ padding: `${token.paddingXS}px ${token.paddingSM}px` }}>
             No models match "{search}"
           </Text>
         ) : (
@@ -226,10 +201,7 @@ function ModelRow({ model, active, onChange }: ModelRowProps) {
         cursor: "pointer",
       }}
     >
-      <Checkbox
-        checked={active}
-        onChange={(e) => onChange(e.target.checked)}
-      />
+      <Checkbox checked={active} onChange={(e) => onChange(e.target.checked)} />
       <Text
         style={{
           fontSize: token.fontSizeSM,

--- a/packages/panel/src/features/providers/components/OAuthSection.tsx
+++ b/packages/panel/src/features/providers/components/OAuthSection.tsx
@@ -1,8 +1,8 @@
-import { Badge, Button, Flex, Space, Typography } from "antd";
 import { GithubOutlined } from "@ant-design/icons";
-import { CopilotDevicePrompt } from "./CopilotDevicePrompt.js";
+import { Badge, Button, Flex, Space, Typography } from "antd";
 import { DEVICE_FLOW_PROVIDERS } from "../constants.js";
 import type { CopilotFlow, OAuthInfo } from "../types.js";
+import { CopilotDevicePrompt } from "./CopilotDevicePrompt.js";
 
 const { Text } = Typography;
 
@@ -28,8 +28,7 @@ export function OAuthSection({
   onCancelFlow,
 }: OAuthSectionProps) {
   const isDeviceFlow = DEVICE_FLOW_PROVIDERS.has(providerId);
-  const accountLabel =
-    providerId === "copilot" ? "GitHub account" : "OpenAI account";
+  const accountLabel = providerId === "copilot" ? "GitHub account" : "OpenAI account";
 
   return (
     <Flex vertical gap={4}>
@@ -45,24 +44,13 @@ export function OAuthSection({
       ) : isDeviceFlow && busy && copilotFlow ? (
         <CopilotDevicePrompt flow={copilotFlow} onCancel={onCancelFlow} />
       ) : (
-        <LoginRow
-          providerId={providerId}
-          busy={busy}
-          error={error}
-          onLogin={onLogin}
-        />
+        <LoginRow providerId={providerId} busy={busy} error={error} onLogin={onLogin} />
       )}
     </Flex>
   );
 }
 
-function LoggedInRow({
-  oauth,
-  onLogout,
-}: {
-  oauth: OAuthInfo;
-  onLogout: () => void;
-}) {
+function LoggedInRow({ oauth, onLogout }: { oauth: OAuthInfo; onLogout: () => void }) {
   return (
     <Space>
       <Badge status="success" />
@@ -94,12 +82,7 @@ function LoginRow({ providerId, busy, error, onLogin }: LoginRowProps) {
 
   return (
     <Flex vertical gap={4}>
-      <Button
-        type="primary"
-        icon={<GithubOutlined />}
-        loading={busy}
-        onClick={onLogin}
-      >
+      <Button type="primary" icon={<GithubOutlined />} loading={busy} onClick={onLogin}>
         {buttonLabel}
       </Button>
       {error && <Text type="danger">{error}</Text>}

--- a/packages/panel/src/features/providers/components/ProviderCard.tsx
+++ b/packages/panel/src/features/providers/components/ProviderCard.tsx
@@ -1,21 +1,6 @@
-import {
-  Badge,
-  Button,
-  Card,
-  Divider,
-  Flex,
-  Space,
-  Switch,
-  Tag,
-  Typography,
-  theme,
-} from "antd";
+import { Badge, Button, Card, Divider, Flex, Space, Switch, Tag, Typography, theme } from "antd";
 import { LOCAL_PROVIDERS, OAUTH_PROVIDERS } from "../constants.js";
-import type {
-  CopilotFlow,
-  ProviderInfo,
-  TestResult,
-} from "../types.js";
+import type { CopilotFlow, ProviderInfo, TestResult } from "../types.js";
 import { ApiKeySection } from "./ApiKeySection.js";
 import { BaseUrlSection } from "./BaseUrlSection.js";
 import { ExtraModelsSection } from "./ExtraModelsSection.js";
@@ -61,8 +46,7 @@ export function ProviderCard({
   const { token } = theme.useToken();
   const isLocal = LOCAL_PROVIDERS.has(p.id);
   const isOAuth = OAUTH_PROVIDERS.has(p.id);
-  const canTest =
-    p.enabled && (isLocal || (isOAuth ? p.oauth?.loggedIn : p.hasKey));
+  const canTest = p.enabled && (isLocal || (isOAuth ? p.oauth?.loggedIn : p.hasKey));
   const ready = isLocal ? true : isOAuth ? p.oauth?.loggedIn === true : p.hasKey;
 
   return (
@@ -80,17 +64,10 @@ export function ProviderCard({
       title={<CardTitle provider={p} result={testResult} />}
       extra={
         <Space>
-          <Button
-            loading={testing}
-            disabled={!canTest}
-            onClick={() => handlers.onTest(p.id)}
-          >
+          <Button loading={testing} disabled={!canTest} onClick={() => handlers.onTest(p.id)}>
             Test
           </Button>
-          <Switch
-            checked={p.enabled}
-            onChange={() => handlers.onToggleEnabled(p.id, p.enabled)}
-          />
+          <Switch checked={p.enabled} onChange={() => handlers.onToggleEnabled(p.id, p.enabled)} />
         </Space>
       }
     >
@@ -142,9 +119,7 @@ export function ProviderCard({
               providerId={p.id}
               disabledModels={p.disabledModels ?? []}
               ready={!!ready}
-              onDisabledModelsChange={(disabled) =>
-                handlers.onDisabledModelsChange(p.id, disabled)
-              }
+              onDisabledModelsChange={(disabled) => handlers.onDisabledModelsChange(p.id, disabled)}
             />
           </>
         )}
@@ -153,13 +128,7 @@ export function ProviderCard({
   );
 }
 
-function CardTitle({
-  provider: p,
-  result,
-}: {
-  provider: ProviderInfo;
-  result?: TestResult;
-}) {
+function CardTitle({ provider: p, result }: { provider: ProviderInfo; result?: TestResult }) {
   return (
     <Space>
       {p.enabled && <Badge status="processing" />}

--- a/packages/panel/src/features/providers/components/ProvidersPage.tsx
+++ b/packages/panel/src/features/providers/components/ProvidersPage.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useState } from "react";
 import { Col, Flex, Row, theme } from "antd";
+import { useCallback, useState } from "react";
 import { PageHeader } from "../../../shared/components/PageHeader.js";
 import { useOAuth } from "../hooks/useOAuth.js";
 import { useProviders } from "../hooks/useProviders.js";
@@ -33,8 +33,7 @@ export default function ProvidersPage() {
     onSaveKey: providersApi.saveKey,
     onRequestReplaceKey: (providerId, newValue) =>
       setConfirm({ kind: "replace-key", providerId, newValue }),
-    onRequestRemoveKey: (providerId) =>
-      setConfirm({ kind: "remove-key", providerId }),
+    onRequestRemoveKey: (providerId) => setConfirm({ kind: "remove-key", providerId }),
     onRequestChangeUrl: (providerId, newValue) =>
       setConfirm({ kind: "change-url", providerId, newValue }),
     onAddModel: providersApi.addModel,

--- a/packages/panel/src/features/providers/hooks/useOAuth.ts
+++ b/packages/panel/src/features/providers/hooks/useOAuth.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { openExternal } from "../../../shared/openExternal.js";
 import { DEVICE_FLOW_PROVIDERS } from "../constants.js";
 import { providersService } from "../providersService.js";
 import type { CopilotFlow } from "../types.js";
-import { openExternal } from "../../../shared/openExternal.js";
 
 const BROWSER_FLOW_TIMEOUT_MS = 5 * 60 * 1000;
 const BROWSER_FLOW_POLL_MS = 1200;
@@ -34,13 +34,7 @@ export function useOAuth({ onSuccess }: UseOAuthOptions) {
   }, [clearPoll]);
 
   const pollUntilDone = useCallback(
-    (
-      id: string,
-      key: string,
-      deadline: number,
-      intervalMs: number,
-      onResolved: () => void,
-    ) => {
+    (id: string, key: string, deadline: number, intervalMs: number, onResolved: () => void) => {
       clearPoll();
       pollRef.current = window.setInterval(async () => {
         try {
@@ -56,8 +50,7 @@ export function useOAuth({ onSuccess }: UseOAuthOptions) {
             clearPoll();
             onResolved();
             setError(
-              result.error ??
-                (expired ? "Device code expired" : "Login failed or timed out"),
+              result.error ?? (expired ? "Device code expired" : "Login failed or timed out"),
             );
           }
         } catch {
@@ -111,8 +104,7 @@ export function useOAuth({ onSuccess }: UseOAuthOptions) {
   );
 
   const start = useCallback(
-    (id: string) =>
-      DEVICE_FLOW_PROVIDERS.has(id) ? startDeviceFlow(id) : startBrowserFlow(id),
+    (id: string) => (DEVICE_FLOW_PROVIDERS.has(id) ? startDeviceFlow(id) : startBrowserFlow(id)),
     [startDeviceFlow, startBrowserFlow],
   );
 

--- a/packages/panel/src/features/providers/hooks/useProviders.ts
+++ b/packages/panel/src/features/providers/hooks/useProviders.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { providersService } from "../providersService.js";
-import { mergeModelLists } from "../utils.js";
 import type { ProviderInfo, TestResult } from "../types.js";
+import { mergeModelLists } from "../utils.js";
 
 export function useProviders() {
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
@@ -86,15 +86,10 @@ export function useProviders() {
     [refresh],
   );
 
-  const setDisabledModels = useCallback(
-    async (id: string, disabledModels: string[]) => {
-      await providersService.setDisabledModels(id, disabledModels);
-      setProviders((prev) =>
-        prev.map((p) => (p.id === id ? { ...p, disabledModels } : p)),
-      );
-    },
-    [],
-  );
+  const setDisabledModels = useCallback(async (id: string, disabledModels: string[]) => {
+    await providersService.setDisabledModels(id, disabledModels);
+    setProviders((prev) => prev.map((p) => (p.id === id ? { ...p, disabledModels } : p)));
+  }, []);
 
   return {
     providers,

--- a/packages/panel/src/features/providers/providersService.ts
+++ b/packages/panel/src/features/providers/providersService.ts
@@ -26,18 +26,14 @@ export const providersService = {
   listModels: (id: string) => http.get<ModelInfo[]>(`/models/${id}`),
 
   setEnabled: (id: string, enabled: boolean) => patchConfig(id, { enabled }),
-  setKey: (id: string, apiKey: string) =>
-    patchConfig(id, { apiKey, enabled: true }),
+  setKey: (id: string, apiKey: string) => patchConfig(id, { apiKey, enabled: true }),
   removeKey: (id: string) => patchConfig(id, { apiKey: "" }),
   setBaseUrl: (id: string, baseUrl: string) => patchConfig(id, { baseUrl }),
   setModels: (id: string, models: string[]) => patchConfig(id, { models }),
-  setDisabledModels: (id: string, disabledModels: string[]) =>
-    patchConfig(id, { disabledModels }),
+  setDisabledModels: (id: string, disabledModels: string[]) => patchConfig(id, { disabledModels }),
 
-  oauthStart: (id: string) =>
-    http.post<OAuthStartResponse>(`/providers/${id}/oauth/start`),
-  oauthStartDeviceFlow: (id: string) =>
-    http.post<CopilotFlow>(`/providers/${id}/oauth/start`),
+  oauthStart: (id: string) => http.post<OAuthStartResponse>(`/providers/${id}/oauth/start`),
+  oauthStartDeviceFlow: (id: string) => http.post<CopilotFlow>(`/providers/${id}/oauth/start`),
   oauthStatus: (id: string, key: string) =>
     http.get<OAuthStatusResponse>(`/providers/${id}/oauth/status/${key}`),
   oauthLogout: (id: string) => http.post(`/providers/${id}/oauth/logout`),

--- a/packages/panel/src/features/providers/types.ts
+++ b/packages/panel/src/features/providers/types.ts
@@ -2,18 +2,13 @@ import type {
   CopilotOAuthStartResponse,
   ModelInfo,
   OAuthInfo,
-  OpenAIAccountOAuthStartResponse,
   OAuthStatusResponse,
+  OpenAIAccountOAuthStartResponse,
   ProviderInfo,
   ProviderTestResult,
 } from "../../../../daemon/src/panel/contracts.js";
 
-export type {
-  ModelInfo,
-  OAuthInfo,
-  OAuthStatusResponse,
-  ProviderInfo,
-};
+export type { ModelInfo, OAuthInfo, OAuthStatusResponse, ProviderInfo };
 
 export type TestResult = ProviderTestResult;
 

--- a/packages/panel/src/features/routing/components/RoutingPage.tsx
+++ b/packages/panel/src/features/routing/components/RoutingPage.tsx
@@ -1,25 +1,16 @@
 import { Alert, Card, Col, Flex, Row, theme } from "antd";
-import { PageHeader } from "../../../shared/components/PageHeader.js";
 import { LoadingState } from "../../../shared/components/LoadingState.js";
+import { PageHeader } from "../../../shared/components/PageHeader.js";
 import { SaveButton } from "../../../shared/components/SaveButton.js";
-import { useRouting } from "../hooks/useRouting.js";
 import { TIERS } from "../constants.js";
-import { TierCard } from "./TierCard.js";
+import { useRouting } from "../hooks/useRouting.js";
 import { ThinkingToggle } from "./ThinkingToggle.js";
+import { TierCard } from "./TierCard.js";
 
 export default function RoutingPage() {
   const { token } = theme.useToken();
-  const {
-    rules,
-    thinking,
-    setThinking,
-    options,
-    updateRule,
-    loaded,
-    saving,
-    saved,
-    save,
-  } = useRouting();
+  const { rules, thinking, setThinking, options, updateRule, loaded, saving, saved, save } =
+    useRouting();
 
   if (!loaded) return <LoadingState />;
 
@@ -55,12 +46,7 @@ export default function RoutingPage() {
       <Card>
         <Flex justify="space-between" align="center">
           <ThinkingToggle checked={thinking} onChange={setThinking} />
-          <SaveButton
-            onClick={save}
-            saving={saving}
-            saved={saved}
-            label="Save routing"
-          />
+          <SaveButton onClick={save} saving={saving} saved={saved} label="Save routing" />
         </Flex>
       </Card>
     </Flex>

--- a/packages/panel/src/features/routing/components/ThinkingToggle.tsx
+++ b/packages/panel/src/features/routing/components/ThinkingToggle.tsx
@@ -1,5 +1,5 @@
-import { Flex, Space, Switch, Typography, theme } from "antd";
 import { BulbOutlined } from "@ant-design/icons";
+import { Flex, Space, Switch, Typography, theme } from "antd";
 
 const { Text } = Typography;
 
@@ -12,9 +12,7 @@ export function ThinkingToggle({ checked, onChange }: ThinkingToggleProps) {
   const { token } = theme.useToken();
   return (
     <Space>
-      <BulbOutlined
-        style={{ color: token.colorWarning, fontSize: token.fontSizeLG }}
-      />
+      <BulbOutlined style={{ color: token.colorWarning, fontSize: token.fontSizeLG }} />
       <Flex vertical>
         <Text strong>Enable thinking blocks</Text>
         <Text type="secondary">Extended reasoning for supported models</Text>

--- a/packages/panel/src/features/routing/components/TierCard.tsx
+++ b/packages/panel/src/features/routing/components/TierCard.tsx
@@ -1,15 +1,4 @@
-import {
-  Alert,
-  Card,
-  Col,
-  Row,
-  Select,
-  Space,
-  Switch,
-  Tag,
-  Typography,
-  theme,
-} from "antd";
+import { Alert, Card, Col, Row, Select, Space, Switch, Tag, Typography, theme } from "antd";
 import { TIER_META } from "../constants.js";
 import type { RoutingOption, RoutingRule, Tier } from "../types.js";
 
@@ -73,9 +62,7 @@ export function TierCard({ tier, rule, options, onChange }: TierCardProps) {
             onChange={(v) => onChange({ providerId: v, model: "" })}
             options={options.map((p) => ({ value: p.id, label: p.label }))}
             allowClear
-            onClear={() =>
-              onChange({ providerId: "", model: "", enabled: false })
-            }
+            onClear={() => onChange({ providerId: "", model: "", enabled: false })}
           />
         </Col>
         <Col span={12}>
@@ -120,10 +107,7 @@ export function TierCard({ tier, rule, options, onChange }: TierCardProps) {
 function FieldLabel({ children }: { children: React.ReactNode }) {
   const { token } = theme.useToken();
   return (
-    <Text
-      type="secondary"
-      style={{ display: "block", marginBottom: token.marginXS }}
-    >
+    <Text type="secondary" style={{ display: "block", marginBottom: token.marginXS }}>
       {children}
     </Text>
   );

--- a/packages/panel/src/features/routing/hooks/useRouting.ts
+++ b/packages/panel/src/features/routing/hooks/useRouting.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSaveFeedback } from "../../../shared/hooks/useSaveFeedback.js";
-import { routingService } from "../routingService.js";
 import { EMPTY_RULE, TIERS } from "../constants.js";
+import { routingService } from "../routingService.js";
 import type { RoutingMap, RoutingOption, RoutingRule, Tier } from "../types.js";
 
 const emptyMap = (): RoutingMap => ({

--- a/packages/panel/src/features/routing/types.ts
+++ b/packages/panel/src/features/routing/types.ts
@@ -1,8 +1,8 @@
+import type { RoutingRule, RoutingTier } from "../../../../daemon/src/config/schema.js";
 import type {
   RoutingConfigResponse,
   RoutingOption,
 } from "../../../../daemon/src/panel/contracts.js";
-import type { RoutingRule, RoutingTier } from "../../../../daemon/src/config/schema.js";
 
 export type Tier = RoutingTier;
 

--- a/packages/panel/src/features/settings/components/ProxyCard.tsx
+++ b/packages/panel/src/features/settings/components/ProxyCard.tsx
@@ -1,5 +1,5 @@
-import { Card, Divider, Flex, Input, Space, Switch, Typography, theme } from "antd";
 import { GlobalOutlined } from "@ant-design/icons";
+import { Card, Divider, Flex, Input, Space, Switch, Typography, theme } from "antd";
 import type { ProxyConfig } from "../types.js";
 
 const { Text } = Typography;
@@ -28,10 +28,7 @@ export function ProxyCard({ value, onChange }: ProxyCardProps) {
               Route OpenAI OAuth and external provider requests through a proxy
             </Text>
           </Flex>
-          <Switch
-            checked={value.enabled}
-            onChange={(v) => onChange({ enabled: v })}
-          />
+          <Switch checked={value.enabled} onChange={(v) => onChange({ enabled: v })} />
         </Flex>
 
         <Divider style={{ margin: 0 }} />

--- a/packages/panel/src/features/settings/components/ServerCard.tsx
+++ b/packages/panel/src/features/settings/components/ServerCard.tsx
@@ -1,6 +1,6 @@
-import { Card, Form, InputNumber, Space, type FormInstance } from "antd";
-import type { CSSProperties } from "react";
 import { SettingOutlined } from "@ant-design/icons";
+import { Card, Form, type FormInstance, InputNumber, Space } from "antd";
+import type { CSSProperties } from "react";
 import type { ServerConfig } from "../types.js";
 
 interface ServerCardProps {

--- a/packages/panel/src/features/settings/components/SettingsPage.tsx
+++ b/packages/panel/src/features/settings/components/SettingsPage.tsx
@@ -1,12 +1,12 @@
 import { Alert, Col, Flex, Row, theme } from "antd";
-import { PageHeader } from "../../../shared/components/PageHeader.js";
 import { LoadingState } from "../../../shared/components/LoadingState.js";
+import { PageHeader } from "../../../shared/components/PageHeader.js";
 import { SaveButton } from "../../../shared/components/SaveButton.js";
 import { useSettings } from "../hooks/useSettings.js";
-import { ServerCard } from "./ServerCard.js";
-import { WebToolsCard } from "./WebToolsCard.js";
 import { ProxyCard } from "./ProxyCard.js";
+import { ServerCard } from "./ServerCard.js";
 import { TokenSaversCard } from "./TokenSaversCard.js";
+import { WebToolsCard } from "./WebToolsCard.js";
 
 export default function SettingsPage() {
   const { token } = theme.useToken();
@@ -52,12 +52,7 @@ export default function SettingsPage() {
       />
 
       <Flex>
-        <SaveButton
-          onClick={save}
-          saving={saving}
-          saved={saved}
-          label="Save settings"
-        />
+        <SaveButton onClick={save} saving={saving} saved={saved} label="Save settings" />
       </Flex>
     </Flex>
   );

--- a/packages/panel/src/features/settings/components/TokenSaversCard.tsx
+++ b/packages/panel/src/features/settings/components/TokenSaversCard.tsx
@@ -1,5 +1,5 @@
-import { Card, Divider, Flex, Segmented, Space, Switch, Typography, theme } from "antd";
 import { CompressOutlined } from "@ant-design/icons";
+import { Card, Divider, Flex, Segmented, Space, Switch, Typography, theme } from "antd";
 import type { TokenSaversConfig } from "../types.js";
 
 const { Text } = Typography;

--- a/packages/panel/src/features/settings/components/WebToolsCard.tsx
+++ b/packages/panel/src/features/settings/components/WebToolsCard.tsx
@@ -1,5 +1,5 @@
-import { Card, Divider, Flex, Space, Switch, Typography, theme } from "antd";
 import { GlobalOutlined } from "@ant-design/icons";
+import { Card, Divider, Flex, Space, Switch, Typography, theme } from "antd";
 import type { WebToolsConfig } from "../types.js";
 
 const { Text } = Typography;
@@ -50,13 +50,7 @@ interface ToggleRowProps {
   onChange: (value: boolean) => void;
 }
 
-function ToggleRow({
-  title,
-  description,
-  checked,
-  disabled = false,
-  onChange,
-}: ToggleRowProps) {
+function ToggleRow({ title, description, checked, disabled = false, onChange }: ToggleRowProps) {
   return (
     <Flex justify="space-between" align="flex-start">
       <Flex vertical>

--- a/packages/panel/src/features/settings/hooks/useSettings.ts
+++ b/packages/panel/src/features/settings/hooks/useSettings.ts
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
 import { Form } from "antd";
+import { useEffect, useState } from "react";
 import { useSaveFeedback } from "../../../shared/hooks/useSaveFeedback.js";
 import { settingsService } from "../settingsService.js";
-import type { ServerConfig, WebToolsConfig, ProxyConfig, TokenSaversConfig } from "../types.js";
+import type { ProxyConfig, ServerConfig, TokenSaversConfig, WebToolsConfig } from "../types.js";
 
 const DEFAULT_WEB_TOOLS: WebToolsConfig = {
   enabled: true,
@@ -22,7 +22,6 @@ const DEFAULT_TOKEN_SAVERS: TokenSaversConfig = {
 
 export function useSettings() {
   const [serverForm] = Form.useForm<ServerConfig>();
-  const [serverConfig, setServerConfig] = useState<ServerConfig | null>(null);
   const [webTools, setWebTools] = useState<WebToolsConfig>(DEFAULT_WEB_TOOLS);
   const [proxy, setProxy] = useState<ProxyConfig>(DEFAULT_PROXY);
   const [tokenSavers, setTokenSavers] = useState<TokenSaversConfig>(DEFAULT_TOKEN_SAVERS);
@@ -33,7 +32,6 @@ export function useSettings() {
     settingsService
       .get()
       .then((c) => {
-        setServerConfig(c.server);
         serverForm.setFieldsValue(c.server);
         setWebTools(c.webTools);
         setProxy(c.proxy);
@@ -45,17 +43,14 @@ export function useSettings() {
   const updateWebTools = (patch: Partial<WebToolsConfig>) =>
     setWebTools((w) => ({ ...w, ...patch }));
 
-  const updateProxy = (patch: Partial<ProxyConfig>) =>
-    setProxy((p) => ({ ...p, ...patch }));
+  const updateProxy = (patch: Partial<ProxyConfig>) => setProxy((p) => ({ ...p, ...patch }));
 
   const updateTokenSavers = (patch: Partial<TokenSaversConfig>) =>
     setTokenSavers((t) => ({ ...t, ...patch }));
 
   const save = () => {
     const nextServer = serverForm.getFieldsValue();
-    return wrap(() => settingsService.save(nextServer, webTools, proxy, tokenSavers)).then(() => {
-      setServerConfig((current) => ({ ...(current ?? serverForm.getFieldsValue(true)), ...nextServer }));
-    });
+    return wrap(() => settingsService.save(nextServer, webTools, proxy, tokenSavers));
   };
 
   return {

--- a/packages/panel/src/features/settings/settingsService.ts
+++ b/packages/panel/src/features/settings/settingsService.ts
@@ -1,5 +1,11 @@
 import { http } from "../../shared/api/http.js";
-import type { SettingsConfig, ServerConfig, WebToolsConfig, ProxyConfig, TokenSaversConfig } from "./types.js";
+import type {
+  ProxyConfig,
+  ServerConfig,
+  SettingsConfig,
+  TokenSaversConfig,
+  WebToolsConfig,
+} from "./types.js";
 
 export const settingsService = {
   get: () => http.get<SettingsConfig>("/config"),
@@ -8,6 +14,5 @@ export const settingsService = {
     webTools: WebToolsConfig,
     proxy: ProxyConfig,
     tokenSavers: TokenSaversConfig,
-  ) =>
-    http.put<unknown>("/config", { server, webTools, proxy, tokenSavers }),
+  ) => http.put<unknown>("/config", { server, webTools, proxy, tokenSavers }),
 };

--- a/packages/panel/src/features/settings/types.ts
+++ b/packages/panel/src/features/settings/types.ts
@@ -1,7 +1,5 @@
-import type {
-  SettingsConfigResponse,
-} from "../../../../daemon/src/panel/contracts.js";
 import type { Config } from "../../../../daemon/src/config/schema.js";
+import type { SettingsConfigResponse } from "../../../../daemon/src/panel/contracts.js";
 
 export type ServerConfig = Partial<Config["server"]>;
 export type WebToolsConfig = Config["webTools"];

--- a/packages/panel/src/features/shell/Sidebar.tsx
+++ b/packages/panel/src/features/shell/Sidebar.tsx
@@ -1,11 +1,12 @@
-import { useState } from "react";
-import { Layout, Menu, Flex, theme, Tooltip, Typography } from "antd";
 import { GithubOutlined } from "@ant-design/icons";
+import { Flex, Layout, Menu, Tooltip, Typography, theme } from "antd";
+import { useState } from "react";
 
 const { Text } = Typography;
+
 import { useLocation, useNavigate } from "react-router-dom";
-import { NAV_ITEMS, selectedKeyFromPath } from "./navItems.js";
 import { openExternal } from "../../shared/openExternal.js";
+import { NAV_ITEMS, selectedKeyFromPath } from "./navItems.js";
 
 const { Sider } = Layout;
 
@@ -53,7 +54,10 @@ function GitHubButton({ collapsed }: { collapsed: boolean }) {
   const link = (
     <a
       href={GITHUB_URL}
-      onClick={(e) => { e.preventDefault(); openExternal(GITHUB_URL); }}
+      onClick={(e) => {
+        e.preventDefault();
+        openExternal(GITHUB_URL);
+      }}
       style={{
         display: "flex",
         alignItems: "center",

--- a/packages/panel/src/features/shell/TopBar.tsx
+++ b/packages/panel/src/features/shell/TopBar.tsx
@@ -1,18 +1,8 @@
-import { useState } from "react";
-import {
-  Badge,
-  Button,
-  Flex,
-  Layout,
-  Popconfirm,
-  Tooltip,
-  Typography,
-  theme,
-  App,
-} from "antd";
 import { PoweroffOutlined } from "@ant-design/icons";
+import { App, Badge, Button, Flex, Layout, Popconfirm, Tooltip, Typography, theme } from "antd";
+import { useState } from "react";
 import { daemonControl } from "./daemonControl.js";
-import { useDaemonStatus, type DaemonState } from "./useDaemonStatus.js";
+import { type DaemonState, useDaemonStatus } from "./useDaemonStatus.js";
 
 const { Header } = Layout;
 const { Text } = Typography;
@@ -50,9 +40,7 @@ export function TopBar() {
         resume();
       }, 500);
     } catch (err) {
-      message.error(
-        err instanceof Error ? err.message : "Failed to stop gateway",
-      );
+      message.error(err instanceof Error ? err.message : "Failed to stop gateway");
     } finally {
       setBusy(false);
     }
@@ -65,9 +53,7 @@ export function TopBar() {
       message.success("Gateway started");
       setTimeout(() => void refresh(), 500);
     } catch (err) {
-      message.error(
-        err instanceof Error ? err.message : "Failed to start gateway",
-      );
+      message.error(err instanceof Error ? err.message : "Failed to start gateway");
     } finally {
       setBusy(false);
     }
@@ -141,12 +127,7 @@ function ControlButton({
   }
 
   return (
-    <Button
-      type="primary"
-      icon={<PoweroffOutlined />}
-      loading={busy}
-      onClick={onStart}
-    >
+    <Button type="primary" icon={<PoweroffOutlined />} loading={busy} onClick={onStart}>
       Start
     </Button>
   );

--- a/packages/panel/src/features/shell/daemonControl.ts
+++ b/packages/panel/src/features/shell/daemonControl.ts
@@ -12,12 +12,10 @@ declare global {
   }
 }
 
-const externalDevDaemon =
-  import.meta.env.VITE_CC_GATEWAY_EXTERNAL_DAEMON === "1";
+const externalDevDaemon = import.meta.env.VITE_CC_GATEWAY_EXTERNAL_DAEMON === "1";
 
 export const runtime = {
-  isTauri: (): boolean =>
-    typeof window !== "undefined" && window.__TAURI_INTERNALS__ != null,
+  isTauri: (): boolean => typeof window !== "undefined" && window.__TAURI_INTERNALS__ != null,
   usesExternalDevDaemon: (): boolean => externalDevDaemon,
 };
 
@@ -40,9 +38,7 @@ export const daemonControl = {
       await tauriInvoke<number>("start_daemon");
       return;
     }
-    throw new Error(
-      "Daemon offline. In dev mode, restart via `bun dev:desk`.",
-    );
+    throw new Error("Daemon offline. In dev mode, restart via `bun dev:desk`.");
   },
 
   canStartFromPanel(): boolean {

--- a/packages/panel/src/features/shell/navItems.tsx
+++ b/packages/panel/src/features/shell/navItems.tsx
@@ -1,4 +1,3 @@
-import type { MenuProps } from "antd";
 import {
   ApiOutlined,
   DashboardOutlined,
@@ -6,6 +5,7 @@ import {
   HistoryOutlined,
   SettingOutlined,
 } from "@ant-design/icons";
+import type { MenuProps } from "antd";
 
 export type NavItem = NonNullable<MenuProps["items"]>[number];
 

--- a/packages/panel/src/features/shell/useDaemonStatus.ts
+++ b/packages/panel/src/features/shell/useDaemonStatus.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
-import { dashboardService } from "../dashboard/dashboardService.js";
 import { usePolling } from "../../shared/hooks/usePolling.js";
+import { dashboardService } from "../dashboard/dashboardService.js";
 import type { GatewayStatus } from "../dashboard/types.js";
 
 export type DaemonState = "running" | "offline" | "unknown";

--- a/packages/panel/src/index.css
+++ b/packages/panel/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap");
 
 *,
 *::before,
@@ -13,7 +13,7 @@ body {
   height: 100%;
   background: #262624;
   color: #f1f1ef;
-  font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: "Outfit", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 }
 
 #root {
@@ -31,6 +31,11 @@ body {
   border-inline-start: 1px solid #3e3e38 !important;
   border-inline-end: 1px solid #3e3e38 !important;
 }
-.ant-table-wrapper .ant-table-expanded-row .ant-table-wrapper .ant-table-tbody > tr:last-child > td {
+.ant-table-wrapper
+  .ant-table-expanded-row
+  .ant-table-wrapper
+  .ant-table-tbody
+  > tr:last-child
+  > td {
   border-bottom: 1px solid #3e3e38 !important;
 }

--- a/packages/panel/src/shared/api/base.ts
+++ b/packages/panel/src/shared/api/base.ts
@@ -6,8 +6,7 @@ declare global {
 
 const DEFAULT_DAEMON_PANEL_ORIGIN = "http://127.0.0.1:6767";
 
-const externalDevDaemon =
-  import.meta.env.VITE_CC_GATEWAY_EXTERNAL_DAEMON === "1";
+const externalDevDaemon = import.meta.env.VITE_CC_GATEWAY_EXTERNAL_DAEMON === "1";
 
 function isTauriRuntime(): boolean {
   return typeof window !== "undefined" && window.__TAURI_INTERNALS__ != null;

--- a/packages/panel/src/shared/api/http.ts
+++ b/packages/panel/src/shared/api/http.ts
@@ -9,6 +9,5 @@ export const http = {
       method: "POST",
       body: body !== undefined ? JSON.stringify(body) : undefined,
     }),
-  delete: <T>(path: string): Promise<T> =>
-    request<T>(path, { method: "DELETE" }),
+  delete: <T>(path: string): Promise<T> => request<T>(path, { method: "DELETE" }),
 };

--- a/packages/panel/src/shared/components/SaveButton.tsx
+++ b/packages/panel/src/shared/components/SaveButton.tsx
@@ -1,5 +1,5 @@
-import { Button } from "antd";
 import { CheckOutlined, SaveOutlined } from "@ant-design/icons";
+import { Button } from "antd";
 
 interface SaveButtonProps {
   onClick: () => void;

--- a/packages/panel/src/shared/hooks/useSSE.ts
+++ b/packages/panel/src/shared/hooks/useSSE.ts
@@ -6,11 +6,7 @@ interface UseSSEOptions {
   withCredentials?: boolean;
 }
 
-export function useSSE<T>(
-  path: string,
-  onMessage: (data: T) => void,
-  options: UseSSEOptions = {},
-) {
+export function useSSE<T>(path: string, onMessage: (data: T) => void, options: UseSSEOptions = {}) {
   const { paused = false, withCredentials = false } = options;
   const handler = useRef(onMessage);
   handler.current = onMessage;

--- a/packages/panel/src/vite-env.d.ts
+++ b/packages/panel/src/vite-env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="vite/client" />
 
-declare const __APP_VERSION__: string
+declare const __APP_VERSION__: string;

--- a/packages/panel/vite.config.ts
+++ b/packages/panel/vite.config.ts
@@ -1,11 +1,11 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import react from "@vitejs/plugin-react";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { defineConfig } from "vite";
 
-const { version } = JSON.parse(
-  readFileSync(resolve(__dirname, '../../package.json'), 'utf-8')
-) as { version: string }
+const { version } = JSON.parse(readFileSync(resolve(__dirname, "../../package.json"), "utf-8")) as {
+  version: string;
+};
 
 export default defineConfig({
   plugins: [react()],
@@ -13,7 +13,7 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify(version),
   },
   build: {
-    outDir: '../../packages/daemon/dist/static',
+    outDir: "../../packages/daemon/dist/static",
     emptyOutDir: true,
   },
   server: {
@@ -21,7 +21,7 @@ export default defineConfig({
     proxy: {
       // 127.0.0.1 explicitly: on Linux with default /etc/hosts, `localhost`
       // can resolve to ::1 (IPv6) while the daemon binds IPv4 only.
-      '/api': 'http://127.0.0.1:6767',
+      "/api": "http://127.0.0.1:6767",
     },
   },
-})
+});


### PR DESCRIPTION
## Summary

This PR centralizes repository code quality tooling around Biome, replacing the previous incomplete ESLint entrypoint with a single root-level formatter, linter, and import organizer setup.

## What changed

- Added root `biome.jsonc` with centralized formatting, linting, import organization, VCS ignore integration, and generated artifact exclusions.
- Added `@biomejs/biome` as a pinned root dev dependency.
- Replaced the old `npm run lint` ESLint command with Biome-based scripts:
  - `npm run format`
  - `npm run format:check`
  - `npm run lint`
  - `npm run lint:fix`
  - `npm run quality`
  - `npm run quality:fix`
  - `npm run quality:ci`
- Added a dedicated Biome job to `.github/workflows/quality.yml`.
- Updated contributor and development docs with the new quality workflow.
- Applied Biome formatting and safe fixes across the repository.
- Removed a few real lint failures found during adoption, including unused variables and one intentional React key exception for append-only log lines.

## CI behavior

The new CI job runs:

```bash
npm run quality:ci -- --reporter=github --diagnostic-level=error
```
This validates formatting, lint errors, and import ordering as a separate quality gate while avoiding PR noise from existing non-blocking warnings during the first Biome rollout.