### PR TITLE
feat: Add desktop tray background mode

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -424,6 +424,7 @@ Tauri v2 app (Rust + webview). Architecture:
 - **Production mode**: the daemon runs as a Tauri sidecar (Bun-compiled binary)
 - **External daemon mode**: development-only path where the daemon runs outside Tauri for hot reload
 - **Panel served as static files**: the React build output is served by the daemon, not by Tauri
+- **Tray/menu bar background mode**: closing the main window hides it; the process and sidecar continue until the tray `Quit` action exits the app
 - **Build pipeline**: Bun compiles the daemon → binary copied to Tauri's `binaries/` directory → Tauri bundles everything
 
 The Rust layer is deliberately narrow. Its job is to integrate with the OS, own the sidecar process, and expose a small command surface to the panel. Provider logic, panel APIs, config semantics, and session history remain in the TypeScript daemon.
@@ -435,6 +436,7 @@ The Rust layer is deliberately narrow. Its job is to integrate with the OS, own 
 | `src/lib.rs` | Application composition: plugins, managed state, setup hook, command registration, exit shutdown |
 | `src/commands.rs` | Tauri command facade. Converts internal errors into serializable `{ code, message }` command errors |
 | `src/daemon_supervisor.rs` | Async sidecar supervisor protected by a Tokio mutex. Starts, stops, reports status, drains process output, and cleans stale daemon PIDs before spawning |
+| `src/tray.rs` | System tray/menu bar integration. Intercepts main-window close requests, shows/hides the window, and marks intentional quits before calling `app.exit(0)` |
 | `src/external_url.rs` | External browser policy. Only allowlisted `https://` hosts can be opened from the panel |
 | `src/master_key.rs` | OS keychain-backed 32-byte hex master key generation and validation |
 | `src/config.rs` | Desktop-specific environment flags shared across modules |
@@ -469,6 +471,8 @@ Tauri setup
 Tauri ExitRequested
   └─ best-effort supervisor.stop()
 ```
+
+The main-window close button is not treated as app exit. `WindowEvent::CloseRequested` for the main window calls `prevent_close()` and hides the window to the tray/menu bar. The tray menu contains `Show App`, `Hide`, and `Quit`; `Quit` sets an internal quitting flag and calls Tauri's `app.exit(0)`, allowing the normal `ExitRequested` sidecar cleanup to run.
 
 The stale PID cleanup performs blocking OS process operations through `spawn_blocking`, keeping the async command path responsive. The supervisor checks for an already-owned child before cleanup so repeated `start_daemon` calls cannot terminate the current sidecar.
 

--- a/docs/CODEBASE_GUIDE.md
+++ b/docs/CODEBASE_GUIDE.md
@@ -88,6 +88,7 @@ belongs in the TypeScript daemon or React panel unless it needs native OS access
 | `lib.rs` | Tauri builder composition, plugin registration, app setup, sidecar startup, and shutdown hooks. |
 | `commands.rs` | Stable Tauri command boundary used by the panel. |
 | `daemon_supervisor.rs` | Sidecar start/stop/status, stale PID cleanup, and stdout/stderr draining. |
+| `tray.rs` | Tray/menu bar behavior for background execution, including hide-on-close, show/hide, and real quit. |
 | `external_url.rs` | Allowlisted external URL validation and opening in the OS browser. |
 | `master_key.rs` | OS keychain integration for the daemon encryption key. |
 | `config.rs` | Desktop runtime environment flags and names. |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -136,6 +136,7 @@ The Rust crate is intentionally small. Keep the desktop shell as orchestration c
 | `src/lib.rs` | Tauri builder composition, plugin registration, app setup, sidecar autostart, and best-effort shutdown on exit |
 | `src/commands.rs` | Public Tauri command boundary used by the React panel |
 | `src/daemon_supervisor.rs` | Sidecar lifecycle: start, stop, status, stdout/stderr draining, stale PID cleanup |
+| `src/tray.rs` | System tray/menu bar behavior: hide-on-close, show/hide actions, and intentional quit handling |
 | `src/external_url.rs` | Allowlisted external URL validation and OS browser opening |
 | `src/master_key.rs` | OS keychain integration for the 32-byte daemon secret key |
 | `src/config.rs` | Environment variable names and desktop runtime flags |
@@ -152,6 +153,8 @@ There are two daemon ownership modes:
 | Sidecar daemon | Default production/dev Tauri path | Rust starts and supervises the bundled sidecar |
 
 In external daemon mode, Rust intentionally refuses `start_daemon`/`stop_daemon`; the panel should treat the daemon as managed by the dev watcher. In sidecar mode, Rust obtains the master key from the OS keychain, passes it to the daemon via `CC_GATEWAY_SECRET_KEY`, drains sidecar output into logs, and stops the sidecar when the desktop app exits.
+
+Closing the main desktop window should keep the app running in the background. For lifecycle work, validate both paths: the window close button hides the window, while tray/menu bar `Quit` performs a real app exit and stops the sidecar through the normal shutdown hook.
 
 #### Desktop validation
 

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -11,6 +11,7 @@ Part of the [Claude Code Provider Gateway](../../README.md) monorepo.
 The desktop package wraps the [panel](../panel) (React-based configuration UI) and [daemon](../daemon) (local proxy server) into a single Tauri desktop application. It handles:
 
 - **Daemon lifecycle management** — starts the daemon as a sidecar process on app launch, stops it on exit, and cleans up stale processes from previous runs.
+- **Background tray behavior** — closing the main window hides it to the OS tray/menu bar while the app and daemon keep running. The tray menu exposes `Show App`, `Hide`, and `Quit`; only `Quit` exits the process.
 - **Master key generation** — creates and stores a 32-byte master key in the OS keychain (`keyring` crate), passed to the daemon via the `CC_GATEWAY_SECRET_KEY` environment variable.
 - **Secure external URL opening** — opens links to known provider dashboards (e.g., OpenRouter, Groq, DeepSeek) while blocking unlisted hosts.
 - **Cross-platform packaging** — produces `.deb`, `.rpm`, `.AppImage` (Linux), `.dmg` (macOS), and `.msi`/`.exe` (Windows) installers.
@@ -60,6 +61,7 @@ packages/desktop/src-tauri/src/
 ├── lib.rs               # Tauri builder setup, plugin registration, autostart
 ├── commands.rs          # Tauri IPC commands: start_daemon, stop_daemon, daemon_status, open_url
 ├── daemon_supervisor.rs # Daemon sidecar process lifecycle (spawn, kill, status)
+├── tray.rs              # System tray/menu bar lifecycle: show, hide, quit
 ├── config.rs            # Environment variable reading (external daemon flag, secret key)
 ├── master_key.rs        # OS keychain read/write for master key (keyring crate)
 └── external_url.rs      # Secure external URL validation and opening (allowlist-based)
@@ -75,6 +77,8 @@ The Tauri app registers four IPC commands callable from the panel frontend:
 | `open_url` | Opens an external URL in the system browser. Only `https://` URLs with hosts on the allowlist are permitted. |
 
 The panel frontend is loaded from `../../daemon/dist/static` (built panel output). At dev time, Tauri opens `http://localhost:5173` (Vite dev server).
