### PR TITLE
feat: Add support for custom OpenAI and Anthropic-compatible providers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,12 @@ This starts the desktop app, panel dev server, and hot-reload daemon. See [docs/
 Start with [docs/ADDING_PROVIDER.md](docs/ADDING_PROVIDER.md). The daemon owns
 provider behavior; the panel should not contain hidden routing rules.
 
+If the upstream is a plain OpenAI Chat Completions-compatible or Anthropic
+Messages-compatible endpoint, prefer the runtime custom provider flow in the UI
+instead of adding a new built-in provider. Built-in provider changes are for
+catalog entries that need shipped metadata, special auth, custom transport
+behavior, or dedicated defaults.
+
 Most provider changes touch:
 
 - `packages/daemon/src/config/schema.ts`
@@ -176,13 +182,14 @@ Useful manual checks:
 
 When adding or changing a provider:
 
-1. Keep provider protocol details in `packages/daemon/src/proxy/providers/`.
-2. Add defaults, labels, and CLI flags in `packages/daemon/src/config/schema.ts`.
-3. Prefer `createOpenAIProvider()` or `createAnthropicProvider()` in the registry for simple API-compatible providers.
-4. Add a provider file only for OAuth, dynamic headers, custom catalogs, custom base URLs, custom streams, or dual transport dispatch.
-5. Make `listModels()` and `testConnection()` useful; the desktop UI depends on both.
-6. Preserve Anthropic-compatible streaming semantics.
-7. Document provider limitations when tools, streaming, images, thinking, or model discovery are partial.
+1. Prefer the runtime custom provider UI for plain OpenAI Chat Completions-compatible or Anthropic Messages-compatible endpoints.
+2. Keep built-in provider protocol details in `packages/daemon/src/proxy/providers/`.
+3. Add built-in defaults, labels, and CLI flags in `packages/daemon/src/config/schema.ts`.
+4. Prefer `createOpenAIProvider()` or `createAnthropicProvider()` in the registry when a built-in provider can use the shared transports.
+5. Add a provider file only for OAuth, dynamic headers, custom catalogs, custom base URLs, custom streams, or dual transport dispatch.
+6. Make `listModels()` and `testConnection()` useful; the desktop UI depends on both.
+7. Preserve Anthropic-compatible streaming semantics.
+8. Document provider limitations when tools, streaming, images, thinking, or model discovery are partial.
 
 Provider PRs should also state:
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 **Claude Code, your provider, one local desktop gateway.**
 
-Run Claude Code through OpenAI Account, GitHub Copilot, OpenRouter, DeepSeek, Groq, xAI, Mistral, GLM, Minimax, Command Code, Ollama, LM Studio, llama.cpp, and many other providers, while keeping the Claude Code workflow intact.
+Run Claude Code through OpenAI Account, GitHub Copilot, OpenRouter, DeepSeek, Groq, xAI, Mistral, GLM, Minimax, Command Code, Ollama, LM Studio, llama.cpp, custom OpenAI/Anthropic-compatible endpoints, and many other providers, while keeping the Claude Code workflow intact.
 
 [![Version](https://img.shields.io/badge/v0.1-early_release-111827?style=for-the-badge)](#status)
 [![License](https://img.shields.io/badge/license-MIT-22c55e?style=for-the-badge)](LICENSE)
 [![Desktop App](https://img.shields.io/badge/desktop_app-Tauri-24c8db?style=for-the-badge)](packages/desktop)
-[![Providers](https://img.shields.io/badge/providers-41-2563eb?style=for-the-badge)](#supported-providers)
+[![Providers](https://img.shields.io/badge/providers-40%2B-2563eb?style=for-the-badge)](#supported-providers)
 <br />
 [![Platforms](https://img.shields.io/badge/macOS%20%7C%20Windows%20%7C%20Linux-supported-f97316?style=for-the-badge)](#system-requirements)
 [![No Telemetry](https://img.shields.io/badge/telemetry-none-0f172a?style=for-the-badge)](#pricing)
@@ -55,7 +55,7 @@ Everything runs locally. There is no hosted CCPG service, no telemetry, no accou
 
 1. Download the desktop installer for your OS.
 2. Open CCPG. The daemon starts automatically.
-3. Add one provider in **Providers** and click **Test**.
+3. Add one built-in or custom provider in **Providers** and click **Test**.
 4. Install the `ccpg` shell command from **Dashboard -> Shell Setup**.
 5. Launch Claude Code:
 
@@ -102,14 +102,14 @@ The next documentation step is a separate official docs site repository. Until t
 ## Features
 
 - **Desktop app, not a terminal science project** - Tauri app for macOS, Windows, and Linux with provider setup, connection tests, routing, logs, and history in one UI.
-- **41 provider cards out of the box** - OAuth, API key, cloud, local, and coming-soon providers, including OpenAI Account, GitHub Copilot, OpenRouter, DeepSeek, Groq, xAI, Mistral, GLM, Minimax, Command Code, Ollama, LM Studio, and llama.cpp.
+- **Built-in and custom provider cards** - OAuth, API key, cloud, local, and coming-soon providers out of the box, plus user-created OpenAI-compatible and Anthropic-compatible providers with custom slugs and logos.
 - **Anthropic-compatible local proxy** - Claude Code sends Anthropic Messages API requests to `127.0.0.1`; CCPG translates and routes them.
 - **Full streaming** - provider responses stream back as Anthropic-style SSE events, so Claude Code still feels live.
 - **Model routing** - map Claude tiers like `opus`, `sonnet`, and `haiku` to different providers and models.
 - **All-providers mode** - aggregate enabled providers into one model catalog and choose by model in Claude Code.
 - **Model Chains** - create custom fallback chains from active provider models. A chain tries models in priority order, retries transient failures, and moves to the next model when an upstream provider fails, rate limits, or runs out of credits.
 - **Built-in OAuth** - OpenAI Account uses PKCE OAuth. GitHub Copilot and Kilo Code use Device Flow. Cline uses browser authorization. Tokens refresh automatically where supported.
-- **Provider management UI** - search providers, filter active/inactive cards, favorite and reorder frequently used providers, edit custom model lists, and hide noisy discovered models.
+- **Provider management UI** - search providers, filter active/inactive cards, add custom OpenAI/Anthropic-compatible providers, favorite and reorder frequently used providers, edit manual model lists, and hide noisy discovered models.
 - **Token savers** - Optional RTK-style tool-result compression and Caveman terse-response mode from Settings.
 - **Outbound proxy support** - Configure an HTTP/HTTPS proxy in Settings so the daemon routes external requests (OAuth, provider API calls) through your network proxy. Required for users in regions where providers restrict direct access.
 - **Local model support** - Ollama, LM Studio, and llama.cpp run through the same Claude Code flow.
@@ -231,6 +231,7 @@ chain.
 | Minimax, Minimax China | API key | Anthropic-compatible endpoints. |
 | OpenCode Go, Xiaomi MiMo, Xiaomi MiMo Token Plan, Cohere, Blackbox AI, HuggingFace Router, Ollama Cloud | API key | Additional hosted model catalogs. |
 | Command Code | API key | Custom provider transport that converts AI SDK v5 NDJSON streams into Anthropic SSE. |
+| Custom OpenAI/Anthropic compatible | API key | Add self-hosted or third-party compatible endpoints from the Providers tab with a custom slug, base URL, optional PNG/WebP logo, and manual models when discovery is unavailable. |
 
 ### Local
 
@@ -342,6 +343,7 @@ ccpg --Ollama --continue
 | `--all` or `--a` | All enabled providers in one model catalog |
 | `--ModelChain`, `--ModelChains`, or `--chains` | All enabled Model Chains |
 | `--<chain-slug>` | One enabled Model Chain with the matching slug |
+| `--<custom-provider-slug>` | One user-created custom provider with the matching slug |
 
 Flags are case-insensitive in the shell setup flow.
 
@@ -409,6 +411,7 @@ Runtime files live in:
 | `config.json` | Non-sensitive provider settings, routing rules, Model Chains, token saver settings, ports, and model mode. |
 | `secrets.enc.json` | API keys, OAuth tokens, and auth token encrypted with AES-256-GCM. |
 | `secret.key` | Local master key, unless `CC_GATEWAY_SECRET_KEY` is provided. |
+| `provider-logos/` | Uploaded PNG/WebP logos for user-created custom providers. |
 | `daemon.pid` | PID marker used by the daemon and desktop supervisor. |
 | `daemon.log` | Local daemon log file. May include provider errors and request diagnostics. |
 | `current-session.json` | Active session checkpoint. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ CCPG protects against accidental network exposure and casual local misuse, but i
 |---|---|
 | Network binding | Proxy and panel bind to `127.0.0.1`. |
 | Proxy auth | Claude Code requests must include the generated gateway auth token. |
-| Secret storage | Provider API keys, OAuth tokens, and gateway auth token are stored in `secrets.enc.json` with AES-256-GCM. |
+| Secret storage | Built-in and custom provider API keys, OAuth tokens, and gateway auth token are stored in `secrets.enc.json` with AES-256-GCM. |
 | Master key | A local `secret.key` is generated unless `CC_GATEWAY_MASTER_KEY` is provided. |
 | Session history | Prompts, response previews, token counts, latency, and errors are stored locally for the History UI. |
 | Telemetry | No project-owned telemetry service is used. |
@@ -31,6 +31,7 @@ Do not share these files publicly:
 - `secrets.enc.json`
 - `secret.key`
 - `config.json`
+- `provider-logos/` if uploaded custom logos reveal private infrastructure names
 - `current-session.json`
 - `sessions.jsonl`
 - daemon logs containing provider errors or prompts

--- a/docs/ADDING_PROVIDER.md
+++ b/docs/ADDING_PROVIDER.md
@@ -5,6 +5,14 @@
 Providers are daemon-owned. The panel should consume provider metadata through
 the daemon API instead of hardcoding provider behavior wherever possible.
 
+If the provider is simply OpenAI Chat Completions-compatible or Anthropic
+Messages-compatible, users can add it at runtime from the Providers page with
+**Add OpenAI Compatible** or **Add Anthropic Compatible**. That flow stores the
+provider under a custom slug, encrypts the API key, supports optional PNG/WebP
+logos, and exposes **Manual models** when catalog discovery is unavailable. Use
+this checklist only when the provider should become a built-in provider or
+needs behavior that cannot be represented by the runtime custom-provider flow.
+
 ## Before You Start
 
 Decide which transport shape the provider uses:

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -80,10 +80,20 @@ keeps secret values in `secrets.enc.json` rather than plaintext `config.json`.
 | `POST` | `/api/providers/:id/test` | Origin/token policy | Runs provider `testConnection()`. |
 | `GET` | `/api/models/:providerId` | Origin/token policy | Lists discovered/manual models for one enabled provider. |
 | `GET` | `/api/routing/options` | Origin/token policy | Lists enabled providers and selectable models for Routing and Model Chain editors. |
+| `POST` | `/api/custom-providers/test` | Origin/token policy | Tests a not-yet-saved OpenAI-compatible or Anthropic-compatible custom provider draft and returns discovered models when available. |
+| `POST` | `/api/custom-providers` | Origin/token policy | Creates a custom provider from multipart form data (`name`, `slug`, `baseUrl`, `apiKey`, `compatibility`, optional PNG/WebP `logo`). |
+| `DELETE` | `/api/custom-providers/:id` | Origin/token policy | Deletes a custom provider and cleans config references, encrypted API key, favorites, Model Chain targets, routing rules, and uploaded logo. |
+| `GET` | `/api/provider-logos/:file` | Origin/token policy | Serves uploaded custom provider PNG/WebP logos from the local config directory. |
 
 Provider behavior remains daemon-owned. The panel can group, filter, favorite,
 and present providers, but final model discovery and routing come from daemon
 config, provider classes, and `model-service.ts`.
+
+Custom provider drafts use `compatibility: "openai"` for OpenAI Chat
+Completions-style endpoints (`{baseUrl}/chat/completions`) or
+`compatibility: "anthropic"` for Anthropic Messages-style endpoints
+(`{baseUrl}/messages`). Both variants use API-key auth and support manual
+models when discovery returns an empty catalog.
 
 ### OAuth
 
@@ -130,6 +140,9 @@ their OAuth routes are not implemented yet.
 The launch preparer deletes `~/.claude/cache/gateway-models.json` on a
 best-effort basis so Claude Code refreshes its gateway model catalog after a
 mode switch.
+
+For user-created custom providers, `--<Provider>` is the provider slug chosen in
+the creation modal, for example `ccpg --acme_ai`.
 
 ### Shell Setup
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -227,6 +227,11 @@ Additional provider shapes:
 - **Declarative providers**: `provider-factory.ts` creates lightweight
   subclasses for providers whose behavior is fully described by transport,
   provider id, label, and static options.
+- **User-created custom providers**: the provider registry can instantiate
+  config-defined providers whose `custom.compatibility` is `"openai"` or
+  `"anthropic"` without adding a built-in provider ID. These use the shared
+  OpenAI Chat or Anthropic Messages transports and are addressed by their
+  user-chosen slug.
 - **Regional Anthropic-compatible providers**: OpenRouter, GLM, Minimax,
   Minimax China, LM Studio, and llama.cpp are declarative
   `AnthropicMessagesTransport` providers. DeepSeek and Ollama keep dedicated
@@ -258,9 +263,9 @@ their own model resolver.
 - Sends to `POST {baseUrl}/chat/completions`
 - Transforms OpenAI streaming chunks (delta-based) → Anthropic SSE events (block-based)
 - Handles: text content, tool calls, finish reasons (`stop` → `end_turn`, `tool_calls` → `tool_use`)
-- Used by: NVIDIA NIM, Kimi, Google AI (Gemini), Groq, xAI, Mistral, Cerebras, Together, Fireworks, GLM China, SiliconFlow, Hyperbolic, Chutes, Perplexity, Nebius, Volcengine Ark, BytePlus, Alibaba Bailian, OpenCode Go, Xiaomi MiMo, Cohere, Blackbox, HuggingFace, Ollama Cloud, Kilo Code, and Cline
+- Used by: NVIDIA NIM, Kimi, Google AI (Gemini), Groq, xAI, Mistral, Cerebras, Together, Fireworks, GLM China, SiliconFlow, Hyperbolic, Chutes, Perplexity, Nebius, Volcengine Ark, BytePlus, Alibaba Bailian, OpenCode Go, Xiaomi MiMo, Cohere, Blackbox, HuggingFace, Ollama Cloud, Kilo Code, Cline, and OpenAI-compatible custom providers
 
-**Custom providers** handle their own API and auth:
+**Special hand-written providers** handle their own API and auth:
 - `openai-account.ts` — OAuth token management, model fixup (`o1-mini`/`o3-mini` → actual model IDs), delegates to `openai-account-responses.ts` for request building and `openai-account-stream.ts` for the Responses API stream format
 - `copilot.ts` — dual-token lifecycle (GH OAuth token → 25-min Copilot API token), editor version headers. Routes claude-* models through native Anthropic protocol (`copilot-native-anthropic.ts`) to preserve tool_use, thinking, and citation blocks; other models go through `copilot-chat-stream.ts` (OpenAI Chat format)
 - `commandcode.ts` — custom request builder and stream transformer. It accepts API keys, exposes a fixed/fetched model list, converts Anthropic messages/tools/tool results to Command Code request blocks, and converts text, reasoning, tool-call, and finish events back to Anthropic SSE.
@@ -286,11 +291,16 @@ UI behavior on top:
   `packages/panel/src/features/providers/domain/apiKeyLinks.ts`.
 - OAuth presentation text and provider-specific UI labels live in
   `packages/panel/src/features/providers/domain/oauthPresentation.ts`.
+- Custom OpenAI/Anthropic-compatible providers are created from tab-level
+  actions on the Providers page. Their cards render in a dedicated section at
+  the end of the All Providers tab, while uploaded logos are served by the
+  daemon from the local config directory.
 
 The provider config modal discovers models as soon as a provider is ready. If
 discovery returns no models, or if a provider already has manually configured
-models, the panel shows the manual model picker. This keeps providers with weak
-catalog APIs usable without special-casing routing in the daemon.
+models, the panel shows the manual model picker. Custom providers always expose
+that picker as **Manual models**. This keeps providers with weak catalog APIs
+usable without special-casing routing in the daemon.
 
 ### 4. SSE Stream Handling (`packages/daemon/src/core/sse/writer.ts`)
 
@@ -333,7 +343,7 @@ secrets.enc.json (AES-256-GCM encrypted JSON)
 secret.key (32-byte hex master key) or CC_GATEWAY_SECRET_KEY env var
 ```
 
-- **Paths** (`paths.ts`) — centralized functions for all config directory paths: `getConfigDir()`, `getConfigPath()`, `getPidPath()`, `getLogPath()`, `getSecretsPath()`, `getMasterKeyPath()`, `getCurrentSessionPath()`, `getSessionArchivePath()`. Handles the Windows `%APPDATA%` path on Win32.
+- **Paths** (`paths.ts`) — centralized functions for all config directory paths: `getConfigDir()`, `getConfigPath()`, `getPidPath()`, `getLogPath()`, `getSecretsPath()`, `getMasterKeyPath()`, `getProviderLogoDir()`, `getCurrentSessionPath()`, `getSessionArchivePath()`. Handles the Windows `%APPDATA%` path on Win32.
 - **Schema** (`schema.ts`) — TypeScript types, provider defaults (base URLs, labels), CLI flag mappings
 - **Validation** (`validation.ts`) — runtime normalization with default merging
 - **Token savers** (`Config.tokenSavers`) — non-secret toggles for RTK compression and Caveman level
@@ -388,7 +398,7 @@ Hono-based REST API for the web panel. The panel module is composed of:
 |---|---|
 | `status-routes.ts` | `GET /api/status`, `POST /api/control/shutdown`, `GET /api/stats`, `GET /api/logs` (SSE) |
 | `config-routes.ts` | `GET /api/config`, `PUT /api/config` |
-| `provider-routes.ts` | `GET /api/providers`, `POST /api/providers/:id/test`, `GET /api/models/:providerId`, `GET /api/routing/options` |
+| `provider-routes.ts` | `GET /api/providers`, `POST /api/providers/:id/test`, custom provider create/test/delete, custom logo serving, `GET /api/models/:providerId`, `GET /api/routing/options` |
 | `session-routes.ts` | `GET /api/sessions`, `DELETE /api/sessions`, `POST /api/launch/end`, `POST /api/launch/heartbeat`, `POST /api/launch/attach` |
 | `shell-routes.ts` | `GET /api/quick-launch`, `GET /api/launch-commands`, `GET /api/launch-command`, `GET /api/shell-setup`, `GET /api/shell-setup/snippet/:shell`, `POST /api/shell-setup/install`, `POST /api/launch/prepare` |
 | `oauth-routes.ts` | OpenAI Account PKCE routes, GitHub Copilot device-flow routes, Kilo Code device-flow routes, and Cline browser authorization routes |
@@ -401,7 +411,7 @@ Panel also serves the React SPA static files (built by Vite to `packages/daemon/
 React 19 SPA built with Vite 6 + Ant Design 5 + Zustand 5.
 
 - **Dashboard** — live session view with provider cards, SSE log feed, quick-launch buttons
-- **Providers** — toggle providers, edit API keys, OAuth login, test connections, add extra models
+- **Providers** — toggle providers, edit API keys, OAuth login, test connections, add extra/manual models, create/delete custom OpenAI/Anthropic-compatible providers
 - **Model Chain** — create, edit, reorder, enable, and launch ordered fallback chains built from active provider models
 - **Routing** — tier-based model routing UI
 - **History** — session archive with per-request drill-down
@@ -620,6 +630,7 @@ Desktop Build (GitHub Actions — .github/workflows/desktop-build.yml, on tag pu
 │                             # Providers, routing, Model Chains, token savers
 ├── secrets.enc.json         # AES-256-GCM encrypted secrets
 ├── secret.key               # Master encryption key (32-byte hex)
+├── provider-logos/          # Uploaded custom provider PNG/WebP logos
 ├── daemon.pid               # Process ID
 ├── daemon.log               # Log output (rotating buffer)
 ├── current-session.json     # Active session (checkpointed every 10s)

--- a/docs/CODEBASE_GUIDE.md
+++ b/docs/CODEBASE_GUIDE.md
@@ -121,7 +121,13 @@ existing package structure.
 
 ### Add a provider
 
-Start with [Adding a Provider](ADDING_PROVIDER.md). The usual files are:
+For plain OpenAI Chat Completions-compatible or Anthropic Messages-compatible
+endpoints, users can add a runtime custom provider from the Providers page. No
+code change is required unless the provider should ship as a built-in card or
+needs custom auth, catalog, headers, streaming, or request conversion.
+
+For built-in provider support, start with [Adding a Provider](ADDING_PROVIDER.md).
+The usual files are:
 
 | Area | Files |
 |---|---|

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -43,6 +43,23 @@ It is a JSON file with the following top-level shape:
       "rateWindow": 60,
       "maxConcurrency": 5,
       "requestTimeoutMs": 120000
+    },
+    "acme_ai": {
+      "enabled": true,
+      "apiKey": "",
+      "authType": "api_key",
+      "models": ["acme-large"],
+      "disabledModels": [],
+      "baseUrl": "https://api.acme.example/v1",
+      "rateLimit": 40,
+      "rateWindow": 60,
+      "maxConcurrency": 5,
+      "custom": {
+        "label": "Acme AI",
+        "slug": "acme_ai",
+        "logoFile": "acme_ai.webp",
+        "compatibility": "openai"
+      }
     }
   },
   "routing": {
@@ -88,7 +105,7 @@ It is a JSON file with the following top-level shape:
 | Key | Type | Description |
 |---|---|---|
 | `server` | object | Daemon network settings: proxy port, panel port, and internal auth token. |
-| `providers` | object | Per-provider configuration keyed by provider ID (e.g., `"openrouter"`, `"ollama"`). Contains multiple provider entries. |
+| `providers` | object | Per-provider configuration keyed by provider ID (e.g., `"openrouter"`, `"ollama"`, or a user-created custom slug). Contains built-in and custom provider entries. |
 | `routing` | object | Model routing rules for Claude Code's tier-based model selection (`default`, `opus`, `sonnet`, `haiku`). |
 | `thinking` | object | Extended thinking toggle, with per-tier overrides. |
 | `webTools` | object | Web search and private-network access controls. |
@@ -117,6 +134,9 @@ Each entry under `providers` uses the following schema:
 | `rateWindow` | number | `60` | Rate window duration in seconds. |
 | `maxConcurrency` | number | `5` | Maximum concurrent in-flight requests to this provider. |
 | `requestTimeoutMs` | number | (none) | Optional per-request timeout in milliseconds. When unset, no explicit timeout is applied. |
+| `custom` | object | (none) | Present only for user-created custom providers. Contains `label`, immutable `slug`, optional `logoFile`, and `compatibility` (`"openai"` or `"anthropic"`). |
+
+Custom providers are created from the **Providers** page with either **Add OpenAI Compatible** or **Add Anthropic Compatible**. Their `baseUrl` remains editable in the details modal, API keys are stored in the encrypted secret store like built-in providers, and user-supplied logos are stored outside `config.json` in `provider-logos/`.
 
 ### Routing Rule Keys
 
@@ -125,7 +145,7 @@ Each routing tier (`default`, `opus`, `sonnet`, `haiku`) contains:
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `enabled` | boolean | `false` | Whether this routing rule is active. |
-| `providerId` | string | `""` | Target provider ID (must be a valid provider ID from the provider catalog). |
+| `providerId` | string | `""` | Target provider ID (must be a built-in provider ID or a configured custom provider slug). |
 | `model` | string | `""` | Target model name on that provider. |
 
 A routing rule is only considered active when `enabled`, `providerId`, and `model` are all set.
@@ -155,7 +175,7 @@ All other settings revert to their defaults if absent from the config file. The 
 | `server.panelPort` | `6767` | `packages/daemon/src/config/index.ts` |
 | `server.authToken` | `sk_` + 16 random hex bytes | Auto-generated on first run |
 | `providers.<id>.enabled` | `false` | All providers start disabled |
-| `providers.<id>.authType` | `"oauth"` for OAuth providers, `"api_key"` otherwise | Per-provider at build time |
+| `providers.<id>.authType` | `"oauth"` for OAuth providers, `"api_key"` otherwise | Per-provider at build time; custom providers always use `"api_key"` |
 | `providers.<id>.rateLimit` | `40` | `packages/daemon/src/config/index.ts` |
 | `providers.<id>.rateWindow` | `60` | `packages/daemon/src/config/index.ts` |
 | `providers.<id>.maxConcurrency` | `5` | `packages/daemon/src/config/index.ts` |
@@ -177,7 +197,7 @@ All other settings revert to their defaults if absent from the config file. The 
 
 ### Provider Default Base URLs
 
-Each provider has a hardcoded default `baseUrl` in `packages/daemon/src/config/schema.ts`. The most commonly customized ones are:
+Built-in providers have hardcoded default `baseUrl` values in `packages/daemon/src/config/schema.ts`. Custom providers store the user-entered `baseUrl` in their own provider config. The most commonly customized built-in URLs are:
 
 | Provider ID | Default `baseUrl` |
 |---|---|
@@ -193,7 +213,7 @@ Each provider has a hardcoded default `baseUrl` in `packages/daemon/src/config/s
 | `xai` | `https://api.x.ai/v1` |
 | `mistral` | `https://api.mistral.ai/v1` |
 
-For the complete list of all 42 provider base URLs, see `PROVIDER_DEFAULTS` in `packages/daemon/src/config/schema.ts`.
+For the complete built-in provider base URL list, see `PROVIDER_DEFAULTS` in `packages/daemon/src/config/schema.ts`.
 
 ## Secrets Storage
 
@@ -211,6 +231,8 @@ The following values are stored encrypted, never in plaintext on disk:
 | `provider.<id>.oauth.accessToken` | OAuth access token. |
 | `provider.<id>.oauth.refreshToken` | OAuth refresh token. |
 | `provider.<id>.oauth.copilotToken` | GitHub Copilot short-lived token. |
+
+For custom providers, deleting the provider from the panel removes the config entry, encrypted API key, routing references, Model Chain references, favorites entry, and the uploaded logo file.
 
 ### Master Key Resolution
 
@@ -272,6 +294,7 @@ This means the config format is forward-compatible: adding new top-level keys to
 | `config.json` | Config directory | Non-sensitive settings (providers, routing, UI prefs, ports). |
 | `secrets.enc.json` | Config directory | AES-256-GCM encrypted API keys, OAuth tokens, and auth token. |
 | `secret.key` | Config directory | 32-byte hex master key for the secrets store. |
+| `provider-logos/` | Config directory | Uploaded PNG/WebP logos for user-created custom providers. |
 | `daemon.pid` | Config directory | PID marker for the running daemon process. |
 | `daemon.log` | Config directory | Local daemon log (provider errors, request diagnostics). |
 | `current-session.json` | Config directory | Active Claude Code session checkpoint. |

--- a/docs/DAEMON_REFERENCE.md
+++ b/docs/DAEMON_REFERENCE.md
@@ -6,10 +6,10 @@
 
 The **daemon** (`@claude-code-provider-gateway/daemon`) is the backend process of CCPG, implemented in TypeScript. It runs two local HTTP servers — a **proxy API** (port `49250`) that speaks the Anthropic Messages API, and a **panel API** (port `6767`) that serves the configuration web UI and REST endpoints. Both servers bind to `127.0.0.1` only.
 
-The daemon's primary job is to intercept Claude Code API requests, route them to one of 41 configured LLM providers, translate between Anthropic and OpenAI API formats, and stream responses back as Anthropic SSE. It also provides session tracking, runtime stats, live logging, and a full configuration API consumed by the panel frontend.
+The daemon's primary job is to intercept Claude Code API requests, route them to a built-in or user-created LLM provider, translate between Anthropic and OpenAI API formats, and stream responses back as Anthropic SSE. It also provides session tracking, runtime stats, live logging, and a full configuration API consumed by the panel frontend.
 
 ```text
-Claude Code ── Anthropic API ──► Proxy (:49250) ──► 41 LLM providers
+Claude Code ── Anthropic API ──► Proxy (:49250) ──► built-in + custom LLM providers
 User Browser ─────────────────► Panel (:6767)  ──► Config + Session + Stats
 ```
 
@@ -38,7 +38,7 @@ packages/daemon/src/
 ├── index.ts               # Entry point: load config → configure network → start servers
 ├── config/                 # Schema, defaults, validation, paths, encrypted secrets
 │   ├── index.ts            # loadConfig(), saveConfig(), buildDefaultConfig(), ConfigManager logic
-│   ├── schema.ts           # Config type, ProviderConfig, ProviderId (41 constants), PROVIDER_DEFAULTS
+│   ├── schema.ts           # Config type, ProviderConfig, built-in ProviderId constants, PROVIDER_DEFAULTS
 │   ├── paths.ts            # OS-aware config dir paths (~/.config/... on Linux/Mac, %APPDATA% on Win)
 │   ├── validation.ts       # normalizeConfig() — validates and backfills all config fields
 │   └── secrets/            # Secret storage layer
@@ -72,7 +72,7 @@ packages/daemon/src/
 │   │   ├── native-claude-routing.ts # Native Claude passthrough detection
 │   │   ├── prompt-serializer.ts     # Request audit trail serialization
 │   │   └── stream-result.ts     # SSE stream response helpers with response capture
-│   ├── providers/           # 41 provider implementations
+│   ├── providers/           # Built-in provider implementations and shared transports
 │   │   ├── base.ts              # BaseProvider abstract class
 │   │   ├── registry.ts          # ProviderRegistry — ID → constructor mapping + caching
 │   │   ├── provider-factory.ts  # createOpenAIProvider() / createAnthropicProvider() factories
@@ -101,7 +101,7 @@ packages/daemon/src/
 │   │   └── auth.ts         # requirePanelAccess — CORS + token auth for Tauri origins
 │   ├── routes/
 │   │   ├── config-routes.ts    # GET/PUT /api/config
-│   │   ├── provider-routes.ts  # GET /api/providers, /api/models/:id, /api/routing/options
+│   │   ├── provider-routes.ts  # Provider list/test/models, custom providers, logo serving, routing options
 │   │   ├── session-routes.ts   # GET/DELETE /api/sessions, /api/launch/*
 │   │   ├── shell-routes.ts     # Shell setup, launch commands, launch-prepare
 │   │   ├── oauth-routes.ts     # OAuth flows: OpenAI Account, Copilot, KiloCode, Cline
@@ -149,7 +149,7 @@ Bound by `createPanelApp()` in `panel/app.ts`. Provides the REST API consumed by
 |-------|-----------|---------|
 | Status | `GET /api/status`, `GET /api/stats`, `GET /api/logs` | Health, per-provider stats, live log SSE stream |
 | Config | `GET /api/config`, `PUT /api/config` | Full config read/update with secrets masking |
-| Providers | `GET /api/providers`, `GET /api/models/:id`, `POST /api/providers/:id/test` | Provider listing, model discovery, connection testing |
+| Providers | `GET /api/providers`, `GET /api/models/:id`, `POST /api/providers/:id/test`, `POST /api/custom-providers/test`, `POST /api/custom-providers`, `DELETE /api/custom-providers/:id`, `GET /api/provider-logos/:file` | Provider listing, model discovery, connection testing, user-created custom providers, uploaded custom logos |
 | Routing | `GET /api/routing/options` | Model selection options for routing rules |
 | Sessions | `GET /api/sessions`, `DELETE /api/sessions` | Current + archived sessions, clear history |
 | Launch | `POST /api/launch/end`, `/api/launch/heartbeat`, `/api/launch/attach` | Session lifecycle from CLI launcher |
@@ -246,7 +246,8 @@ export class ProviderRegistry {
 
 - **Lazy instantiation**: Provider instances are created on first access (`get()`) and cached in a `Map`. Disabled providers return `null`.
 - **Hot-reload**: `updateConfig()` replaces the stored config and clears the cache so next access uses fresh configuration.
-- **Provider map**: The `PROVIDER_MAP` constant maps 41 `ProviderId` values to constructors. Most providers use factory-generated classes (`createOpenAIProvider()` / `createAnthropicProvider()`); special providers (Copilot, OpenAI Account, Cline, KiloCode, Kiro, iFlow, DeepSeek, Google, Ollama, Ollama Cloud, CommandCode) have dedicated hand-written classes.
+- **Provider map**: The `PROVIDER_MAP` constant maps the built-in provider IDs to constructors. Most built-ins use factory-generated classes (`createOpenAIProvider()` / `createAnthropicProvider()`); special providers (Copilot, OpenAI Account, Cline, KiloCode, Kiro, iFlow, DeepSeek, Google, Ollama, Ollama Cloud, CommandCode) have dedicated hand-written classes.
+- **Dynamic custom providers**: IDs not present in `PROVIDER_MAP` can still be instantiated when `config.providers.<id>.custom` exists. `custom.compatibility: "openai"` creates an `OpenAIChatTransport` subclass; `"anthropic"` creates an `AnthropicMessagesTransport` subclass. Custom providers are cached and hot-reloaded like built-ins.
 
 ### `MessageService`
 
@@ -334,7 +335,7 @@ While there isn't a single `ConfigManager` class, the configuration system is th
 ```ts
 interface Config {
   server: { proxyPort: 49250; panelPort: 6767; authToken: string };
-  providers: Record<ProviderId, ProviderConfig>;  // 41 providers
+  providers: Record<ProviderId, ProviderConfig>;  // built-ins plus user-created custom providers
   routing: Record<RoutingTier, RoutingRule>;       // default/opus/sonnet/haiku
   thinking: { enabled: boolean; opus: boolean|null; sonnet: boolean|null; haiku: boolean|null };
   webTools: { enabled: boolean; allowPrivateNetworks: boolean };
@@ -352,7 +353,7 @@ interface Config {
 
 - **`SecretStore` interface** — `get(key)`, `set(key, value)`, `delete(key)`, `keys()`.
 - **`EncryptedFileSecretStore`** — AES-256-GCM encrypted JSON file at `secrets.enc.json`. Each secret is stored as `{nonce, ciphertext, tag}` hex objects. Read/write with `0o600` permissions.
-- **`config-splitter.ts`** — `extractSecretsToStore()` drains secrets from the config object before persistence. `hydrateSecretsFromStore()` restores them after loading. Handles `server.authToken`, `provider.<id>.apiKey`, and `provider.<id>.oauth.*` keys.
+- **`config-splitter.ts`** — `extractSecretsToStore()` drains secrets from the config object before persistence. `hydrateSecretsFromStore()` restores them after loading. Handles `server.authToken`, `provider.<id>.apiKey`, and `provider.<id>.oauth.*` keys for both built-in and custom providers.
 - **Master key resolution** (`master-key.ts`): priority order is `CC_GATEWAY_SECRET_KEY` env var → existing `secret.key` file → generate new 32-byte key and persist.
 
 ## Request Lifecycle
@@ -417,7 +418,7 @@ Fallback chains iterate through a configurable list of `{providerId, model}` pai
 
 ## Provider System
 
-The daemon supports **41 providers**. Each provider is represented by a `ProviderId` literal union type (defined in `config/schema.ts`). Providers are registered in `PROVIDER_MAP` inside `ProviderRegistry`.
+The daemon ships with a built-in provider catalog and also supports user-created custom providers. Built-ins are registered in `PROVIDER_MAP` inside `ProviderRegistry`; custom providers are stored in config under their slug and instantiated dynamically.
 
 ### Provider Categories
 
@@ -430,6 +431,13 @@ The daemon supports **41 providers**. Each provider is represented by a `Provide
 - Generated via `createOpenAIProvider()`: NVIDIA NIM, Kimi, Groq, xAI, Mistral, Cerebras, Together, Fireworks, SiliconFlow, Hyperbolic, Chutes, Perplexity, Nebius, GLM CN, Volcengine Ark, BytePlus, Alibaba Bailian (both), OpenCode Go, Xiaomi MiMo (both), Cohere, Blackbox, HuggingFace
 - Auth: `Authorization: Bearer <key>`
 - Request/response conversion handled by `transport-openai.ts`
+
+**User-created custom providers**:
+- Created from the Providers page as OpenAI-compatible or Anthropic-compatible.
+- Stored in `config.providers.<slug>.custom` with `label`, immutable `slug`, optional `logoFile`, and `compatibility`.
+- API keys live in the encrypted secret store under `provider.<slug>.apiKey`.
+- Uploaded logos are served from `provider-logos/` through `GET /api/provider-logos/:file`.
+- Deletion removes the config entry, encrypted API key, uploaded logo, routing rules, Model Chain entries, and favorites references.
 
 **Special hand-written providers**:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -269,11 +269,13 @@ Provider source of truth lives in the daemon:
 
 - `packages/daemon/src/config/schema.ts` — controls provider IDs, defaults,
   labels, OAuth membership, CLI flags, and panel settings defaults. Adding a new
-  provider ID or changing its defaults starts here.
+  built-in provider ID or changing its defaults starts here.
 - `packages/daemon/src/proxy/providers/registry.ts` — **the authoritative
   registry for provider construction**. Declarative factory registration via
   this registry is the preferred way to add a provider. Most providers can be
   fully expressed as a registry entry without a dedicated implementation file.
+  Runtime custom providers are also constructed here from
+  `config.providers.<slug>.custom.compatibility`.
 - `packages/daemon/src/proxy/providers/` — provider implementation files.
   Create a dedicated file here **only** for non-declarative or edge-case
   behavior (custom stream handling, bespoke auth logic, dual-transport dispatch,
@@ -290,6 +292,9 @@ Panel provider support is intentionally thinner:
   shortcuts.
 - `packages/panel/src/features/providers/domain/oauthPresentation.ts` for OAuth copy
   and provider-specific sign-in presentation.
+- Custom provider UI lives in `packages/panel/src/features/providers/components/config/AddCustomProviderModal.tsx`
+  plus the Providers page tab actions. Custom provider logos are uploaded to the
+  daemon config directory instead of `packages/panel/public/providers/`.
 
 Useful focused checks while working on providers:
 
@@ -309,7 +314,9 @@ Manual provider validation path:
 
 1. Start the desktop dev app with `npm run dev:desk`.
 2. Open **Providers**.
-3. Search for the provider, configure auth or base URL, and click **Test**.
+3. Search for the provider, configure auth or base URL, and click **Test**. For
+   a runtime custom provider, use **Add OpenAI Compatible** or **Add Anthropic
+   Compatible**, test discovery in the creation modal, then save it.
 4. Check the model list and disable any models that should not be exposed.
 5. Launch Claude Code with the provider flag, or use `ccpg --all` to validate
    gateway-prefixed routing.
@@ -404,12 +411,14 @@ The `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` flag is required for Claude C
 Use the provider checklist in [Adding a Provider](ADDING_PROVIDER.md). Short
 version:
 
-1. Create `packages/daemon/src/proxy/providers/<provider>.ts`
-2. Extend `BaseProvider` (or `AnthropicMessagesTransport`/`OpenAIChatTransport` if applicable)
-3. Implement `streamResponse()` and `listModels()`
-4. Add to `ProviderRegistry` in `registry.ts`
-5. Add defaults, labels, and CLI flags in `config/schema.ts`
-6. Add focused daemon tests before opening the PR
+1. Prefer a runtime custom provider from the UI when the endpoint is plain
+   OpenAI Chat Completions-compatible or Anthropic Messages-compatible.
+2. For a new built-in provider, add it to `config/schema.ts`, register it in
+   `ProviderRegistry`, add icon/panel metadata as needed, and add focused daemon
+   tests before opening the PR.
+3. Create `packages/daemon/src/proxy/providers/<provider>.ts` only when the
+   provider needs custom auth, catalog, request conversion, streaming, or
+   protocol dispatch that cannot be expressed by the shared transports.
 
 ### Adding a panel API endpoint
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -38,7 +38,7 @@
 
 2. Install and open the app. The daemon starts automatically.
 
-3. Open the **Providers** tab, add at least one provider, and click **Test** to verify the connection works.
+3. Open the **Providers** tab, configure at least one built-in provider or add a custom OpenAI/Anthropic-compatible provider, and click **Test** to verify the connection works.
 
 4. Go to **Dashboard → Shell Setup** and install the `ccpg` shell command. Follow the setup wizard for your shell (zsh, bash, or fish).
 
@@ -65,7 +65,7 @@ Once the app is open and you have at least one provider configured and tested, l
 ccpg --DeepSeek
 ```
 
-Replace `--DeepSeek` with the provider flag matching your configured provider (e.g., `--OpenRouter`, `--Ollama`, `--Copilot`, `--OpenAIAccount`). Any arguments after the provider flag are passed through to Claude Code:
+Replace `--DeepSeek` with the provider flag matching your configured provider (e.g., `--OpenRouter`, `--Ollama`, `--Copilot`, `--OpenAIAccount`) or with `--<custom-provider-slug>` for a custom provider. Any arguments after the provider flag are passed through to Claude Code:
 
 ```bash
 ccpg --OpenRouter --resume <session-id>
@@ -101,8 +101,9 @@ Common causes and fixes:
 | Missing API key | Add or replace the API key in the provider modal. |
 | OAuth token expired | Log out and sign in again from the provider card. |
 | Wrong base URL | Restore the default URL or check your local server address. |
+| Custom provider compatibility mismatch | Recreate the provider with the correct **Add OpenAI Compatible** or **Add Anthropic Compatible** action. |
 | Network restriction | Configure **Settings → Outbound Proxy** and restart CCPG. |
-| Empty model list | Add models manually in the provider modal. |
+| Empty model list | Add models manually in the provider modal. Custom providers always expose **Manual models**. |
 
 For local providers, make sure the upstream server is running:
 

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -9,7 +9,7 @@
 | Area | Why it matters | Suggested direction |
 |---|---|---|
 | Config reload | The proxy reloads config from disk on each request, which keeps settings fresh but adds synchronous file I/O to the hot path. | Cache parsed config and invalidate it with file watching or a short TTL. Only refresh provider instances whose config changed. |
-| Provider registry invalidation | Clearing the full provider cache after every config reload can recreate providers unnecessarily. | Compare provider config snapshots or hashes and invalidate specific providers. |
+| Provider registry invalidation | Clearing the full provider cache after every config reload can recreate providers unnecessarily, especially now that runtime custom providers are created from config. | Compare provider config snapshots or hashes and invalidate specific providers. |
 | Session persistence | Session checkpoints and archive operations use local JSON files and can become expensive as request logs grow. | Add pagination/lazy loading for request logs, atomic archive writes, and clearer retention controls. |
 | Request history privacy | Prompt and response previews are useful for debugging but are stored locally in plain JSON session records. | Add a config toggle for prompt/response capture, retention policy controls, and consider encrypted session archives. |
 | Panel test coverage | The daemon has focused tests; the React panel currently relies mostly on manual validation. | Start with tests for shared hooks/services and critical flows like provider config, Model Chain setup, history, and shell setup. |
@@ -26,6 +26,7 @@
 | `packages/daemon/src/proxy/providers/commandcode.ts` | Custom provider with request conversion, catalog handling, and NDJSON/SSE stream transformation. | Split new behavior into helper modules where possible and keep tests close to the stream state machine. |
 | `packages/daemon/src/runtime/session-store.ts` | Reads, writes, archives, and deletes session JSON/JSONL files. | Prefer atomic writes, explicit logging on failure, and temp-directory tests for file operations. |
 | `packages/daemon/src/config/secrets/` | Encrypts and hydrates API keys, OAuth tokens, and gateway auth token. | Treat changes as security-sensitive. Preserve backward compatibility and test corrupted/missing store cases. |
+| `packages/daemon/src/panel/routes/provider-routes.ts` | Owns provider config updates plus custom provider create/test/delete and logo serving. | Verify deletion cleans config, encrypted API keys, routing refs, Model Chain refs, favorites, active provider fallback, and uploaded logos. |
 | `packages/desktop/src-tauri/src/daemon_supervisor.rs` | Owns sidecar lifecycle in the desktop app. | Add tests around pure policy code and manually validate start/stop/restart behavior on the target OS. |
 
 ## Security Review Checklist
@@ -37,6 +38,7 @@ or storage:
 - Does every proxy API request still require the gateway auth token?
 - Does any new panel API route need auth or origin handling updates?
 - Are provider API keys and OAuth tokens kept out of `config.json`, logs, and docs?
+- Do custom provider deletion paths remove encrypted API keys and uploaded logos?
 - Are provider error messages sanitized before being shown or logged?
 - Does any new file containing prompts, responses, tokens, or account data need
   retention controls or encryption?

--- a/docs/PANEL_FEATURES.md
+++ b/docs/PANEL_FEATURES.md
@@ -383,38 +383,39 @@ type RoutingOption = {
 
 ## Feature: Providers (`features/providers/`)
 
-The most feature-rich module. Manages all LLM providers: API key configuration, OAuth login, model selection, connection testing, and favorites.
+The most feature-rich module. Manages built-in and user-created LLM providers: API key configuration, OAuth login, custom OpenAI/Anthropic-compatible provider creation, model selection, connection testing, and favorites.
 
 ### Components
 
 | Component | Purpose |
 |---|---|
-| `ProvidersPage` | Main page: search bar, status filter, provider grid grouped by configuration type (Local/OAuth/API Key), favorites toolbar. |
-| `ProviderToolbar` | Search input + status filter (all/enabled/disabled/configured/unconfigured) + favorites tip. |
-| `ProviderTabs` | Tab bar with "Favorites" and "All Providers" tabs. |
-| `ProviderGridSection` | Renders a group of provider cards with a section title. |
+| `ProvidersPage` | Main page: search bar, status filter, provider grid grouped by configuration type, custom provider section, favorites toolbar, and custom-provider modal state. |
+| `ProviderToolbar` | Search input + status filter (all/enabled/disabled/configured/unconfigured). |
+| `ProviderTabs` | Tab bar with "Favorites" and "All Providers" tabs plus right-aligned tab actions for adding OpenAI- or Anthropic-compatible custom providers. |
+| `ProviderGridSection` | Renders a group of provider cards with a section title. Built-in groups render first; the custom provider section renders last on the All Providers tab. |
 | `SortableFavoritesGrid` | Drag-and-drop grid for favorite providers using `@dnd-kit`. |
 | `ProviderCard` | Individual provider card: logo, label, enabled switch, test button, status indicator, favorite star. |
 | `ProviderCardSkeleton` | Loading skeleton for a provider card. |
-| `ProviderLogo` | Provider logo image (80+ provider logos in `packages/panel/public/providers/`). |
-| `ProviderConfigModal` | Full-featured configuration modal. Contains sections for API key, OAuth, base URL, model picker, and extra models. |
-| `ProviderConfigContent` | Modal content orchestrator — renders the appropriate sections based on provider type. |
+| `ProviderLogo` | Provider logo image. Built-ins load from `packages/panel/public/providers/`; custom providers can use daemon-served `logoUrl` files uploaded by the user. |
+| `AddCustomProviderModal` | Creates OpenAI-compatible or Anthropic-compatible custom providers from name, immutable slug, base URL, API key, optional PNG/WebP logo, and a connection test that can return discovered models. |
+| `ProviderConfigModal` | Full-featured configuration modal. Contains sections for API key, OAuth, base URL, model picker, manual/extra models, and custom-provider deletion. |
+| `ProviderConfigContent` | Modal content orchestrator — renders the appropriate sections based on provider type. Custom providers show Custom Base URL, API Key Authentication, then Manual models before the shared sections. |
 | `ApiKeySection` | API key input with preview, reveal/hide, and remove. |
 | `OAuthSection` | OAuth login/logout buttons with status display. |
 | `OAuthProviderSettings` | OAuth-specific UI for device flow providers (GitHub Copilot, Kilo Code) showing user code and verification URI. |
 | `BaseUrlSection` | Custom base URL override input. |
 | `ModelPickerSection` | Enabled/disabled model toggle list with search. Uses `useModelSelector`. |
-| `ExtraModelsSection` | Add/remove additional model IDs not in the auto-discovered list. |
+| `ExtraModelsSection` | Add/remove additional model IDs not in the auto-discovered list. Custom providers label this surface as **Manual models**. |
 | `ModelSelector` | Dual-list model picker: search, toggle individual models, toggle all, expand/collapse. |
-| `ConfirmModal` | Confirmation dialog for destructive actions (replace/remove key, change URL). |
+| `ConfirmModal` | Confirmation dialog for destructive actions (replace/remove key, change URL, delete custom provider). |
 | `CopilotDevicePrompt` | Prompts the user to enter their device code when the daemon returns a Copilot device flow. |
 
 ### Hooks
 
 | Hook | Purpose |
 |---|---|
-| `useProviders` | Core hook: fetches `GET /api/providers`, manages `test()`, `toggleEnabled()`, `saveKey()`, `removeKey()`, `saveBaseUrl()`, `addModel()`, `removeModel()`, `setDisabledModels()`. |
-| `useProvidersPage` | Page orchestrator: composes `useProviders`, `useOAuth`, `useFavorites`. Manages search, status filter, selected provider for modal, confirm action state. |
+| `useProviders` | Core hook: fetches `GET /api/providers`, manages `test()`, `toggleEnabled()`, `saveKey()`, `removeKey()`, `saveBaseUrl()`, `addModel()`, `removeModel()`, `setDisabledModels()`, `testCustom()`, `createCustom()`, and `deleteCustom()`. |
+| `useProvidersPage` | Page orchestrator: composes `useProviders`, `useOAuth`, `useFavorites`. Manages search, status filter, selected provider for modal, custom-provider compatibility modal, and confirm action state. |
 | `useOAuth` | Manages OAuth flows: `startBrowserFlow(id)` and `startDeviceFlow(id)`. Polls `GET /api/providers/:id/oauth/status/:key` until login completes or times out. Handles `logout()`. Device flow opens verification URI in external browser. |
 | `useFavorites` | Persists favorite provider order to backend via `GET /api/config` and `PUT /api/config` (panel settings). Handles `toggleFavorite()`, `reorderFavorites()`, `dismissTip()`. |
 | `useModelSelector` | Model selection logic: search filtering, toggle individual/all, counts (active/total). |
@@ -424,16 +425,16 @@ The most feature-rich module. Manages all LLM providers: API key configuration, 
 
 | Service | Endpoints Used |
 |---|---|
-| `providersService` | `GET /api/providers`, `POST /api/providers/:id/test`, `GET /api/models/:id`, `PUT /api/config` (provider config), OAuth endpoints (`/providers/:id/oauth/start`, `/providers/:id/oauth/status/:key`, `/providers/:id/oauth/logout`) |
+| `providersService` | `GET /api/providers`, `POST /api/providers/:id/test`, `GET /api/models/:id`, `PUT /api/config` (provider config), custom provider endpoints (`POST /api/custom-providers/test`, `POST /api/custom-providers`, `DELETE /api/custom-providers/:id`), OAuth endpoints (`/providers/:id/oauth/start`, `/providers/:id/oauth/status/:key`, `/providers/:id/oauth/logout`) |
 
 ### Domain
 
 | File | Purpose |
 |---|---|
-| `types.ts` | Type aliases: `ProviderInfo`, `ModelInfo`, `TestResult`, `OAuthInfo`, `OAuthStatusResponse`, `CopilotFlow`, `ConfirmAction`. |
+| `types.ts` | Type aliases: `ProviderInfo` (including `custom`, `customCompatibility`, and `logoUrl`), `ModelInfo`, `TestResult`, `OAuthInfo`, `OAuthStatusResponse`, `CopilotFlow`, `ConfirmAction`. |
 | `constants.ts` | Provider classification: `LOCAL_PROVIDERS` (ollama, lmstudio, llamacpp), `OAUTH_PROVIDERS` (openai_account, copilot, kiro, iflow, kilocode, cline), `DEVICE_FLOW_PROVIDERS` (copilot, kilocode), `COMING_SOON_PROVIDERS` (kiro, iflow). |
 | `status.ts` | `getProviderKind(provider)` — "local" / "oauth" / "api-key". `isProviderReady(provider)` — whether the provider is configured and ready to use. `canTestProvider(provider)` — whether test is possible (enabled + ready). |
-| `providerGroups.ts` | `groupProvidersByConfiguration(providers)` — sorts providers into Local / OAuth / API Key groups, sorted by label. |
+| `providerGroups.ts` | `groupProvidersByConfiguration(providers)` — sorts built-in providers into Local / OAuth / API Key groups, sorted by label. Custom providers are rendered separately at the end of All Providers. |
 | `providerFilters.ts` | `filterProviders(providers, { searchTerm, status })` — filters by search text and status. |
 | `utils.ts` | `mergeModelLists(value)` — deduplicates and trims model IDs. `stripModelPrefix(displayName)` — removes `"provider · "` prefix. |
 | `oauthPresentation.ts` | Presentation helpers for OAuth provider labels and descriptions. |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -13,6 +13,8 @@ favorites, icons, suggested models, and OAuth-specific controls.
 | OAuth | Sign in from the Providers page. Tokens are stored in the encrypted secret store. | OpenAI Account, GitHub Copilot, Kilo Code, Cline |
 | API key | Paste an upstream provider key in the provider modal. | OpenRouter, Groq, xAI, Mistral, Command Code |
 | Local | Run the local model server and adjust the base URL if needed. | Ollama, LM Studio, llama.cpp |
+| Custom OpenAI-compatible | Click **Add OpenAI Compatible**, enter name/slug/base URL/API key, optionally upload a PNG/WebP logo. | Self-hosted or third-party OpenAI Chat Completions-compatible endpoints |
+| Custom Anthropic-compatible | Click **Add Anthropic Compatible**, enter name/slug/base URL/API key, optionally upload a PNG/WebP logo. | Self-hosted or third-party Anthropic Messages-compatible endpoints |
 | Coming soon OAuth | Visible in the UI, disabled until the flow is implemented. | Kiro AI, iFlow AI |
 
 ## Supported Providers
@@ -73,6 +75,32 @@ favorites, icons, suggested models, and OAuth-specific controls.
 | LM Studio | `lmstudio` | `http://localhost:1234/v1` |
 | llama.cpp | `llamacpp` | `http://localhost:8080/v1` |
 
+### User-Created Custom Providers
+
+Custom providers are not part of `PROVIDER_IDS`; they are stored in
+`config.providers` under the user-chosen slug. The daemon creates the provider
+at runtime from `config.providers.<slug>.custom.compatibility`:
+
+| Compatibility | Runtime transport | Upstream endpoints |
+|---|---|---|
+| `openai` | `OpenAIChatTransport` | `{baseUrl}/models`, `{baseUrl}/chat/completions` |
+| `anthropic` | `AnthropicMessagesTransport` | `{baseUrl}/models`, `{baseUrl}/messages` |
+
+Creation flow:
+
+1. Open **Providers**.
+2. Use the tab action **Add OpenAI Compatible** or **Add Anthropic Compatible**.
+3. Enter display name, immutable slug, Base URL, API key, and optionally a PNG/WebP logo.
+4. Click **Test Connection** to probe model discovery before saving.
+5. Save the provider. If discovery fails or returns no models, open the provider details and add **Manual models**.
+
+Custom provider details intentionally allow editing only Base URL, API key, enabled state, manual/disabled models, and deletion. Name, slug, and logo are immutable after creation; delete and recreate the provider to change them.
+
+Uploaded logos are stored locally in
+`~/.config/claude-code-provider-gateway/provider-logos/` (or the Windows
+`%APPDATA%` equivalent). API keys are stored in `secrets.enc.json`, not
+`config.json`.
+
 ## CLI Flags
 
 Provider flags are defined in `packages/daemon/src/config/schema.ts`. They are
@@ -124,6 +152,7 @@ case-insensitive in the shell setup flow.
 | All enabled providers | `--all`, `--a` |
 | All enabled Model Chains | `--ModelChain`, `--ModelChains`, `--chains` |
 | One enabled Model Chain | `--<chain-slug>` |
+| One custom provider | `--<custom-provider-slug>` |
 
 ## Model Discovery And Manual Models
 
@@ -136,6 +165,8 @@ provider is ready.
   `packages/panel/src/features/providers/data/suggestedModels.ts`.
 - User-added model IDs are stored in `config.providers.<id>.models`.
 - Disabled model IDs are stored in `config.providers.<id>.disabledModels`.
+- Custom providers always expose the manual picker as **Manual models** in the
+  details modal, even when auto-discovery succeeds.
 - In `all` mode, models are exposed as gateway-prefixed IDs such as
   `anthropic/groq/llama-3.3-70b-versatile`.
 - Model Chain entries are exposed as synthetic IDs such as
@@ -195,12 +226,18 @@ The Providers page supports:
 - Search by provider label.
 - Active/inactive filtering.
 - Provider groups by configuration type.
+- A **Custom Providers (OpenAI/Anthropic Compatible)** section at the end of
+  the All Providers tab; creation buttons are aligned with the tab bar actions.
 - Favorite providers saved in `config.panelSettings.favoriteProviders`.
 - Drag-and-drop ordering for favorites.
 - Confirmation before replacing/removing API keys or changing local base URLs.
+- Custom provider deletion requires confirmation and removes its config,
+  encrypted API key, uploaded logo, routing references, Model Chain targets,
+  and favorite entry.
 - Direct API key documentation links for known providers.
 
-Provider icons live in `packages/panel/public/providers/<provider_id>.webp`.
+Built-in provider icons live in `packages/panel/public/providers/<provider_id>.webp`.
+Custom provider logos live in the user's config directory under `provider-logos/`.
 
 ## Adding Or Updating Providers
 
@@ -223,5 +260,7 @@ and OAuth presentation text.
 
 The current provider architecture intentionally avoids one file per provider
 when that file would only contain `id`, `label`, and `extends Transport`.
-Plain providers are registered with `createOpenAIProvider("<id>")` or
-`createAnthropicProvider("<id>")`; custom providers keep their own files.
+Plain built-in providers are registered with `createOpenAIProvider("<id>")` or
+`createAnthropicProvider("<id>")`; dedicated files are reserved for built-ins
+with custom behavior. User-created custom providers are config-defined and do
+not need source files.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ cleaner, source-linked form.
 | [Architecture](ARCHITECTURE.md) | System layers, request lifecycle, provider transports, session handling, storage, and security model. |
 | [Daemon Reference](DAEMON_REFERENCE.md) | Backend module reference for proxy, panel API, providers, sessions, observability, and build output. |
 | [API Reference](API_REFERENCE.md) | Local proxy and panel API endpoints used by Claude Code, the panel, and shell setup. |
-| [Adding a Provider](ADDING_PROVIDER.md) | Implementation checklist and design patterns for new provider support. |
+| [Adding a Provider](ADDING_PROVIDER.md) | Implementation checklist and design patterns for built-in provider support. Runtime-compatible endpoints can usually be added from the Providers UI instead. |
 | [Codebase Guide](CODEBASE_GUIDE.md) | Repository structure, naming conventions, module patterns, and where to add code. |
 | [Development](DEVELOPMENT.md) | Source setup, local dev modes, package scripts, quality gates, builds, and release flow. |
 | [Testing](TESTING.md) | Test commands, test layout, coverage expectations, and CI integration. |
@@ -42,7 +42,8 @@ cleaner, source-linked form.
 - Update [API Reference](API_REFERENCE.md) when adding or changing routes in
   `packages/daemon/src/proxy/routes/` or `packages/daemon/src/panel/routes/`.
 - Update [Providers](PROVIDERS.md) and [Adding a Provider](ADDING_PROVIDER.md)
-  when changing provider IDs, CLI flags, auth behavior, or model discovery.
+  when changing provider IDs, CLI flags, auth behavior, custom-provider
+  behavior, or model discovery.
 - Update [Codebase Guide](CODEBASE_GUIDE.md) when moving modules, changing
   naming conventions, or introducing a new architectural pattern.
 - Update [Testing](TESTING.md) when adding a new test runner, package test

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -75,8 +75,9 @@ Common causes:
 | Missing API key | Add or replace the API key in the provider modal. |
 | OAuth expired | Log out and sign in again from the provider card. |
 | Wrong base URL | Restore the default URL or verify the local server URL. |
+| Custom provider compatibility mismatch | Delete and recreate the provider with the correct **Add OpenAI Compatible** or **Add Anthropic Compatible** action. Name, slug, and logo are immutable after creation. |
 | Network/proxy restriction | Configure **Settings -> Outbound Proxy** and restart the gateway. |
-| Empty model catalog | Add manual models in the provider modal, then test launch/routing. |
+| Empty model catalog | Add manual models in the provider modal, then test launch/routing. Custom providers always show the manual model input as **Manual models**. |
 
 Local providers need their upstream server running first:
 
@@ -182,6 +183,7 @@ Useful files:
 |---|---|
 | `daemon.log` | Provider errors, OAuth failures, RTK/Caveman logs, startup/shutdown messages. |
 | `config.json` | Non-secret provider settings, model mode, Model Chains, ports, token saver settings. |
+| `provider-logos/` | Uploaded PNG/WebP logos for user-created custom providers. |
 | `current-session.json` | Active session checkpoint. |
 | `sessions.jsonl` | Archived sessions. |
 

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -80,7 +80,7 @@ All `/v1/*` routes require the gateway auth token in the `x-api-key` header.
 | `GET` | `/api/status` | Daemon status and provider list. |
 | `GET`/`POST` | `/api/sessions` | Active session and session history. |
 | `GET`/`POST` | `/api/config` | Read and write gateway configuration. |
-| `GET`/`POST` | `/api/providers` | Provider management — test connections, fetch models, manage OAuth. |
+| `GET`/`POST` | `/api/providers` and `/api/custom-providers/*` | Provider management — test connections, fetch models, manage OAuth, create/test/delete custom providers, and serve uploaded custom logos. |
 | `GET`/`POST` | `/api/oauth/*` | OAuth flow endpoints for OpenAI Account, GitHub Copilot, Kilo Code, and Cline. |
 | `POST` | `/api/shell/*` | Shell setup — install/uninstall the `ccpg` command wrapper. |
 
@@ -106,7 +106,7 @@ export type { Config, ProviderConfig, ProviderId, RoutingRule } from "./config/s
 
 ### Provider system
 
-The daemon supports **41 providers** (cloud API key, OAuth, and local) via a provider registry. Each provider implements a transport adapter — either Anthropic-native passthrough or OpenAI-format translation. Provider implementations live in `src/proxy/providers/`.
+The daemon ships with a built-in provider catalog (cloud API key, OAuth, and local) and can add user-created OpenAI-compatible or Anthropic-compatible providers at runtime. Each provider implements a transport adapter — either Anthropic-native passthrough or OpenAI-format translation. Built-in provider implementations live in `src/proxy/providers/`; custom providers are stored in config under their slug and instantiated dynamically from their compatibility mode.
 
 OAuth providers (`openai_account`, `copilot`, `kiro`, `iflow`, `kilocode`, `cline`) include built-in token refresh logic.
 

--- a/packages/daemon/src/config/index.ts
+++ b/packages/daemon/src/config/index.ts
@@ -2,7 +2,7 @@ import { randomBytes } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { writePrivateFile } from "../core/files/private-file.js";
 import { getConfigPath, getMasterKeyPath, getSecretsPath } from "./paths.js";
-import type { Config, ProviderConfig, ProviderId } from "./schema.js";
+import type { BuiltInProviderId, Config, ProviderConfig } from "./schema.js";
 import { OAUTH_PROVIDER_IDS, PROVIDER_DEFAULTS, PROVIDER_IDS } from "./schema.js";
 import { extractSecretsToStore, hydrateSecretsFromStore } from "./secrets/config-splitter.js";
 import { EncryptedFileSecretStore } from "./secrets/encrypted-file-store.js";
@@ -18,6 +18,7 @@ export {
   getLogPath,
   getMasterKeyPath,
   getPidPath,
+  getProviderLogoDir,
   getSecretsPath,
   getSessionArchivePath,
 } from "./paths.js";
@@ -31,7 +32,7 @@ export function getSecretStore(): SecretStore {
   return cachedSecretStore;
 }
 
-function buildDefaultProviderConfig(id: ProviderId): ProviderConfig {
+function buildDefaultProviderConfig(id: BuiltInProviderId): ProviderConfig {
   const isOAuth = OAUTH_PROVIDER_IDS.has(id);
   return {
     enabled: false,
@@ -45,13 +46,13 @@ function buildDefaultProviderConfig(id: ProviderId): ProviderConfig {
   };
 }
 
-function buildDefaultProviders(): Record<ProviderId, ProviderConfig> {
+function buildDefaultProviders(): Record<string, ProviderConfig> {
   return PROVIDER_IDS.reduce(
     (providers, id) => {
       providers[id] = buildDefaultProviderConfig(id);
       return providers;
     },
-    {} as Record<ProviderId, ProviderConfig>,
+    {} as Record<string, ProviderConfig>,
   );
 }
 

--- a/packages/daemon/src/config/paths.ts
+++ b/packages/daemon/src/config/paths.ts
@@ -35,3 +35,7 @@ export function getCurrentSessionPath(): string {
 export function getSessionArchivePath(): string {
   return join(getConfigDir(), "sessions.jsonl");
 }
+
+export function getProviderLogoDir(): string {
+  return join(getConfigDir(), "provider-logos");
+}

--- a/packages/daemon/src/config/schema.ts
+++ b/packages/daemon/src/config/schema.ts
@@ -51,7 +51,8 @@ export const OAUTH_PROVIDER_IDS = new Set<ProviderId>([
   "cline",
 ]);
 
-export type ProviderId = (typeof PROVIDER_IDS)[number];
+export type BuiltInProviderId = (typeof PROVIDER_IDS)[number];
+export type ProviderId = BuiltInProviderId | string;
 
 export interface ProviderOAuthConfig {
   accessToken?: string;
@@ -79,6 +80,12 @@ export interface ProviderConfig {
   rateWindow: number;
   maxConcurrency: number;
   requestTimeoutMs?: number;
+  custom?: {
+    label: string;
+    slug: string;
+    logoFile?: string;
+    compatibility: "openai" | "anthropic";
+  };
 }
 
 export type ModelMode = "single" | "all" | "chains";
@@ -142,56 +149,58 @@ export interface Config {
   };
 }
 
-export const PROVIDER_DEFAULTS: Record<ProviderId, Partial<ProviderConfig> & { baseUrl?: string }> =
-  {
-    openai_account: { baseUrl: "https://chatgpt.com/backend-api", models: [] },
-    copilot: { baseUrl: "https://api.individual.githubcopilot.com", models: [] },
-    nvidia_nim: { baseUrl: "https://integrate.api.nvidia.com/v1" },
-    openrouter: { baseUrl: "https://openrouter.ai/api/v1" },
-    deepseek: { baseUrl: "https://api.deepseek.com/anthropic" },
-    kimi: { baseUrl: "https://api.moonshot.ai/v1" },
-    google: {
-      baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
-    },
-    ollama: { baseUrl: "http://localhost:11434" },
-    lmstudio: { baseUrl: "http://localhost:1234/v1" },
-    llamacpp: { baseUrl: "http://localhost:8080/v1" },
-    groq: { baseUrl: "https://api.groq.com/openai/v1" },
-    xai: { baseUrl: "https://api.x.ai/v1" },
-    mistral: { baseUrl: "https://api.mistral.ai/v1" },
-    cerebras: { baseUrl: "https://api.cerebras.ai/v1" },
-    together: { baseUrl: "https://api.together.xyz/v1" },
-    fireworks: { baseUrl: "https://api.fireworks.ai/inference/v1" },
-    glm: { baseUrl: "https://api.z.ai/api/anthropic/v1" },
-    siliconflow: { baseUrl: "https://api.siliconflow.cn/v1" },
-    hyperbolic: { baseUrl: "https://api.hyperbolic.xyz/v1" },
-    chutes: { baseUrl: "https://llm.chutes.ai/v1" },
-    perplexity: { baseUrl: "https://api.perplexity.ai" },
-    nebius: { baseUrl: "https://api.studio.nebius.com/v1" },
-    glm_cn: { baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4" },
-    volcengine_ark: { baseUrl: "https://ark.cn-beijing.volces.com/api/v3" },
-    byteplus: { baseUrl: "https://ark.ap-southeast.bytepluses.com/api/v3" },
-    alicode: { baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" },
-    alicode_intl: {
-      baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-    },
-    minimax: { baseUrl: "https://api.minimax.io/anthropic/v1" },
-    minimax_cn: { baseUrl: "https://api.minimaxi.com/anthropic/v1" },
-    opencode_go: { baseUrl: "https://opencode.ai/zen/go/v1" },
-    xiaomi_mimo: { baseUrl: "https://api.xiaomimimo.com/v1" },
-    xiaomi_tokenplan: { baseUrl: "https://token-plan-sgp.xiaomimimo.com/v1" },
-    cohere: { baseUrl: "https://api.cohere.ai/compatibility/v1" },
-    blackbox: { baseUrl: "https://api.blackbox.ai" },
-    huggingface: { baseUrl: "https://router.huggingface.co/v1" },
-    kiro: { baseUrl: "" },
-    iflow: { baseUrl: "https://apis.iflow.cn/v1" },
-    kilocode: { baseUrl: "https://api.kilo.ai/api/openrouter" },
-    cline: { baseUrl: "https://api.cline.bot/api/v1" },
-    ollama_cloud: { baseUrl: "https://ollama.com" },
-    commandcode: { baseUrl: "https://api.commandcode.ai/alpha/generate", models: [] },
-  };
+export const PROVIDER_DEFAULTS: Record<
+  BuiltInProviderId,
+  Partial<ProviderConfig> & { baseUrl?: string }
+> = {
+  openai_account: { baseUrl: "https://chatgpt.com/backend-api", models: [] },
+  copilot: { baseUrl: "https://api.individual.githubcopilot.com", models: [] },
+  nvidia_nim: { baseUrl: "https://integrate.api.nvidia.com/v1" },
+  openrouter: { baseUrl: "https://openrouter.ai/api/v1" },
+  deepseek: { baseUrl: "https://api.deepseek.com/anthropic" },
+  kimi: { baseUrl: "https://api.moonshot.ai/v1" },
+  google: {
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+  },
+  ollama: { baseUrl: "http://localhost:11434" },
+  lmstudio: { baseUrl: "http://localhost:1234/v1" },
+  llamacpp: { baseUrl: "http://localhost:8080/v1" },
+  groq: { baseUrl: "https://api.groq.com/openai/v1" },
+  xai: { baseUrl: "https://api.x.ai/v1" },
+  mistral: { baseUrl: "https://api.mistral.ai/v1" },
+  cerebras: { baseUrl: "https://api.cerebras.ai/v1" },
+  together: { baseUrl: "https://api.together.xyz/v1" },
+  fireworks: { baseUrl: "https://api.fireworks.ai/inference/v1" },
+  glm: { baseUrl: "https://api.z.ai/api/anthropic/v1" },
+  siliconflow: { baseUrl: "https://api.siliconflow.cn/v1" },
+  hyperbolic: { baseUrl: "https://api.hyperbolic.xyz/v1" },
+  chutes: { baseUrl: "https://llm.chutes.ai/v1" },
+  perplexity: { baseUrl: "https://api.perplexity.ai" },
+  nebius: { baseUrl: "https://api.studio.nebius.com/v1" },
+  glm_cn: { baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4" },
+  volcengine_ark: { baseUrl: "https://ark.cn-beijing.volces.com/api/v3" },
+  byteplus: { baseUrl: "https://ark.ap-southeast.bytepluses.com/api/v3" },
+  alicode: { baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" },
+  alicode_intl: {
+    baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+  },
+  minimax: { baseUrl: "https://api.minimax.io/anthropic/v1" },
+  minimax_cn: { baseUrl: "https://api.minimaxi.com/anthropic/v1" },
+  opencode_go: { baseUrl: "https://opencode.ai/zen/go/v1" },
+  xiaomi_mimo: { baseUrl: "https://api.xiaomimimo.com/v1" },
+  xiaomi_tokenplan: { baseUrl: "https://token-plan-sgp.xiaomimimo.com/v1" },
+  cohere: { baseUrl: "https://api.cohere.ai/compatibility/v1" },
+  blackbox: { baseUrl: "https://api.blackbox.ai" },
+  huggingface: { baseUrl: "https://router.huggingface.co/v1" },
+  kiro: { baseUrl: "" },
+  iflow: { baseUrl: "https://apis.iflow.cn/v1" },
+  kilocode: { baseUrl: "https://api.kilo.ai/api/openrouter" },
+  cline: { baseUrl: "https://api.cline.bot/api/v1" },
+  ollama_cloud: { baseUrl: "https://ollama.com" },
+  commandcode: { baseUrl: "https://api.commandcode.ai/alpha/generate", models: [] },
+};
 
-export const PROVIDER_LABELS: Record<ProviderId, string> = {
+export const PROVIDER_LABELS: Record<BuiltInProviderId, string> = {
   openai_account: "OpenAI Account",
   copilot: "GitHub Copilot",
   nvidia_nim: "NVIDIA NIM",
@@ -235,7 +244,7 @@ export const PROVIDER_LABELS: Record<ProviderId, string> = {
   commandcode: "Command Code",
 };
 
-export const CLI_FLAGS: Record<string, ProviderId> = {
+export const CLI_FLAGS: Record<string, BuiltInProviderId> = {
   "--OpenAIAccount": "openai_account",
   "--Copilot": "copilot",
   "--GitHubCopilot": "copilot",

--- a/packages/daemon/src/config/secrets/config-splitter.ts
+++ b/packages/daemon/src/config/secrets/config-splitter.ts
@@ -1,5 +1,4 @@
 import type { Config } from "../schema.js";
-import { PROVIDER_IDS } from "../schema.js";
 import { SECRET_KEYS, type SecretStore } from "./store.js";
 
 // Drains secrets *out of* `config` into `store`, leaving the config object
@@ -8,7 +7,7 @@ export function extractSecretsToStore(config: Config, store: SecretStore): void 
   writeIfPresent(store, SECRET_KEYS.serverAuthToken, config.server.authToken);
   config.server.authToken = "";
 
-  for (const id of PROVIDER_IDS) {
+  for (const id of Object.keys(config.providers)) {
     const provider = config.providers[id];
     if (!provider) continue;
 
@@ -33,7 +32,7 @@ export function extractSecretsToStore(config: Config, store: SecretStore): void 
 export function hydrateSecretsFromStore(config: Config, store: SecretStore): void {
   config.server.authToken = store.get(SECRET_KEYS.serverAuthToken) ?? config.server.authToken;
 
-  for (const id of PROVIDER_IDS) {
+  for (const id of Object.keys(config.providers)) {
     const provider = config.providers[id];
     if (!provider) continue;
 
@@ -70,7 +69,7 @@ export function clearProviderOAuthSecrets(store: SecretStore, id: string): void 
 // one-shot migration that moves secrets into the SecretStore.
 export function jsonStillHasSecrets(config: Config): boolean {
   if (config.server.authToken) return true;
-  for (const id of PROVIDER_IDS) {
+  for (const id of Object.keys(config.providers)) {
     const p = config.providers[id];
     if (!p) continue;
     if (p.apiKey) return true;

--- a/packages/daemon/src/config/validation.test.ts
+++ b/packages/daemon/src/config/validation.test.ts
@@ -17,6 +17,22 @@ test("normalizeConfig preserves valid config values", () => {
         enabled: true,
         requestTimeoutMs: 1200,
       },
+      acme_anthropic: {
+        enabled: true,
+        apiKey: "sk-acme-anthropic",
+        authType: "api_key" as const,
+        models: ["claude-custom"],
+        disabledModels: [],
+        baseUrl: "https://anthropic.acme.test/v1",
+        rateLimit: 40,
+        rateWindow: 60,
+        maxConcurrency: 5,
+        custom: {
+          label: "Acme Anthropic",
+          slug: "acme_anthropic",
+          compatibility: "anthropic" as const,
+        },
+      },
     },
   };
 
@@ -186,4 +202,56 @@ test("normalizeConfig preserves OAuth provider metadata", () => {
     "https://api.individual.githubcopilot.com",
   );
   assert.equal(normalized.providers.kilocode.oauth?.orgId, "org_123");
+});
+
+test("normalizeConfig preserves custom OpenAI-compatible providers", () => {
+  const defaults = buildDefaultConfig();
+  const config = {
+    ...defaults,
+    activeProvider: "acme_ai",
+    providers: {
+      ...defaults.providers,
+      acme_ai: {
+        enabled: true,
+        apiKey: "sk-acme",
+        authType: "api_key" as const,
+        models: ["acme-large"],
+        disabledModels: [],
+        baseUrl: "https://api.acme.test/v1",
+        rateLimit: 40,
+        rateWindow: 60,
+        maxConcurrency: 5,
+        custom: {
+          label: "Acme AI",
+          slug: "acme_ai",
+          logoFile: "acme_ai.webp",
+          compatibility: "openai" as const,
+        },
+      },
+      acme_anthropic: {
+        enabled: true,
+        apiKey: "sk-acme-anthropic",
+        authType: "api_key" as const,
+        models: ["claude-custom"],
+        disabledModels: [],
+        baseUrl: "https://anthropic.acme.test/v1",
+        rateLimit: 40,
+        rateWindow: 60,
+        maxConcurrency: 5,
+        custom: {
+          label: "Acme Anthropic",
+          slug: "acme_anthropic",
+          compatibility: "anthropic" as const,
+        },
+      },
+    },
+  };
+
+  const normalized = normalizeConfig(config, defaults);
+
+  assert.equal(normalized.activeProvider, "acme_ai");
+  assert.equal(normalized.providers.acme_ai.custom?.label, "Acme AI");
+  assert.equal(normalized.providers.acme_ai.baseUrl, "https://api.acme.test/v1");
+  assert.deepEqual(normalized.providers.acme_ai.models, ["acme-large"]);
+  assert.equal(normalized.providers.acme_anthropic.custom?.compatibility, "anthropic");
 });

--- a/packages/daemon/src/config/validation.ts
+++ b/packages/daemon/src/config/validation.ts
@@ -15,8 +15,16 @@ const MODEL_MODES = new Set<ModelMode>(["single", "all", "chains"]);
 const CAVEMAN_LEVELS = new Set<CavemanLevel>(["lite", "full", "ultra"]);
 
 export function normalizeConfig(config: Config, defaults: Config): Config {
-  const modelFallbacks = normalizeModelFallbacks(config.modelFallbacks, defaults.modelFallbacks);
   const providers = normalizeProviders(config.providers, defaults.providers);
+  const knownProviderIds = new Set([
+    ...(PROVIDER_IDS as readonly string[]),
+    ...Object.keys(providers),
+  ]);
+  const modelFallbacks = normalizeModelFallbacks(
+    config.modelFallbacks,
+    defaults.modelFallbacks,
+    knownProviderIds,
+  );
 
   return {
     server: {
@@ -26,10 +34,10 @@ export function normalizeConfig(config: Config, defaults: Config): Config {
     },
     providers,
     routing: {
-      default: normalizeRoutingRule(config.routing?.default, defaults.routing.default),
-      opus: normalizeRoutingRule(config.routing?.opus, defaults.routing.opus),
-      sonnet: normalizeRoutingRule(config.routing?.sonnet, defaults.routing.sonnet),
-      haiku: normalizeRoutingRule(config.routing?.haiku, defaults.routing.haiku),
+      default: normalizeRoutingRule(config.routing?.default, defaults.routing.default, knownProviderIds),
+      opus: normalizeRoutingRule(config.routing?.opus, defaults.routing.opus, knownProviderIds),
+      sonnet: normalizeRoutingRule(config.routing?.sonnet, defaults.routing.sonnet, knownProviderIds),
+      haiku: normalizeRoutingRule(config.routing?.haiku, defaults.routing.haiku, knownProviderIds),
     },
     thinking: {
       enabled: booleanOrDefault(config.thinking.enabled, defaults.thinking.enabled),
@@ -75,6 +83,7 @@ export function normalizeConfig(config: Config, defaults: Config): Config {
       favoriteProviders: normalizeProviderIdList(
         config.panelSettings?.favoriteProviders,
         defaults.panelSettings.favoriteProviders,
+        knownProviderIds,
       ),
       favoritesTipDismissed: booleanOrDefault(
         config.panelSettings?.favoritesTipDismissed,
@@ -87,6 +96,7 @@ export function normalizeConfig(config: Config, defaults: Config): Config {
 function normalizeModelFallbacks(
   value: unknown,
   fallback: ModelFallbackConfig[],
+  knownProviderIds: Set<string>,
 ): ModelFallbackConfig[] {
   if (!Array.isArray(value)) return fallback;
   const seen = new Set<string>();
@@ -101,14 +111,17 @@ function normalizeModelFallbacks(
       typeof raw.id === "string" && raw.id.trim()
         ? raw.id.trim()
         : `chain_${slug.replaceAll("-", "_")}`;
-    const models = normalizeModelFallbackEntries(raw.models);
+    const models = normalizeModelFallbackEntries(raw.models, knownProviderIds);
     seen.add(slug);
     out.push({ id, name, slug, models, enabled: raw.enabled !== false && models.length > 0 });
   }
   return out;
 }
 
-function normalizeModelFallbackEntries(value: unknown): ModelFallbackEntry[] {
+function normalizeModelFallbackEntries(
+  value: unknown,
+  knownProviderIds: Set<string>,
+): ModelFallbackEntry[] {
   if (!Array.isArray(value)) return [];
   const seen = new Set<string>();
   const out: ModelFallbackEntry[] = [];
@@ -116,7 +129,7 @@ function normalizeModelFallbackEntries(value: unknown): ModelFallbackEntry[] {
     if (!item || typeof item !== "object") continue;
     const raw = item as Partial<ModelFallbackEntry>;
     const providerId =
-      typeof raw.providerId === "string" && isKnownProviderId(raw.providerId)
+      typeof raw.providerId === "string" && isKnownProviderId(raw.providerId, knownProviderIds)
         ? raw.providerId
         : null;
     const model = typeof raw.model === "string" ? raw.model.trim() : "";
@@ -252,14 +265,18 @@ function normalizeOAuth(
   };
 }
 
-function normalizeRoutingRule(value: unknown, fallback: RoutingRule): RoutingRule {
+function normalizeRoutingRule(
+  value: unknown,
+  fallback: RoutingRule,
+  knownProviderIds: Set<string>,
+): RoutingRule {
   // Legacy migration: string "provider_id/model-name"
   if (typeof value === "string") {
     const slash = value.indexOf("/");
     if (slash > 0) {
       const pid = value.slice(0, slash);
       const model = value.slice(slash + 1);
-      if (isKnownProviderId(pid) && model) {
+      if (isKnownProviderId(pid, knownProviderIds) && model) {
         return { enabled: true, providerId: pid, model };
       }
     }
@@ -268,7 +285,8 @@ function normalizeRoutingRule(value: unknown, fallback: RoutingRule): RoutingRul
   if (!value || typeof value !== "object") return fallback;
   const v = value as Partial<RoutingRule>;
   const providerId =
-    typeof v.providerId === "string" && (v.providerId === "" || isKnownProviderId(v.providerId))
+    typeof v.providerId === "string" &&
+    (v.providerId === "" || isKnownProviderId(v.providerId, knownProviderIds))
       ? (v.providerId as ProviderId | "")
       : "";
   const model = typeof v.model === "string" ? v.model : "";
@@ -355,12 +373,16 @@ function cavemanLevelOrDefault(value: unknown, fallback: CavemanLevel): CavemanL
     : fallback;
 }
 
-function normalizeProviderIdList(value: unknown, fallback: ProviderId[]): ProviderId[] {
+function normalizeProviderIdList(
+  value: unknown,
+  fallback: ProviderId[],
+  knownProviderIds: Set<string>,
+): ProviderId[] {
   if (!Array.isArray(value)) return fallback;
   const seen = new Set<ProviderId>();
   const out: ProviderId[] = [];
   for (const item of value) {
-    if (typeof item === "string" && isKnownProviderId(item)) {
+    if (typeof item === "string" && isKnownProviderId(item, knownProviderIds)) {
       if (!seen.has(item as ProviderId)) {
         seen.add(item as ProviderId);
         out.push(item as ProviderId);
@@ -370,6 +392,6 @@ function normalizeProviderIdList(value: unknown, fallback: ProviderId[]): Provid
   return out;
 }
 
-function isKnownProviderId(id: string): boolean {
-  return PROVIDER_ID_SET.has(id) || normalizeSlug(id) === id;
+function isKnownProviderId(id: string, knownProviderIds: Set<string>): boolean {
+  return knownProviderIds.has(id);
 }

--- a/packages/daemon/src/config/validation.ts
+++ b/packages/daemon/src/config/validation.ts
@@ -16,6 +16,7 @@ const CAVEMAN_LEVELS = new Set<CavemanLevel>(["lite", "full", "ultra"]);
 
 export function normalizeConfig(config: Config, defaults: Config): Config {
   const modelFallbacks = normalizeModelFallbacks(config.modelFallbacks, defaults.modelFallbacks);
+  const providers = normalizeProviders(config.providers, defaults.providers);
 
   return {
     server: {
@@ -23,7 +24,7 @@ export function normalizeConfig(config: Config, defaults: Config): Config {
       panelPort: numberOrDefault(config.server.panelPort, defaults.server.panelPort),
       authToken: stringOrDefault(config.server.authToken, defaults.server.authToken),
     },
-    providers: normalizeProviders(config.providers, defaults.providers),
+    providers,
     routing: {
       default: normalizeRoutingRule(config.routing?.default, defaults.routing.default),
       opus: normalizeRoutingRule(config.routing?.opus, defaults.routing.opus),
@@ -58,7 +59,11 @@ export function normalizeConfig(config: Config, defaults: Config): Config {
         defaults.tokenSavers.cavemanLevel,
       ),
     },
-    activeProvider: providerIdOrDefault(config.activeProvider, defaults.activeProvider),
+    activeProvider: activeProviderOrDefault(
+      config.activeProvider,
+      defaults.activeProvider,
+      providers,
+    ),
     modelMode: modelModeOrDefault(config.modelMode, defaults.modelMode),
     activeModelFallbackSlug: normalizeActiveModelFallbackSlug(
       config.activeModelFallbackSlug,
@@ -111,8 +116,8 @@ function normalizeModelFallbackEntries(value: unknown): ModelFallbackEntry[] {
     if (!item || typeof item !== "object") continue;
     const raw = item as Partial<ModelFallbackEntry>;
     const providerId =
-      typeof raw.providerId === "string" && PROVIDER_ID_SET.has(raw.providerId)
-        ? (raw.providerId as ProviderId)
+      typeof raw.providerId === "string" && isKnownProviderId(raw.providerId)
+        ? raw.providerId
         : null;
     const model = typeof raw.model === "string" ? raw.model.trim() : "";
     const key = providerId && model ? `${providerId}/${model}` : "";
@@ -143,13 +148,13 @@ function hasEnabledFallbackSlug(modelFallbacks: ModelFallbackConfig[], slug: str
 }
 
 function normalizeProviders(
-  providers: Record<ProviderId, ProviderConfig>,
-  defaults: Record<ProviderId, ProviderConfig>,
-): Record<ProviderId, ProviderConfig> {
-  return PROVIDER_IDS.reduce(
+  providers: Record<string, ProviderConfig>,
+  defaults: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+  return mergeProviderIds(providers, defaults).reduce(
     (out, id) => {
       const provider = providers[id];
-      const fallback = defaults[id];
+      const fallback = defaults[id] ?? defaultCustomProviderConfig(provider, id);
       out[id] = {
         enabled: booleanOrDefault(provider.enabled, fallback.enabled),
         apiKey: optionalString(provider.apiKey),
@@ -162,11 +167,71 @@ function normalizeProviders(
         rateWindow: numberOrDefault(provider.rateWindow, fallback.rateWindow),
         maxConcurrency: numberOrDefault(provider.maxConcurrency, fallback.maxConcurrency),
         requestTimeoutMs: optionalPositiveNumber(provider.requestTimeoutMs),
+        custom: normalizeCustomProvider(provider.custom, fallback.custom, id),
       };
       return out;
     },
-    {} as Record<ProviderId, ProviderConfig>,
+    {} as Record<string, ProviderConfig>,
   );
+}
+
+function mergeProviderIds(
+  providers: Record<string, ProviderConfig> | undefined,
+  defaults: Record<string, ProviderConfig>,
+): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const id of [...PROVIDER_IDS, ...Object.keys(providers ?? {}), ...Object.keys(defaults)]) {
+    if (seen.has(id)) continue;
+    if (!PROVIDER_ID_SET.has(id) && !isCustomProviderId(id, providers?.[id])) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}
+
+function isCustomProviderId(id: string, provider: ProviderConfig | undefined): boolean {
+  return !!provider?.custom && normalizeSlug(id) === id;
+}
+
+function defaultCustomProviderConfig(
+  provider: ProviderConfig | undefined,
+  id: string,
+): ProviderConfig {
+  return {
+    enabled: false,
+    apiKey: "",
+    authType: "api_key",
+    models: [],
+    disabledModels: [],
+    baseUrl: "",
+    rateLimit: 40,
+    rateWindow: 60,
+    maxConcurrency: 5,
+    custom: {
+      label: provider?.custom?.label || id,
+      slug: id,
+      logoFile: provider?.custom?.logoFile,
+      compatibility: provider?.custom?.compatibility === "anthropic" ? "anthropic" : "openai",
+    },
+  };
+}
+
+function normalizeCustomProvider(
+  value: ProviderConfig["custom"],
+  fallback: ProviderConfig["custom"],
+  id: string,
+): ProviderConfig["custom"] {
+  const source = value ?? fallback;
+  if (!source || typeof source !== "object") return undefined;
+  const label = typeof source.label === "string" && source.label.trim() ? source.label.trim() : id;
+  const slug = normalizeSlug(source.slug) ?? id;
+  const logoFile =
+    typeof source.logoFile === "string" && /^[a-zA-Z0-9_-]+\.(png|webp)$/.test(source.logoFile)
+      ? source.logoFile
+      : undefined;
+  const compatibility = source.compatibility === "anthropic" ? "anthropic" : "openai";
+  return { label, slug, logoFile, compatibility };
 }
 
 function normalizeOAuth(
@@ -194,8 +259,8 @@ function normalizeRoutingRule(value: unknown, fallback: RoutingRule): RoutingRul
     if (slash > 0) {
       const pid = value.slice(0, slash);
       const model = value.slice(slash + 1);
-      if (PROVIDER_ID_SET.has(pid) && model) {
-        return { enabled: true, providerId: pid as ProviderId, model };
+      if (isKnownProviderId(pid) && model) {
+        return { enabled: true, providerId: pid, model };
       }
     }
     return { enabled: false, providerId: "", model: "" };
@@ -203,7 +268,7 @@ function normalizeRoutingRule(value: unknown, fallback: RoutingRule): RoutingRul
   if (!value || typeof value !== "object") return fallback;
   const v = value as Partial<RoutingRule>;
   const providerId =
-    typeof v.providerId === "string" && (v.providerId === "" || PROVIDER_ID_SET.has(v.providerId))
+    typeof v.providerId === "string" && (v.providerId === "" || isKnownProviderId(v.providerId))
       ? (v.providerId as ProviderId | "")
       : "";
   const model = typeof v.model === "string" ? v.model : "";
@@ -270,8 +335,12 @@ function authTypeOrDefault(
   return value === "oauth" || value === "api_key" ? value : fallback;
 }
 
-function providerIdOrDefault(value: unknown, fallback: ProviderId): ProviderId {
-  return typeof value === "string" && PROVIDER_ID_SET.has(value) ? (value as ProviderId) : fallback;
+function activeProviderOrDefault(
+  value: unknown,
+  fallback: ProviderId,
+  providers: Record<string, ProviderConfig>,
+): ProviderId {
+  return typeof value === "string" && providers[value] ? value : fallback;
 }
 
 function modelModeOrDefault(value: unknown, fallback: ModelMode): ModelMode {
@@ -291,7 +360,7 @@ function normalizeProviderIdList(value: unknown, fallback: ProviderId[]): Provid
   const seen = new Set<ProviderId>();
   const out: ProviderId[] = [];
   for (const item of value) {
-    if (typeof item === "string" && PROVIDER_ID_SET.has(item)) {
+    if (typeof item === "string" && isKnownProviderId(item)) {
       if (!seen.has(item as ProviderId)) {
         seen.add(item as ProviderId);
         out.push(item as ProviderId);
@@ -299,4 +368,8 @@ function normalizeProviderIdList(value: unknown, fallback: ProviderId[]): Provid
     }
   }
   return out;
+}
+
+function isKnownProviderId(id: string): boolean {
+  return PROVIDER_ID_SET.has(id) || normalizeSlug(id) === id;
 }

--- a/packages/daemon/src/config/validation.ts
+++ b/packages/daemon/src/config/validation.ts
@@ -34,9 +34,17 @@ export function normalizeConfig(config: Config, defaults: Config): Config {
     },
     providers,
     routing: {
-      default: normalizeRoutingRule(config.routing?.default, defaults.routing.default, knownProviderIds),
+      default: normalizeRoutingRule(
+        config.routing?.default,
+        defaults.routing.default,
+        knownProviderIds,
+      ),
       opus: normalizeRoutingRule(config.routing?.opus, defaults.routing.opus, knownProviderIds),
-      sonnet: normalizeRoutingRule(config.routing?.sonnet, defaults.routing.sonnet, knownProviderIds),
+      sonnet: normalizeRoutingRule(
+        config.routing?.sonnet,
+        defaults.routing.sonnet,
+        knownProviderIds,
+      ),
       haiku: normalizeRoutingRule(config.routing?.haiku, defaults.routing.haiku, knownProviderIds),
     },
     thinking: {

--- a/packages/daemon/src/panel/contracts.ts
+++ b/packages/daemon/src/panel/contracts.ts
@@ -100,6 +100,9 @@ export type ProviderInfo = {
   disabledModels?: string[];
   authType?: "api_key" | "oauth";
   oauth?: OAuthInfo;
+  custom?: boolean;
+  customCompatibility?: "openai" | "anthropic";
+  logoUrl?: string;
 };
 
 export type { ModelInfo };

--- a/packages/daemon/src/panel/launch-prepare.ts
+++ b/packages/daemon/src/panel/launch-prepare.ts
@@ -74,7 +74,9 @@ export function prepareLaunch(
     config.modelMode = "all";
     config.activeModelFallbackSlug = null;
     if (!config.providers[config.activeProvider]?.enabled) {
-      const fallbackProvider = PROVIDER_IDS.find((id) => config.providers[id]?.enabled);
+      const fallbackProvider = Object.keys(config.providers).find(
+        (id) => config.providers[id]?.enabled,
+      );
       if (fallbackProvider) config.activeProvider = fallbackProvider;
     }
     saveConfig(config);
@@ -93,7 +95,7 @@ export function prepareLaunch(
     };
   }
 
-  const providerId = resolveProviderFlag(flag);
+  const providerId = resolveProviderFlag(flag) ?? resolveCustomProviderFlag(config, flag);
   if (!providerId) {
     const fallback = resolveFallbackFlag(config, flag);
     if (!fallback) {
@@ -144,6 +146,15 @@ export function prepareLaunch(
     shellScript: buildShellExports(config, session.id),
     envVars: buildEnvVars(config, session.id),
   };
+}
+
+function resolveCustomProviderFlag(config: Config, flag: string): ProviderId | null {
+  if (!flag.startsWith("--")) return null;
+  const target = flag.slice(2).toLowerCase();
+  const match = Object.keys(config.providers).find(
+    (id) => id.toLowerCase() === target && config.providers[id]?.custom,
+  );
+  return match ?? null;
 }
 
 function isModelChainFlag(flag: string): boolean {

--- a/packages/daemon/src/panel/routes/provider-routes.ts
+++ b/packages/daemon/src/panel/routes/provider-routes.ts
@@ -70,7 +70,11 @@ export function registerProviderRoutes(app: Hono, runtime: PanelRuntime): void {
     if (!parsed.ok) return c.json({ error: parsed.error }, 400);
 
     const config = structuredClone(runtime.currentConfig());
-    if (config.providers[parsed.slug]) {
+    if (RESERVED_CUSTOM_SLUGS.has(parsed.slug)) {
+      return c.json({ error: `Provider slug "${parsed.slug}" is reserved` }, 409);
+    }
+    const existingLower = Object.keys(config.providers).map((k) => k.toLowerCase());
+    if (existingLower.includes(parsed.slug)) {
       return c.json({ error: `Provider slug "${parsed.slug}" already exists` }, 409);
     }
 
@@ -170,6 +174,9 @@ export function registerProviderRoutes(app: Hono, runtime: PanelRuntime): void {
   });
 }
 
+const RESERVED_CUSTOM_SLUGS = new Set(["anthropic", "chain", "fallback"]);
+const MAX_LOGO_BYTES = 5 * 1024 * 1024;
+
 type CustomFields = Record<string, unknown>;
 
 function parseCustomProviderFields(fields: CustomFields):
@@ -182,7 +189,7 @@ function parseCustomProviderFields(fields: CustomFields):
     }
   | { ok: false; error: string } {
   const label = stringField(fields.name)?.trim();
-  const slug = normalizeSlug(stringField(fields.slug));
+  const slug = normalizeSlug(stringField(fields.slug))?.toLowerCase() ?? null;
   const baseUrl = stringField(fields.baseUrl)?.trim().replace(/\/+$/, "");
   const apiKey = stringField(fields.apiKey)?.trim();
   const compatibility = parseCompatibility(fields.compatibility);
@@ -229,6 +236,7 @@ function parseCompatibility(value: unknown): "openai" | "anthropic" {
 
 async function saveProviderLogo(slug: string, value: unknown): Promise<string | undefined> {
   if (!(value instanceof File) || value.size === 0) return undefined;
+  if (value.size > MAX_LOGO_BYTES) throw new Error("Logo file must not exceed 5 MB");
   if (value.type !== "image/png" && value.type !== "image/webp") {
     throw new Error("Logo must be a PNG or WebP image");
   }

--- a/packages/daemon/src/panel/routes/provider-routes.ts
+++ b/packages/daemon/src/panel/routes/provider-routes.ts
@@ -1,6 +1,14 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { extname, join } from "node:path";
 import type { Hono } from "hono";
+import { getSecretStore } from "../../config/index.js";
+import { getProviderLogoDir } from "../../config/paths.js";
 import type { ProviderConfig, ProviderId } from "../../config/schema.js";
 import { PROVIDER_LABELS } from "../../config/schema.js";
+import { SECRET_KEYS } from "../../config/secrets/store.js";
+import type { ModelInfo } from "../../core/anthropic/types.js";
+import { AnthropicMessagesTransport } from "../../proxy/providers/transport-anthropic.js";
+import { OpenAIChatTransport } from "../../proxy/providers/transport-openai.js";
 import type { ProviderInfo, RoutingOption } from "../contracts.js";
 import type { PanelRuntime } from "../runtime.js";
 
@@ -13,7 +21,7 @@ export function registerProviderRoutes(app: Hono, runtime: PanelRuntime): void {
       const oauth = pc.oauth;
       return {
         id,
-        label: PROVIDER_LABELS[id as ProviderId] ?? id,
+        label: pc.custom?.label ?? PROVIDER_LABELS[id as keyof typeof PROVIDER_LABELS] ?? id,
         enabled: pc.enabled,
         hasKey: !!key,
         keyPreview,
@@ -21,6 +29,9 @@ export function registerProviderRoutes(app: Hono, runtime: PanelRuntime): void {
         models: pc.models ?? [],
         disabledModels: pc.disabledModels ?? [],
         authType: pc.authType,
+        custom: !!pc.custom,
+        customCompatibility: pc.custom?.compatibility,
+        logoUrl: pc.custom?.logoFile ? `/api/provider-logos/${pc.custom.logoFile}` : undefined,
         oauth: oauth?.accessToken
           ? {
               loggedIn: true,
@@ -41,6 +52,96 @@ export function registerProviderRoutes(app: Hono, runtime: PanelRuntime): void {
     return c.json(await provider.testConnection());
   });
 
+  app.post("/api/custom-providers/test", async (c) => {
+    const body = await c.req
+      .json<{ slug?: string; name?: string; baseUrl?: string; apiKey?: string }>()
+      .catch(() => ({}));
+    const parsed = parseCustomProviderFields(body);
+    if (!parsed.ok) return c.json({ ok: false, latencyMs: 0, error: parsed.error }, 400);
+    const provider = createTempCustomProvider(parsed.config);
+    const result = await provider.testConnection();
+    const models = result.ok ? await provider.listModels().catch(() => [] as ModelInfo[]) : [];
+    return c.json({ ...result, models });
+  });
+
+  app.post("/api/custom-providers", async (c) => {
+    const form = await c.req.parseBody();
+    const parsed = parseCustomProviderFields(form);
+    if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+
+    const config = structuredClone(runtime.currentConfig());
+    if (config.providers[parsed.slug]) {
+      return c.json({ error: `Provider slug "${parsed.slug}" already exists` }, 409);
+    }
+
+    let logoFile: string | undefined;
+    try {
+      logoFile = await saveProviderLogo(parsed.slug, form.logo);
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : "Invalid logo file" }, 400);
+    }
+    config.providers[parsed.slug] = {
+      ...parsed.config,
+      enabled: true,
+      custom: {
+        label: parsed.label,
+        slug: parsed.slug,
+        logoFile,
+        compatibility: parsed.compatibility,
+      },
+    };
+    if (!config.activeProvider || !config.providers[config.activeProvider]?.enabled) {
+      config.activeProvider = parsed.slug;
+    }
+    runtime.saveAndUpdateConfig(config);
+    return c.json({ ok: true, id: parsed.slug });
+  });
+
+  app.delete("/api/custom-providers/:id", (c) => {
+    const id = c.req.param("id");
+    const config = structuredClone(runtime.currentConfig());
+    const provider = config.providers[id];
+    if (!provider?.custom) return c.json({ error: "Custom provider not found" }, 404);
+
+    if (provider.custom.logoFile) {
+      rmSync(join(getProviderLogoDir(), provider.custom.logoFile), { force: true });
+    }
+    getSecretStore().delete(SECRET_KEYS.providerApiKey(id));
+    delete config.providers[id];
+    for (const rule of Object.values(config.routing)) {
+      if (rule.providerId === id) {
+        rule.enabled = false;
+        rule.providerId = "";
+        rule.model = "";
+      }
+    }
+    config.modelFallbacks = config.modelFallbacks.map((fallback) => ({
+      ...fallback,
+      models: fallback.models.filter((model) => model.providerId !== id),
+    }));
+    config.panelSettings.favoriteProviders = config.panelSettings.favoriteProviders.filter(
+      (providerId) => providerId !== id,
+    );
+    if (config.activeProvider === id) {
+      config.activeProvider =
+        Object.entries(config.providers).find(([, pc]) => pc.enabled)?.[0] ?? "nvidia_nim";
+    }
+    runtime.saveAndUpdateConfig(config);
+    return c.json({ ok: true });
+  });
+
+  app.get("/api/provider-logos/:file", (c) => {
+    const file = c.req.param("file");
+    if (!/^[a-zA-Z0-9_-]+\.(png|webp)$/.test(file)) return c.body(null, 404);
+    try {
+      const bytes = readFileSync(join(getProviderLogoDir(), file));
+      const type = file.endsWith(".png") ? "image/png" : "image/webp";
+      return c.body(bytes, 200, { "Content-Type": type, "Cache-Control": "no-store" });
+    } catch {
+      return c.body(null, 404);
+    }
+  });
+
   app.get("/api/models/:providerId", async (c) => {
     const id = c.req.param("providerId") as ProviderId;
     const provider = runtime.registry.get(id);
@@ -57,13 +158,111 @@ export function registerProviderRoutes(app: Hono, runtime: PanelRuntime): void {
     const options = (await Promise.all(
       enabledProviders.map(async (id) => ({
         id,
-        label: PROVIDER_LABELS[id] ?? id,
+        label:
+          config.providers[id].custom?.label ??
+          PROVIDER_LABELS[id as keyof typeof PROVIDER_LABELS] ??
+          id,
         models: await listSelectableModels(runtime, id),
       })),
     )) satisfies RoutingOption[];
 
     return c.json(options);
   });
+}
+
+type CustomFields = Record<string, unknown>;
+
+function parseCustomProviderFields(fields: CustomFields):
+  | {
+      ok: true;
+      slug: string;
+      label: string;
+      compatibility: "openai" | "anthropic";
+      config: ProviderConfig;
+    }
+  | { ok: false; error: string } {
+  const label = stringField(fields.name)?.trim();
+  const slug = normalizeSlug(stringField(fields.slug));
+  const baseUrl = stringField(fields.baseUrl)?.trim().replace(/\/+$/, "");
+  const apiKey = stringField(fields.apiKey)?.trim();
+  const compatibility = parseCompatibility(fields.compatibility);
+  if (!label) return { ok: false, error: "Provider name is required" };
+  if (!slug)
+    return { ok: false, error: "Slug must start with a letter and use letters, numbers, _ or -" };
+  if (!baseUrl || (!baseUrl.startsWith("http://") && !baseUrl.startsWith("https://"))) {
+    return { ok: false, error: "Base URL must start with http:// or https://" };
+  }
+  if (!apiKey) return { ok: false, error: "API key is required" };
+  return {
+    ok: true,
+    slug,
+    label,
+    compatibility,
+    config: {
+      enabled: true,
+      apiKey,
+      authType: "api_key",
+      models: [],
+      disabledModels: [],
+      baseUrl,
+      rateLimit: 40,
+      rateWindow: 60,
+      maxConcurrency: 5,
+      custom: { label, slug, compatibility },
+    },
+  };
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function normalizeSlug(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const slug = value.trim().replace(/^--/, "");
+  return /^[a-zA-Z][a-zA-Z0-9_-]{1,62}$/.test(slug) ? slug : null;
+}
+
+function parseCompatibility(value: unknown): "openai" | "anthropic" {
+  return value === "anthropic" ? "anthropic" : "openai";
+}
+
+async function saveProviderLogo(slug: string, value: unknown): Promise<string | undefined> {
+  if (!(value instanceof File) || value.size === 0) return undefined;
+  if (value.type !== "image/png" && value.type !== "image/webp") {
+    throw new Error("Logo must be a PNG or WebP image");
+  }
+  const ext = value.type === "image/png" ? ".png" : extname(value.name).toLowerCase() || ".webp";
+  const file = `${slug}${ext === ".png" ? ".png" : ".webp"}`;
+  mkdirSync(getProviderLogoDir(), { recursive: true });
+  writeFileSync(join(getProviderLogoDir(), file), Buffer.from(await value.arrayBuffer()));
+  return file;
+}
+
+function createTempCustomProvider(config: ProviderConfig) {
+  return config.custom?.compatibility === "anthropic"
+    ? new TempCustomAnthropicProvider(config)
+    : new TempCustomOpenAIProvider(config);
+}
+
+class TempCustomOpenAIProvider extends OpenAIChatTransport {
+  get id() {
+    return this.config.custom?.slug ?? "custom";
+  }
+
+  get label() {
+    return this.config.custom?.label ?? "Custom Provider";
+  }
+}
+
+class TempCustomAnthropicProvider extends AnthropicMessagesTransport {
+  get id() {
+    return this.config.custom?.slug ?? "custom";
+  }
+
+  get label() {
+    return this.config.custom?.label ?? "Custom Provider";
+  }
 }
 
 async function listSelectableModels(

--- a/packages/daemon/src/panel/routes/shell-routes.ts
+++ b/packages/daemon/src/panel/routes/shell-routes.ts
@@ -1,5 +1,5 @@
 import type { Hono } from "hono";
-import type { ProviderId } from "../../config/schema.js";
+import type { BuiltInProviderId, ProviderId } from "../../config/schema.js";
 import { CLI_FLAGS, PROVIDER_LABELS } from "../../config/schema.js";
 import type {
   InstallShellSetupResponse,
@@ -92,13 +92,13 @@ export function registerShellRoutes(app: Hono, runtime: PanelRuntime): void {
 }
 
 function buildQuickLaunchProviders(config: ReturnType<PanelRuntime["currentConfig"]>) {
-  const providers: Array<{ id: string; label: string; cli: string }> = (
-    Object.entries(config.providers) as [ProviderId, (typeof config.providers)[ProviderId]][]
+  const providers: Array<{ id: string; label: string; cli: string }> = Object.entries(
+    config.providers,
   )
     .filter(([, pc]) => pc.enabled)
-    .map(([id]) => ({
+    .map(([id, pc]) => ({
       id,
-      label: PROVIDER_LABELS[id] ?? id,
+      label: pc.custom?.label ?? PROVIDER_LABELS[id as BuiltInProviderId] ?? id,
       cli: `ccpg ${flagFor(id) ?? `--${id}`}`,
     }));
   return providers.concat(

--- a/packages/daemon/src/panel/routes/status-routes.ts
+++ b/packages/daemon/src/panel/routes/status-routes.ts
@@ -1,5 +1,4 @@
 import type { Hono } from "hono";
-import type { ProviderId } from "../../config/schema.js";
 import { PROVIDER_LABELS } from "../../config/schema.js";
 import { addLogListener, getLogBuffer } from "../../observability/log.js";
 import { getDaemonStatus } from "../../runtime/process.js";
@@ -31,13 +30,11 @@ export function registerStatusRoutes(app: Hono, runtime: PanelRuntime): void {
   app.get("/api/stats", (c) => {
     const config = runtime.currentConfig();
     const runtimeStats = getStats();
-    const providers = (
-      Object.entries(config.providers) as [ProviderId, (typeof config.providers)[ProviderId]][]
-    )
+    const providers = Object.entries(config.providers)
       .filter(([, pc]) => pc.enabled)
       .map(([id, pc]) => ({
         id,
-        label: PROVIDER_LABELS[id] ?? id,
+        label: pc.custom?.label ?? PROVIDER_LABELS[id as keyof typeof PROVIDER_LABELS] ?? id,
         baseUrl: pc.baseUrl,
         hasKey: !!pc.apiKey,
         ...(runtimeStats[id] ?? {

--- a/packages/daemon/src/proxy/model-router.ts
+++ b/packages/daemon/src/proxy/model-router.ts
@@ -14,6 +14,8 @@ export type ResolvedModel =
 
 type ProviderResolvedModel = Extract<ResolvedModel, { providerId: ProviderId }>;
 
+const RESERVED_PROVIDER_IDS = new Set(["anthropic", "chain", "fallback"]);
+
 const CLAUDE_OPUS_PATTERN = /claude-(3-opus|opus)/i;
 const CLAUDE_SONNET_PATTERN = /claude-(3[.-]5?-sonnet|sonnet)/i;
 const CLAUDE_HAIKU_PATTERN = /claude-(3-haiku|haiku)/i;
@@ -48,6 +50,7 @@ export function resolveModel(requestedModel: string, config: Config): ResolvedMo
 
   // Direct provider/model syntax: "nvidia_nim/z-ai/glm4.7"
   for (const pid of Object.keys(config.providers)) {
+    if (RESERVED_PROVIDER_IDS.has(pid) || !config.providers[pid].enabled) continue;
     if (model.startsWith(`${pid}/`)) {
       return { providerId: pid, providerModel: model.slice(pid.length + 1), source: "prefix" };
     }

--- a/packages/daemon/src/proxy/model-router.ts
+++ b/packages/daemon/src/proxy/model-router.ts
@@ -1,5 +1,4 @@
 import type { Config, ModelFallbackConfig, ProviderId, RoutingRule } from "../config/schema.js";
-import { PROVIDER_IDS } from "../config/schema.js";
 
 export type ResolvedModel =
   | {
@@ -48,7 +47,7 @@ export function resolveModel(requestedModel: string, config: Config): ResolvedMo
   if (requestedFallback) return { source: "fallback", fallback: requestedFallback };
 
   // Direct provider/model syntax: "nvidia_nim/z-ai/glm4.7"
-  for (const pid of PROVIDER_IDS) {
+  for (const pid of Object.keys(config.providers)) {
     if (model.startsWith(`${pid}/`)) {
       return { providerId: pid, providerModel: model.slice(pid.length + 1), source: "prefix" };
     }

--- a/packages/daemon/src/proxy/providers/provider-factory.ts
+++ b/packages/daemon/src/proxy/providers/provider-factory.ts
@@ -1,4 +1,4 @@
-import type { Config, ProviderConfig, ProviderId } from "../../config/schema.js";
+import type { BuiltInProviderId, Config, ProviderConfig } from "../../config/schema.js";
 import { PROVIDER_LABELS } from "../../config/schema.js";
 import type { BaseProvider } from "./base.js";
 import { AnthropicMessagesTransport } from "./transport-anthropic.js";
@@ -13,7 +13,7 @@ interface ProviderFactoryOptions {
 }
 
 export function createOpenAIProvider(
-  id: ProviderId,
+  id: BuiltInProviderId,
   options: ProviderFactoryOptions = {},
 ): ProviderConstructor {
   return class ConfiguredOpenAIProvider extends OpenAIChatTransport {
@@ -36,7 +36,7 @@ export function createOpenAIProvider(
 }
 
 export function createAnthropicProvider(
-  id: ProviderId,
+  id: BuiltInProviderId,
   options: ProviderFactoryOptions = {},
 ): ProviderConstructor {
   return class ConfiguredAnthropicProvider extends AnthropicMessagesTransport {

--- a/packages/daemon/src/proxy/providers/registry.ts
+++ b/packages/daemon/src/proxy/providers/registry.ts
@@ -101,12 +101,16 @@ export class ProviderRegistry {
   }
 
   private constructorFor(id: string, providerConfig: ProviderConfig): ProviderConstructor | null {
+    if (providerConfig.custom) {
+      if ((PROVIDER_IDS as readonly string[]).includes(id)) return null;
+      if (providerConfig.custom.compatibility === "openai") return createCustomOpenAIProvider(id);
+      if (providerConfig.custom.compatibility === "anthropic") {
+        return createCustomAnthropicProvider(id);
+      }
+      return null;
+    }
     if ((PROVIDER_IDS as readonly string[]).includes(id)) {
       return PROVIDER_MAP[id as BuiltInProviderId];
-    }
-    if (providerConfig.custom?.compatibility === "openai") return createCustomOpenAIProvider(id);
-    if (providerConfig.custom?.compatibility === "anthropic") {
-      return createCustomAnthropicProvider(id);
     }
     return null;
   }

--- a/packages/daemon/src/proxy/providers/registry.ts
+++ b/packages/daemon/src/proxy/providers/registry.ts
@@ -1,4 +1,4 @@
-import type { Config, ProviderConfig, ProviderId } from "../../config/schema.js";
+import type { BuiltInProviderId, Config, ProviderConfig, ProviderId } from "../../config/schema.js";
 import { PROVIDER_IDS } from "../../config/schema.js";
 import type { BaseProvider } from "./base.js";
 import { ClineProvider } from "./cline.js";
@@ -13,10 +13,12 @@ import { OllamaProvider } from "./ollama.js";
 import { OllamaCloudProvider } from "./ollama-cloud.js";
 import { OpenAIAccountProvider } from "./openai-account.js";
 import { createAnthropicProvider, createOpenAIProvider } from "./provider-factory.js";
+import { AnthropicMessagesTransport } from "./transport-anthropic.js";
+import { OpenAIChatTransport } from "./transport-openai.js";
 
 type ProviderConstructor = new (config: ProviderConfig, rootConfig: Config) => BaseProvider;
 
-const PROVIDER_MAP: Record<ProviderId, ProviderConstructor> = {
+const PROVIDER_MAP: Record<BuiltInProviderId, ProviderConstructor> = {
   openai_account: OpenAIAccountProvider,
   copilot: CopilotProvider,
   nvidia_nim: createOpenAIProvider("nvidia_nim"),
@@ -63,7 +65,7 @@ const PROVIDER_MAP: Record<ProviderId, ProviderConstructor> = {
 };
 
 export class ProviderRegistry {
-  private cache = new Map<ProviderId, BaseProvider>();
+  private cache = new Map<string, BaseProvider>();
 
   constructor(private config: Config) {}
 
@@ -72,7 +74,8 @@ export class ProviderRegistry {
     if (!providerConfig?.enabled) return null;
 
     if (!this.cache.has(id)) {
-      const Ctor = PROVIDER_MAP[id];
+      const Ctor = this.constructorFor(id, providerConfig);
+      if (!Ctor) return null;
       this.cache.set(id, new Ctor(providerConfig, this.config));
     }
 
@@ -88,12 +91,47 @@ export class ProviderRegistry {
     this.cache.clear();
   }
 
-  all(): Array<{ id: ProviderId; provider: BaseProvider }> {
-    const result: Array<{ id: ProviderId; provider: BaseProvider }> = [];
-    for (const id of PROVIDER_IDS) {
+  all(): Array<{ id: string; provider: BaseProvider }> {
+    const result: Array<{ id: string; provider: BaseProvider }> = [];
+    for (const id of Object.keys(this.config.providers)) {
       const p = this.get(id);
       if (p) result.push({ id, provider: p });
     }
     return result;
   }
+
+  private constructorFor(id: string, providerConfig: ProviderConfig): ProviderConstructor | null {
+    if ((PROVIDER_IDS as readonly string[]).includes(id)) {
+      return PROVIDER_MAP[id as BuiltInProviderId];
+    }
+    if (providerConfig.custom?.compatibility === "openai") return createCustomOpenAIProvider(id);
+    if (providerConfig.custom?.compatibility === "anthropic") {
+      return createCustomAnthropicProvider(id);
+    }
+    return null;
+  }
+}
+
+function createCustomOpenAIProvider(id: string): ProviderConstructor {
+  return class CustomOpenAIProvider extends OpenAIChatTransport {
+    get id() {
+      return id;
+    }
+
+    get label() {
+      return this.config.custom?.label ?? id;
+    }
+  };
+}
+
+function createCustomAnthropicProvider(id: string): ProviderConstructor {
+  return class CustomAnthropicProvider extends AnthropicMessagesTransport {
+    get id() {
+      return id;
+    }
+
+    get label() {
+      return this.config.custom?.label ?? id;
+    }
+  };
 }

--- a/packages/panel/README.md
+++ b/packages/panel/README.md
@@ -46,7 +46,7 @@ The panel exposes the following pages:
 |------|------|-------------|
 | **Dashboard** | `/` | System status overview, enabled provider count, quick launch, and shell setup instructions. |
 | **Live Session** | `/live` | Real-time monitoring of the active Claude Code session, including request logs, model stats, and provider latency. |
-| **Providers** | `/providers` | Add, configure, test, reorder, and favorite LLM providers. Supports search and status filtering. |
+| **Providers** | `/providers` | Add custom OpenAI/Anthropic-compatible providers, configure, test, reorder, and favorite LLM providers. Supports search and status filtering. |
 | **Model Chain** | `/model-chain` | Create custom fallback chains from active provider models. Chains try models in priority order on failure. |
 | **Routing** | `/routing` | Map Claude model tiers (Opus, Sonnet, Haiku) to specific providers and models. |
 | **History** | `/history` | Browse completed session history with request details, token counts, latency, and response previews. |
@@ -57,7 +57,7 @@ The panel exposes the following pages:
 
 The panel communicates with the CCPG daemon through a typed HTTP client in `src/shared/api/`:
 
-- **`client.ts`** — `request<T>(path, init?)` wraps `fetch` with JSON serialization and error handling via `ApiError`.
+- **`client.ts`** — `request<T>(path, init?)` wraps `fetch` with JSON serialization and error handling via `ApiError`. It preserves browser-generated multipart boundaries for `FormData` uploads such as custom provider logos.
 - **`http.ts`** — Convenience methods (`http.get`, `http.put`, `http.post`, `http.delete`) for standard CRUD operations.
 - **`base.ts`** — Resolves the API base URL, defaulting to `http://127.0.0.1:6767`; automatically detected in Tauri runtime.
 

--- a/packages/panel/src/features/providers/components/config/AddCustomProviderModal.tsx
+++ b/packages/panel/src/features/providers/components/config/AddCustomProviderModal.tsx
@@ -1,0 +1,183 @@
+import { CheckCircleOutlined, PlusOutlined } from "@ant-design/icons";
+import { Alert, Button, Form, Input, Modal, Space, Tag, Typography, Upload } from "antd";
+import type { UploadFile } from "antd/es/upload/interface";
+import { useState } from "react";
+import type { ModelInfo, TestResult } from "../../domain/types.js";
+import type { CustomProviderDraft } from "../../services/providersService.js";
+
+const { Text } = Typography;
+
+interface AddCustomProviderModalProps {
+  open: boolean;
+  testing: boolean;
+  compatibility: "openai" | "anthropic";
+  onCancel: () => void;
+  onTest: (
+    draft: CustomProviderDraft,
+  ) => Promise<(TestResult & { models?: ModelInfo[] }) | TestResult>;
+  onCreate: (draft: CustomProviderDraft) => Promise<string | null>;
+  onCreated: (id: string) => void;
+}
+
+interface FormValues {
+  name: string;
+  slug: string;
+  baseUrl: string;
+  apiKey: string;
+  logo?: UploadFile[];
+}
+
+export function AddCustomProviderModal({
+  open,
+  testing,
+  compatibility,
+  onCancel,
+  onTest,
+  onCreate,
+  onCreated,
+}: AddCustomProviderModalProps) {
+  const [form] = Form.useForm<FormValues>();
+  const [testResult, setTestResult] = useState<(TestResult & { models?: ModelInfo[] }) | null>(
+    null,
+  );
+  const [creating, setCreating] = useState(false);
+
+  const draftFromForm = async (): Promise<CustomProviderDraft> => {
+    const values = await form.validateFields();
+    return {
+      name: values.name.trim(),
+      slug: values.slug.trim(),
+      baseUrl: values.baseUrl.trim(),
+      apiKey: values.apiKey.trim(),
+      compatibility,
+      logo: values.logo?.[0]?.originFileObj ?? null,
+    };
+  };
+
+  const handleTest = async () => {
+    const result = await onTest(await draftFromForm());
+    setTestResult(result as TestResult & { models?: ModelInfo[] });
+  };
+
+  const handleCreate = async () => {
+    setCreating(true);
+    try {
+      const id = await onCreate(await draftFromForm());
+      if (id) {
+        form.resetFields();
+        setTestResult(null);
+        onCreated(id);
+      }
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Modal
+      title={`Add ${compatibility === "anthropic" ? "Anthropic" : "OpenAI"} Compatible Provider`}
+      open={open}
+      onCancel={onCancel}
+      width={620}
+      destroyOnClose
+      footer={[
+        <Button key="test" loading={testing} onClick={handleTest}>
+          Test Connection
+        </Button>,
+        <Button key="cancel" onClick={onCancel}>
+          Cancel
+        </Button>,
+        <Button key="create" type="primary" loading={creating} onClick={handleCreate}>
+          Add Provider
+        </Button>,
+      ]}
+    >
+      <Form form={form} layout="vertical" requiredMark={false} preserve={false}>
+        <Form.Item
+          name="name"
+          label="Name"
+          rules={[{ required: true, message: "Provider name is required" }]}
+        >
+          <Input placeholder="Acme AI" />
+        </Form.Item>
+
+        <Form.Item
+          name="slug"
+          label="Slug"
+          rules={[
+            { required: true, message: "Slug is required" },
+            {
+              pattern: /^[a-zA-Z][a-zA-Z0-9_-]{1,62}$/,
+              message: "Start with a letter; use letters, numbers, _ or -",
+            },
+          ]}
+        >
+          <Input placeholder="acme_ai" />
+        </Form.Item>
+
+        <Form.Item
+          name="baseUrl"
+          label="Base URL"
+          rules={[
+            { required: true, message: "Base URL is required" },
+            { type: "url", message: "Use a valid http:// or https:// URL" },
+          ]}
+        >
+          <Input placeholder="https://api.example.com/v1" />
+        </Form.Item>
+
+        <Form.Item
+          name="apiKey"
+          label="API Key"
+          rules={[{ required: true, message: "API key is required" }]}
+        >
+          <Input.Password placeholder="sk-..." autoComplete="off" />
+        </Form.Item>
+
+        <Form.Item
+          name="logo"
+          label="Logo"
+          valuePropName="fileList"
+          getValueFromEvent={(event) => event.fileList}
+        >
+          <Upload
+            accept="image/png,image/webp"
+            maxCount={1}
+            listType="picture"
+            beforeUpload={() => false}
+          >
+            <Button icon={<PlusOutlined />}>Upload PNG or WebP</Button>
+          </Upload>
+        </Form.Item>
+      </Form>
+
+      {testResult && (
+        <Alert
+          type={testResult.ok ? "success" : "warning"}
+          showIcon
+          icon={testResult.ok ? <CheckCircleOutlined /> : undefined}
+          message={
+            testResult.ok
+              ? `${testResult.models?.length ?? testResult.modelCount ?? 0} models discovered`
+              : testResult.error || "Discovery failed"
+          }
+          description={
+            testResult.ok && testResult.models?.length ? (
+              <Space wrap style={{ marginTop: 8 }}>
+                {testResult.models.slice(0, 8).map((model) => (
+                  <Tag key={model.id}>{model.id.replace(/^anthropic\/[^/]+\//, "")}</Tag>
+                ))}
+                {testResult.models.length > 8 && (
+                  <Text type="secondary">+{testResult.models.length - 8} more</Text>
+                )}
+              </Space>
+            ) : (
+              "You can still add the provider and enter Manual models from its details."
+            )
+          }
+          style={{ marginTop: 16 }}
+        />
+      )}
+    </Modal>
+  );
+}

--- a/packages/panel/src/features/providers/components/config/ConfirmModal.tsx
+++ b/packages/panel/src/features/providers/components/config/ConfirmModal.tsx
@@ -32,6 +32,13 @@ const COPY = {
     okText: "Update",
     danger: false,
   },
+  "delete-provider": {
+    title: "Delete custom provider?",
+    text: (label: string) =>
+      `${label} will be permanently removed, including its API key, routing rules, and logo.`,
+    okText: "Delete",
+    danger: true,
+  },
 } as const;
 
 export function ConfirmModal({ action, providers, onCancel, onConfirm }: ConfirmModalProps) {

--- a/packages/panel/src/features/providers/components/config/ModelPickerSection.tsx
+++ b/packages/panel/src/features/providers/components/config/ModelPickerSection.tsx
@@ -13,6 +13,7 @@ const { Text } = Typography;
 interface ModelPickerSectionProps {
   models: string[];
   suggestions?: SuggestedModel[];
+  title?: string;
   placeholder?: string;
   onAdd: (model: string) => void;
   onRemove: (model: string) => void;
@@ -21,6 +22,7 @@ interface ModelPickerSectionProps {
 export function ModelPickerSection({
   models,
   suggestions,
+  title = "Extra models",
   placeholder = "provider/model-id",
   onAdd,
   onRemove,
@@ -65,7 +67,7 @@ export function ModelPickerSection({
       <Text type="secondary">
         <Space>
           <PlusOutlined />
-          Extra models
+          {title}
         </Space>
       </Text>
 

--- a/packages/panel/src/features/providers/components/config/ProviderConfigContent.tsx
+++ b/packages/panel/src/features/providers/components/config/ProviderConfigContent.tsx
@@ -54,8 +54,37 @@ export function ProviderConfigContent({
   // Show picker when: API key provider, ready, discovery returned nothing.
   // Also always show if already has manually configured models (so they're editable).
   const showPicker =
-    providerKind === "api-key" &&
-    ((discoveredEmpty && ready) || (provider.models ?? []).length > 0);
+    provider.custom ||
+    (providerKind === "api-key" &&
+      ((discoveredEmpty && ready) || (provider.models ?? []).length > 0));
+
+  const apiKeySection = providerKind === "api-key" && (
+    <ApiKeySection
+      hasKey={provider.hasKey}
+      keyPreview={provider.keyPreview}
+      onSave={(value) => handlers.onSaveKey(provider.id, value)}
+      onRequestRemove={() => handlers.onRequestRemoveKey(provider.id)}
+      onRequestReplace={(value) => handlers.onRequestReplaceKey(provider.id, value)}
+    />
+  );
+
+  const modelPickerSection = showPicker && (
+    <ModelPickerSection
+      models={provider.models ?? []}
+      suggestions={SUGGESTED_MODELS[provider.id as keyof typeof SUGGESTED_MODELS]}
+      title={provider.custom ? "Manual models" : "Extra models"}
+      placeholder="provider/model-id"
+      onAdd={(model) => handlers.onAddModel(provider, model)}
+      onRemove={(model) => handlers.onRemoveModel(provider, model)}
+    />
+  );
+
+  const baseUrlSection = (providerKind === "local" || provider.custom) && (
+    <BaseUrlSection
+      baseUrl={provider.baseUrl}
+      onRequestChange={(url) => handlers.onRequestChangeUrl(provider.id, url)}
+    />
+  );
 
   return (
     <Flex vertical gap="large" style={{ marginTop: 24 }}>
@@ -69,31 +98,18 @@ export function ProviderConfigContent({
         />
       )}
 
-      {providerKind === "api-key" && (
-        <ApiKeySection
-          hasKey={provider.hasKey}
-          keyPreview={provider.keyPreview}
-          onSave={(value) => handlers.onSaveKey(provider.id, value)}
-          onRequestRemove={() => handlers.onRequestRemoveKey(provider.id)}
-          onRequestReplace={(value) => handlers.onRequestReplaceKey(provider.id, value)}
-        />
-      )}
-
-      {showPicker && (
-        <ModelPickerSection
-          models={provider.models ?? []}
-          suggestions={SUGGESTED_MODELS[provider.id as keyof typeof SUGGESTED_MODELS]}
-          placeholder="provider/model-id"
-          onAdd={(model) => handlers.onAddModel(provider, model)}
-          onRemove={(model) => handlers.onRemoveModel(provider, model)}
-        />
-      )}
-
-      {providerKind === "local" && (
-        <BaseUrlSection
-          baseUrl={provider.baseUrl}
-          onRequestChange={(url) => handlers.onRequestChangeUrl(provider.id, url)}
-        />
+      {provider.custom ? (
+        <>
+          {baseUrlSection}
+          {apiKeySection}
+          {modelPickerSection}
+        </>
+      ) : (
+        <>
+          {apiKeySection}
+          {modelPickerSection}
+          {baseUrlSection}
+        </>
       )}
 
       {provider.enabled && (

--- a/packages/panel/src/features/providers/components/config/ProviderConfigModal.tsx
+++ b/packages/panel/src/features/providers/components/config/ProviderConfigModal.tsx
@@ -9,6 +9,7 @@ import { ProviderConfigContent, type ProviderConfigHandlers } from "./ProviderCo
 
 export interface ProviderConfigModalHandlers extends ProviderConfigHandlers {
   onTest: (id: string) => void;
+  onRequestDeleteProvider: (id: string) => void;
 }
 
 export interface ProviderConfigModalProps {
@@ -42,6 +43,11 @@ export function ProviderConfigModal({
       open={open}
       onCancel={onClose}
       footer={[
+        p.custom && (
+          <Button key="delete" danger onClick={() => handlers.onRequestDeleteProvider(p.id)}>
+            Delete Provider
+          </Button>
+        ),
         <Button
           key="test"
           loading={testing}
@@ -87,7 +93,12 @@ function ProviderConfigTitle({
       }}
     >
       <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-        <ProviderLogo providerId={provider.id} label={provider.label} size={28} />
+        <ProviderLogo
+          providerId={provider.id}
+          label={provider.label}
+          logoUrl={provider.logoUrl}
+          size={28}
+        />
         <span style={{ fontSize: 18 }}>{provider.label} Configuration</span>
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>

--- a/packages/panel/src/features/providers/components/grid/ProviderCard.tsx
+++ b/packages/panel/src/features/providers/components/grid/ProviderCard.tsx
@@ -77,7 +77,7 @@ export function ProviderCard({
         style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 12, minWidth: 0, flex: 1 }}>
-          <ProviderLogo providerId={p.id} label={p.label} size={42} />
+          <ProviderLogo providerId={p.id} label={p.label} logoUrl={p.logoUrl} size={42} />
           <div
             style={{
               display: "flex",

--- a/packages/panel/src/features/providers/components/grid/ProviderCard.tsx
+++ b/packages/panel/src/features/providers/components/grid/ProviderCard.tsx
@@ -1,5 +1,5 @@
 import { StarFilled, StarOutlined } from "@ant-design/icons";
-import { Badge, Button, Card, Space, Switch, Tag, Tooltip, Typography, theme } from "antd";
+import { Badge, Button, Card, Space, Switch, Tag, Typography, theme } from "antd";
 import { COMING_SOON_PROVIDERS } from "../../domain/constants.js";
 import { isProviderReady } from "../../domain/status.js";
 import type { ProviderInfo, TestResult } from "../../domain/types.js";
@@ -107,11 +107,7 @@ export function ProviderCard({
             </Space>
           </div>
         </div>
-        {comingSoon ? (
-          <Tooltip title="OAuth flow not yet implemented">
-            <Switch checked={false} disabled size="small" aria-label={`${p.label} — coming soon`} />
-          </Tooltip>
-        ) : (
+        {!comingSoon && (
           <Space size={8}>
             {onToggleFavorite && (
               <Button

--- a/packages/panel/src/features/providers/components/grid/ProviderLogo.tsx
+++ b/packages/panel/src/features/providers/components/grid/ProviderLogo.tsx
@@ -10,9 +10,10 @@ interface ProviderLogoProps {
 
 export function ProviderLogo({ providerId, label, size, logoUrl }: ProviderLogoProps) {
   const { token } = theme.useToken();
-  const [failedProviderId, setFailedProviderId] = useState<string | null>(null);
+  const [failedLogoSrc, setFailedLogoSrc] = useState<string | null>(null);
+  const src = logoUrl ?? `/providers/${providerId}.webp`;
 
-  if (failedProviderId === providerId) {
+  if (failedLogoSrc === src) {
     return (
       <Avatar
         shape="square"
@@ -28,7 +29,7 @@ export function ProviderLogo({ providerId, label, size, logoUrl }: ProviderLogoP
 
   return (
     <img
-      src={logoUrl ?? `/providers/${providerId}.webp`}
+      src={src}
       alt=""
       aria-hidden="true"
       style={{
@@ -37,7 +38,7 @@ export function ProviderLogo({ providerId, label, size, logoUrl }: ProviderLogoP
         objectFit: "contain",
         flexShrink: 0,
       }}
-      onError={() => setFailedProviderId(providerId)}
+      onError={() => setFailedLogoSrc(src)}
     />
   );
 }

--- a/packages/panel/src/features/providers/components/grid/ProviderLogo.tsx
+++ b/packages/panel/src/features/providers/components/grid/ProviderLogo.tsx
@@ -5,9 +5,10 @@ interface ProviderLogoProps {
   providerId: string;
   label: string;
   size: number;
+  logoUrl?: string;
 }
 
-export function ProviderLogo({ providerId, label, size }: ProviderLogoProps) {
+export function ProviderLogo({ providerId, label, size, logoUrl }: ProviderLogoProps) {
   const { token } = theme.useToken();
   const [failedProviderId, setFailedProviderId] = useState<string | null>(null);
 
@@ -27,7 +28,7 @@ export function ProviderLogo({ providerId, label, size }: ProviderLogoProps) {
 
   return (
     <img
-      src={`/providers/${providerId}.webp`}
+      src={logoUrl ?? `/providers/${providerId}.webp`}
       alt=""
       aria-hidden="true"
       style={{

--- a/packages/panel/src/features/providers/components/page/ProviderTabs.tsx
+++ b/packages/panel/src/features/providers/components/page/ProviderTabs.tsx
@@ -1,11 +1,13 @@
-import { Alert, Empty, Flex, theme } from "antd";
+import { Alert, Col, Empty, Flex, Row, Typography, theme } from "antd";
 import type { ProviderGroup } from "../../domain/providerGroups.js";
 import type { ProviderInfo, TestResult } from "../../domain/types.js";
+import { ProviderCard } from "../grid/ProviderCard.js";
 import { ProviderGridSection } from "../grid/ProviderGridSection.js";
 import { SortableFavoritesGrid } from "../grid/SortableFavoritesGrid.js";
 
 interface AllProvidersTabProps {
   groups: ProviderGroup[];
+  customProviders: ProviderInfo[];
   testResults: Record<string, TestResult>;
   favorites: string[];
   onProviderSelect: (providerId: string) => void;
@@ -15,6 +17,7 @@ interface AllProvidersTabProps {
 
 export function AllProvidersTab({
   groups,
+  customProviders,
   testResults,
   favorites,
   onProviderSelect,
@@ -23,7 +26,7 @@ export function AllProvidersTab({
 }: AllProvidersTabProps) {
   const { token } = theme.useToken();
 
-  if (groups.length === 0) {
+  if (groups.length === 0 && customProviders.length === 0) {
     return (
       <Empty description="No providers found matching your filters" style={{ margin: "40px 0" }} />
     );
@@ -43,6 +46,70 @@ export function AllProvidersTab({
           onToggleFavorite={(provider) => onToggleFavorite(provider.id)}
         />
       ))}
+      <CustomProvidersSection
+        providers={customProviders}
+        testResults={testResults}
+        favorites={favorites}
+        onProviderSelect={(provider) => onProviderSelect(provider.id)}
+        onToggleEnabled={onToggleEnabled}
+        onToggleFavorite={(provider) => onToggleFavorite(provider.id)}
+      />
+    </Flex>
+  );
+}
+
+function CustomProvidersSection({
+  providers,
+  testResults,
+  favorites,
+  onProviderSelect,
+  onToggleEnabled,
+  onToggleFavorite,
+}: {
+  providers: ProviderInfo[];
+  testResults: Record<string, TestResult>;
+  favorites: string[];
+  onProviderSelect: (provider: ProviderInfo) => void;
+  onToggleEnabled: (id: string, currentlyEnabled: boolean) => void;
+  onToggleFavorite: (provider: ProviderInfo, event: React.MouseEvent) => void;
+}) {
+  const { token } = theme.useToken();
+
+  return (
+    <Flex vertical gap={token.paddingSM}>
+      <Typography.Title level={5} style={{ margin: 0, fontWeight: 600 }}>
+        Custom Providers (OpenAI/Anthropic Compatible)
+      </Typography.Title>
+
+      {providers.length === 0 ? (
+        <div
+          style={{
+            border: `1px dashed ${token.colorBorder}`,
+            borderRadius: token.borderRadiusLG,
+            color: token.colorTextSecondary,
+            padding: `${token.paddingSM}px ${token.paddingMD}px`,
+            textAlign: "center",
+          }}
+        >
+          No custom providers. Use the tab actions above to add OpenAI or Anthropic compatible
+          endpoints.
+        </div>
+      ) : (
+        <Row gutter={[token.paddingMD, token.paddingMD]} align="stretch">
+          {providers.map((provider) => (
+            <Col xs={24} sm={12} lg={8} xl={6} key={provider.id}>
+              <ProviderCard
+                provider={provider}
+                testResult={testResults[provider.id]}
+                onClick={onProviderSelect}
+                onToggleEnabled={onToggleEnabled}
+                isFavorite={favorites.includes(provider.id)}
+                onToggleFavorite={onToggleFavorite}
+              />
+            </Col>
+          ))}
+        </Row>
+      )}
     </Flex>
   );
 }

--- a/packages/panel/src/features/providers/components/page/ProvidersPage.tsx
+++ b/packages/panel/src/features/providers/components/page/ProvidersPage.tsx
@@ -1,6 +1,8 @@
-import { App, Flex, Tabs, Typography, theme } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import { App, Button, Flex, Tabs, Typography, theme } from "antd";
 import { PageHeader } from "../../../../shared/components/PageHeader.js";
 import { useProvidersPage } from "../../hooks/useProvidersPage.js";
+import { AddCustomProviderModal } from "../config/AddCustomProviderModal.js";
 import { ConfirmModal } from "../config/ConfirmModal.js";
 import { ProviderConfigModal } from "../config/ProviderConfigModal.js";
 import { ProviderGridSkeleton } from "../grid/ProviderCardSkeleton.js";
@@ -13,6 +15,10 @@ export default function ProvidersPage() {
   const { token } = theme.useToken();
   const { message } = App.useApp();
   const page = useProvidersPage({ message });
+  const openCustomProviderModal = (compatibility: "openai" | "anthropic") => {
+    page.setCustomCompatibility(compatibility);
+    page.setAddCustomOpen(true);
+  };
 
   return (
     <Flex vertical gap={token.paddingLG}>
@@ -28,6 +34,25 @@ export default function ProvidersPage() {
       <Tabs
         defaultActiveKey="all"
         onChange={page.resetFilters}
+        tabBarExtraContent={
+          <Flex gap={token.paddingXS} wrap>
+            <Button
+              size="small"
+              type="primary"
+              icon={<PlusOutlined />}
+              onClick={() => openCustomProviderModal("anthropic")}
+            >
+              Add Anthropic Compatible
+            </Button>
+            <Button
+              size="small"
+              icon={<PlusOutlined />}
+              onClick={() => openCustomProviderModal("openai")}
+            >
+              Add OpenAI Compatible
+            </Button>
+          </Flex>
+        }
         items={[
           {
             key: "all",
@@ -37,6 +62,7 @@ export default function ProvidersPage() {
             ) : (
               <AllProvidersTab
                 groups={page.providerGroups}
+                customProviders={page.customProviders}
                 testResults={page.providersApi.testResults}
                 favorites={page.favoritesApi.favorites}
                 onProviderSelect={page.setSelectedProviderId}
@@ -82,6 +108,19 @@ export default function ProvidersPage() {
         providers={page.providersApi.providers}
         onCancel={() => page.setConfirm(null)}
         onConfirm={page.runConfirmed}
+      />
+
+      <AddCustomProviderModal
+        open={page.addCustomOpen}
+        testing={page.providersApi.testing === "custom-provider"}
+        compatibility={page.customCompatibility}
+        onCancel={() => page.setAddCustomOpen(false)}
+        onTest={page.providersApi.testCustom}
+        onCreate={page.providersApi.createCustom}
+        onCreated={(id) => {
+          page.setAddCustomOpen(false);
+          page.setSelectedProviderId(id);
+        }}
       />
     </Flex>
   );

--- a/packages/panel/src/features/providers/domain/providerGroups.ts
+++ b/packages/panel/src/features/providers/domain/providerGroups.ts
@@ -22,7 +22,9 @@ export function groupProvidersByConfiguration(providers: ProviderInfo[]): Provid
     },
     {
       title: "API Key Providers",
-      providers: sortProvidersByLabel(providers.filter((provider) => isApiKeyProvider(provider))),
+      providers: sortProvidersByLabel(
+        providers.filter((provider) => isApiKeyProvider(provider) && !provider.custom),
+      ),
     },
   ].filter((group) => group.providers.length > 0);
 }

--- a/packages/panel/src/features/providers/domain/types.ts
+++ b/packages/panel/src/features/providers/domain/types.ts
@@ -15,7 +15,8 @@ export type TestResult = ProviderTestResult;
 export type ConfirmAction =
   | { kind: "replace-key"; providerId: string; newValue: string }
   | { kind: "remove-key"; providerId: string }
-  | { kind: "change-url"; providerId: string; newValue: string };
+  | { kind: "change-url"; providerId: string; newValue: string }
+  | { kind: "delete-provider"; providerId: string };
 
 export type CopilotFlow = CopilotOAuthStartResponse;
 export type OAuthStartResponse = OpenAIAccountOAuthStartResponse;

--- a/packages/panel/src/features/providers/hooks/useProviders.ts
+++ b/packages/panel/src/features/providers/hooks/useProviders.ts
@@ -173,9 +173,13 @@ export function useProviders() {
     async (draft: CustomProviderDraft) => {
       try {
         const result = await providersService.createCustom(draft);
-        message.success("Custom provider added");
-        refresh();
-        return result.id;
+        if (result.ok) {
+          message.success("Custom provider added");
+          refresh();
+          return result.id;
+        }
+        message.error("Failed to add custom provider");
+        return null;
       } catch {
         message.error("Failed to add custom provider");
         return null;

--- a/packages/panel/src/features/providers/hooks/useProviders.ts
+++ b/packages/panel/src/features/providers/hooks/useProviders.ts
@@ -2,7 +2,7 @@ import { App } from "antd";
 import { useCallback, useEffect, useState } from "react";
 import type { ProviderInfo, TestResult } from "../domain/types.js";
 import { mergeModelLists } from "../domain/utils.js";
-import { providersService } from "../services/providersService.js";
+import { type CustomProviderDraft, providersService } from "../services/providersService.js";
 
 export function useProviders() {
   const { message } = App.useApp();
@@ -147,6 +147,56 @@ export function useProviders() {
     [message],
   );
 
+  const testCustom = useCallback(
+    async (draft: CustomProviderDraft) => {
+      setTesting("custom-provider");
+      try {
+        const result = await providersService.testCustom(draft);
+        if (result.ok) {
+          message.success(`Connection test passed (${result.latencyMs}ms)`);
+        } else {
+          message.error(`Test failed: ${result.error ?? "Unknown error"}`);
+        }
+        return result;
+      } catch {
+        const result = { ok: false, latencyMs: 0, error: "Request failed" };
+        message.error("Connection test failed");
+        return result;
+      } finally {
+        setTesting(null);
+      }
+    },
+    [message],
+  );
+
+  const createCustom = useCallback(
+    async (draft: CustomProviderDraft) => {
+      try {
+        const result = await providersService.createCustom(draft);
+        message.success("Custom provider added");
+        refresh();
+        return result.id;
+      } catch {
+        message.error("Failed to add custom provider");
+        return null;
+      }
+    },
+    [refresh, message],
+  );
+
+  const deleteCustom = useCallback(
+    async (id: string) => {
+      try {
+        await providersService.deleteCustom(id);
+        message.success("Custom provider deleted");
+        refresh();
+      } catch {
+        message.error("Failed to delete custom provider");
+      }
+    },
+    [refresh, message],
+  );
+
   return {
     providers,
     isLoading,
@@ -161,5 +211,8 @@ export function useProviders() {
     addModel,
     removeModel,
     setDisabledModels,
+    testCustom,
+    createCustom,
+    deleteCustom,
   };
 }

--- a/packages/panel/src/features/providers/hooks/useProvidersPage.ts
+++ b/packages/panel/src/features/providers/hooks/useProvidersPage.ts
@@ -19,6 +19,8 @@ export function useProvidersPage({ message }: UseProvidersPageOptions) {
 
   const [confirm, setConfirm] = useState<ConfirmAction | null>(null);
   const [selectedProviderId, setSelectedProviderId] = useState<string | null>(null);
+  const [addCustomOpen, setAddCustomOpen] = useState(false);
+  const [customCompatibility, setCustomCompatibility] = useState<"openai" | "anthropic">("openai");
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState<ProviderStatusFilter>("all");
 
@@ -31,6 +33,11 @@ export function useProvidersPage({ message }: UseProvidersPageOptions) {
 
   const providerGroups = useMemo(
     () => groupProvidersByConfiguration(filteredProviders),
+    [filteredProviders],
+  );
+
+  const customProviders = useMemo(
+    () => filteredProviders.filter((provider) => provider.custom),
     [filteredProviders],
   );
 
@@ -72,6 +79,10 @@ export function useProvidersPage({ message }: UseProvidersPageOptions) {
       case "change-url":
         await providersApi.saveBaseUrl(confirm.providerId, confirm.newValue);
         break;
+      case "delete-provider":
+        await providersApi.deleteCustom(confirm.providerId);
+        setSelectedProviderId(null);
+        break;
     }
 
     setConfirm(null);
@@ -95,6 +106,7 @@ export function useProvidersPage({ message }: UseProvidersPageOptions) {
       onRequestRemoveKey: (providerId) => setConfirm({ kind: "remove-key", providerId }),
       onRequestChangeUrl: (providerId, newValue) =>
         setConfirm({ kind: "change-url", providerId, newValue }),
+      onRequestDeleteProvider: (providerId) => setConfirm({ kind: "delete-provider", providerId }),
       onAddModel: providersApi.addModel,
       onRemoveModel: providersApi.removeModel,
       onDisabledModelsChange: providersApi.setDisabledModels,
@@ -113,12 +125,17 @@ export function useProvidersPage({ message }: UseProvidersPageOptions) {
     activeProvider,
     filteredProviders,
     providerGroups,
+    customProviders,
     searchTerm,
     statusFilter,
     modalHandlers,
+    addCustomOpen,
+    customCompatibility,
     setSearchTerm,
     setStatusFilter,
     setSelectedProviderId,
+    setAddCustomOpen,
+    setCustomCompatibility,
     setConfirm,
     resetFilters,
     closeProviderModal,

--- a/packages/panel/src/features/providers/services/providersService.ts
+++ b/packages/panel/src/features/providers/services/providersService.ts
@@ -44,7 +44,7 @@ export const providersService = {
     if (draft.logo) form.set("logo", draft.logo);
     return http.post<{ ok: boolean; id: string }>("/custom-providers", form);
   },
-  deleteCustom: (id: string) => http.delete(`/custom-providers/${id}`),
+  deleteCustom: (id: string) => http.delete(`/custom-providers/${encodeURIComponent(id)}`),
   listModels: (id: string) => http.get<ModelInfo[]>(`/models/${id}`),
 
   setEnabled: (id: string, enabled: boolean) => patchConfig(id, { enabled }),

--- a/packages/panel/src/features/providers/services/providersService.ts
+++ b/packages/panel/src/features/providers/services/providersService.ts
@@ -16,6 +16,15 @@ interface ProviderPatch {
   disabledModels?: string[];
 }
 
+export interface CustomProviderDraft {
+  name: string;
+  slug: string;
+  baseUrl: string;
+  apiKey: string;
+  compatibility: "openai" | "anthropic";
+  logo?: File | null;
+}
+
 function patchConfig(providerId: string, patch: ProviderPatch) {
   return http.put("/config", { providers: { [providerId]: patch } });
 }
@@ -23,6 +32,19 @@ function patchConfig(providerId: string, patch: ProviderPatch) {
 export const providersService = {
   list: () => http.get<ProviderInfo[]>("/providers"),
   test: (id: string) => http.post<TestResult>(`/providers/${id}/test`),
+  testCustom: (draft: CustomProviderDraft) =>
+    http.post<TestResult & { models?: ModelInfo[] }>("/custom-providers/test", draft),
+  createCustom: (draft: CustomProviderDraft) => {
+    const form = new FormData();
+    form.set("name", draft.name);
+    form.set("slug", draft.slug);
+    form.set("baseUrl", draft.baseUrl);
+    form.set("apiKey", draft.apiKey);
+    form.set("compatibility", draft.compatibility);
+    if (draft.logo) form.set("logo", draft.logo);
+    return http.post<{ ok: boolean; id: string }>("/custom-providers", form);
+  },
+  deleteCustom: (id: string) => http.delete(`/custom-providers/${id}`),
   listModels: (id: string) => http.get<ModelInfo[]>(`/models/${id}`),
 
   setEnabled: (id: string, enabled: boolean) => patchConfig(id, { enabled }),

--- a/packages/panel/src/shared/api/client.ts
+++ b/packages/panel/src/shared/api/client.ts
@@ -12,9 +12,10 @@ export class ApiError extends Error {
 }
 
 export async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const isFormData = init?.body instanceof FormData;
   const res = await fetch(apiUrl(path), {
     ...init,
-    headers: { "Content-Type": "application/json", ...init?.headers },
+    headers: { ...(isFormData ? {} : { "Content-Type": "application/json" }), ...init?.headers },
   });
   if (!res.ok) {
     let body: unknown;

--- a/packages/panel/src/shared/api/http.ts
+++ b/packages/panel/src/shared/api/http.ts
@@ -7,7 +7,7 @@ export const http = {
   post: <T>(path: string, body?: unknown): Promise<T> =>
     request<T>(path, {
       method: "POST",
-      body: body !== undefined ? JSON.stringify(body) : undefined,
+      body: body instanceof FormData ? body : body !== undefined ? JSON.stringify(body) : undefined,
     }),
   delete: <T>(path: string): Promise<T> => request<T>(path, { method: "DELETE" }),
 };


### PR DESCRIPTION
This pull request updates documentation to clarify and highlight support for user-created custom providers—specifically OpenAI Chat Completions-compatible and Anthropic Messages-compatible endpoints. It explains when to use the new runtime custom provider flow versus adding a built-in provider, and documents the API, configuration, and UI changes related to custom providers. The updates also describe how users can add, test, and manage custom providers (including custom logos), and how these fit into the overall architecture and security model.

Key documentation and guidance updates:

**Custom Provider Support and Guidance**
- Added clear guidance in `CONTRIBUTING.md` and `docs/ADDING_PROVIDER.md` to prefer the runtime custom provider UI for plain OpenAI/Anthropic-compatible endpoints, reserving built-in providers for cases needing special handling or shipped metadata. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R80-R85) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L179-R192) [[3]](diffhunk://#diff-7e3e2983ee94122f9486cbe56ec1847ddf029f02e3844468ba477e88319daa13R8-R15)
- Updated checklists and provider addition instructions to reflect the distinction between built-in and custom providers. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L179-R192) [[2]](diffhunk://#diff-7e3e2983ee94122f9486cbe56ec1847ddf029f02e3844468ba477e88319daa13R8-R15)

**API and Configuration Documentation**
- Documented new REST API endpoints for creating, testing, and deleting custom providers, as well as serving uploaded custom provider logos.
- Explained how custom providers are addressed by user-chosen slugs in the CLI and how their compatibility is specified.
- Updated architecture docs to describe how the provider registry instantiates config-defined custom providers, and how custom provider logos are handled in the config directory. [[1]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R230-R234) [[2]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L336-R346) [[3]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R633)

**UI and User Experience**
- Clarified in the README and architecture docs that users can add custom OpenAI/Anthropic-compatible providers from the Providers UI, including uploading custom logos and specifying manual models when discovery is unavailable. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R58) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L105-R112) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R234) [[5]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R294-R303) [[6]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L404-R414)

**Security and Local Storage**
- Updated security documentation to note that API keys and logos for both built-in and custom providers are encrypted and stored locally, and to warn about sharing uploaded logo directories if they reveal private infrastructure. [[1]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L17-R17) [[2]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7R34) [[3]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L336-R346) [[4]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R633)

**CLI and Routing**
- Documented how custom providers are referenced by slug in CLI commands and routing options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R346) [[2]](diffhunk://#diff-aad5ecc11464df5ad697d70b7611a32437d06da77119dfe5a5665492490010a4R144-R146)

These changes ensure users and contributors understand when and how to add custom providers, how they are managed and secured, and how they fit into the application's architecture and UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for creating custom OpenAI and Anthropic-compatible providers at runtime without code changes
  * Enabled optional custom provider logo uploads
  * Added provider testing and deletion functionality in the UI
  * Introduced manual model selection for custom providers

* **Documentation**
  * Updated contributor and development guides to reflect custom provider workflow
  * Expanded API reference and configuration documentation
  * Enhanced troubleshooting and security guidance for custom providers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danielalves96/claude-code-provider-gateway/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->