+
+Closing the main window does not exit the app. The close request is intercepted in Rust, the window is hidden, and the sidecar keeps running in the background. Use the tray/menu bar `Quit` action for a real app exit and sidecar shutdown.
 
 ## Scripts
 

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -3,17 +3,21 @@ mod config;
 mod daemon_supervisor;
 mod external_url;
 mod master_key;
+mod tray;
 
 use daemon_supervisor::DaemonSupervisor;
 use std::sync::Arc;
-use tauri::{AppHandle, Manager, RunEvent};
+use tauri::{AppHandle, Manager, RunEvent, WindowEvent};
 
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_process::init())
         .manage(DaemonSupervisor::new())
+        .manage(tray::TrayState::default())
         .setup(|app| {
+            tray::init(app)?;
+
             let handle = app.handle().clone();
             if config::uses_external_daemon() {
                 log::info!("using external dev daemon; sidecar autostart disabled");
@@ -39,14 +43,31 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("failed to build Tauri app")
         .run(|app, event| {
-            if let RunEvent::ExitRequested { .. } = event {
-                // Best-effort sync shutdown so we don't leave the sidecar
-                // orphaned. Tokio runtime is gone by Exit, so we block here.
-                let supervisor: Arc<DaemonSupervisor> =
-                    app.state::<Arc<DaemonSupervisor>>().inner().clone();
-                tauri::async_runtime::block_on(async move {
-                    let _ = supervisor.stop().await;
-                });
+            match event {
+                RunEvent::WindowEvent {
+                    label,
+                    event: WindowEvent::CloseRequested { api, .. },
+                    ..
+                } if tray::is_main_window(&label) => {
+                    if let Some(window) = app.get_webview_window(&label) {
+                        tray::handle_close_requested(app, &window, &api);
+                    }
+                }
+                #[cfg(target_os = "macos")]
+                RunEvent::Reopen {
+                    has_visible_windows: false,
+                    ..
+                } => tray::show_main_window(app),
+                RunEvent::ExitRequested { .. } => {
+                    // Best-effort sync shutdown so we don't leave the sidecar
+                    // orphaned. Tokio runtime is gone by Exit, so we block here.
+                    let supervisor: Arc<DaemonSupervisor> =
+                        app.state::<Arc<DaemonSupervisor>>().inner().clone();
+                    tauri::async_runtime::block_on(async move {
+                        let _ = supervisor.stop().await;
+                    });
+                }
+                _ => {}
             }
         });
 }

--- a/packages/desktop/src-tauri/src/tray.rs
+++ b/packages/desktop/src-tauri/src/tray.rs
@@ -1,0 +1,112 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tauri::{
+    menu::{Menu, MenuItem, PredefinedMenuItem},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+    App, AppHandle, Manager, Runtime, WebviewWindow,
+};
+
+const MAIN_WINDOW_LABEL: &str = "main";
+const TRAY_ID: &str = "main-tray";
+const MENU_SHOW_ID: &str = "tray-show";
+const MENU_HIDE_ID: &str = "tray-hide";
+const MENU_QUIT_ID: &str = "tray-quit";
+
+#[derive(Default)]
+pub struct TrayState {
+    quitting: AtomicBool,
+}
+
+pub fn init(app: &App) -> tauri::Result<()> {
+    let show = MenuItem::with_id(app, MENU_SHOW_ID, "Show App", true, None::<&str>)?;
+    let hide = MenuItem::with_id(app, MENU_HIDE_ID, "Hide", true, None::<&str>)?;
+    let separator = PredefinedMenuItem::separator(app)?;
+    let quit = MenuItem::with_id(app, MENU_QUIT_ID, "Quit", true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&show, &hide, &separator, &quit])?;
+
+    let mut builder = TrayIconBuilder::with_id(TRAY_ID)
+        .menu(&menu)
+        .show_menu_on_left_click(false)
+        .tooltip("Claude Code Provider Gateway")
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            MENU_SHOW_ID => show_main_window(app),
+            MENU_HIDE_ID => hide_main_window(app),
+            MENU_QUIT_ID => quit_app(app),
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                show_main_window(tray.app_handle());
+            }
+        });
+
+    if let Some(icon) = app.default_window_icon().cloned() {
+        builder = builder.icon(icon);
+    }
+
+    builder.build(app)?;
+    Ok(())
+}
+
+pub fn handle_close_requested<R: Runtime>(
+    app: &AppHandle<R>,
+    window: &WebviewWindow<R>,
+    api: &tauri::CloseRequestApi,
+) {
+    if is_quitting(app) {
+        return;
+    }
+
+    api.prevent_close();
+    if let Err(err) = window.hide() {
+        log::warn!("failed to hide main window on close request: {err}");
+    }
+}
+
+pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
+    let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) else {
+        log::warn!("main window not found while opening from tray");
+        return;
+    };
+
+    if let Err(err) = window.unminimize() {
+        log::warn!("failed to unminimize main window: {err}");
+    }
+    if let Err(err) = window.show() {
+        log::warn!("failed to show main window: {err}");
+    }
+    if let Err(err) = window.set_focus() {
+        log::warn!("failed to focus main window: {err}");
+    }
+}
+
+pub fn hide_main_window<R: Runtime>(app: &AppHandle<R>) {
+    let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) else {
+        log::warn!("main window not found while hiding from tray");
+        return;
+    };
+
+    if let Err(err) = window.hide() {
+        log::warn!("failed to hide main window: {err}");
+    }
+}
+
+pub fn is_main_window(label: &str) -> bool {
+    label == MAIN_WINDOW_LABEL
+}
+
+fn quit_app<R: Runtime>(app: &AppHandle<R>) {
+    app.state::<TrayState>()
+        .quitting
+        .store(true, Ordering::SeqCst);
+    app.exit(0);
+}
+
+fn is_quitting<R: Runtime>(app: &AppHandle<R>) -> bool {
+    app.state::<TrayState>().quitting.load(Ordering::SeqCst)
+}


### PR DESCRIPTION
## Summary

- Adds a Tauri system tray/menu bar icon for the desktop app.
- Changes main-window close behavior so clicking X hides the window instead of exiting the app.
- Adds tray actions for Show App, Hide, and Quit.
- Ensures Quit performs a real app exit and preserves the existing daemon shutdown flow.
- Documents the new desktop background behavior in desktop and architecture docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Closing the main window now hides the app to the system tray while the application and daemon continue running in the background.
  * System tray menu includes Show, Hide, and Quit actions; only Quit fully exits the application and shuts down the daemon.

* **Documentation**
  * Updated architecture and development documentation to describe desktop window lifecycle and system tray behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danielalves96/claude-code-provider-gateway/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->