### PR TITLE
feat: Add desktop exports for logs and history sessions

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -414,7 +414,8 @@ React 19 SPA built with Vite 6 + Ant Design 5 + Zustand 5.
 - **Providers** — toggle providers, edit API keys, OAuth login, test connections, add extra/manual models, create/delete custom OpenAI/Anthropic-compatible providers
 - **Model Chain** — create, edit, reorder, enable, and launch ordered fallback chains built from active provider models
 - **Routing** — tier-based model routing UI
-- **History** — session archive with per-request drill-down
+- **History** — session archive with per-request drill-down and per-session JSON export
+- **Server Logs** — live daemon log viewer with filtering and `.log` export
 - **Settings** — daemon configuration, outbound proxy, web tools, and token savers
 
 ### 9. Desktop Shell (`packages/desktop/`)
@@ -434,7 +435,7 @@ The Rust layer is deliberately narrow. Its job is to integrate with the OS, own 
 | Module | Role |
 |---|---|
 | `src/lib.rs` | Application composition: plugins, managed state, setup hook, command registration, exit shutdown |
-| `src/commands.rs` | Tauri command facade. Converts internal errors into serializable `{ code, message }` command errors |
+| `src/commands.rs` | Tauri command facade. Converts internal errors into serializable `{ code, message }` command errors and owns native file-save helpers for panel exports |
 | `src/daemon_supervisor.rs` | Async sidecar supervisor protected by a Tokio mutex. Starts, stops, reports status, drains process output, and cleans stale daemon PIDs before spawning |
 | `src/tray.rs` | System tray/menu bar integration. Intercepts main-window close requests, shows/hides the window, and marks intentional quits before calling `app.exit(0)` |
 | `src/external_url.rs` | External browser policy. Only allowlisted `https://` hosts can be opened from the panel |
@@ -449,6 +450,8 @@ The Rust layer is deliberately narrow. Its job is to integrate with the OS, own 
 | `stop_daemon` | Stop the supervised sidecar | Idempotent when no child is running |
 | `daemon_status` | Return `{ running, pid }` for the current supervised child | Tracks the sidecar owned by this Tauri process |
 | `open_url` | Open an allowlisted external URL in the OS browser | Validates scheme and host before calling the shell plugin |
+| `save_server_logs` | Save the Server Logs buffer as a `.log` file | Writes to the user's Downloads directory from the desktop app |
+| `save_session_json` | Save one History session as formatted JSON | Writes `session-{id}.json` to the user's Downloads directory from the desktop app |
 
 Command errors are structured as `{ code, message }`. This keeps the panel from depending on free-form Rust error strings while still preserving useful diagnostic text.
 

--- a/docs/CODEBASE_GUIDE.md
+++ b/docs/CODEBASE_GUIDE.md
@@ -86,7 +86,7 @@ belongs in the TypeScript daemon or React panel unless it needs native OS access
 | Rust module | Responsibility |
 |---|---|
 | `lib.rs` | Tauri builder composition, plugin registration, app setup, sidecar startup, and shutdown hooks. |
-| `commands.rs` | Stable Tauri command boundary used by the panel. |
+| `commands.rs` | Stable Tauri command boundary used by the panel, including daemon lifecycle, safe URL opening, and native file exports. |
 | `daemon_supervisor.rs` | Sidecar start/stop/status, stale PID cleanup, and stdout/stderr draining. |
 | `tray.rs` | Tray/menu bar behavior for background execution, including hide-on-close, show/hide, and real quit. |
 | `external_url.rs` | Allowlisted external URL validation and opening in the OS browser. |

--- a/docs/PANEL_FEATURES.md
+++ b/docs/PANEL_FEATURES.md
@@ -243,12 +243,12 @@ Displays archived Claude Code sessions with detailed breakdowns.
 
 | Component | Purpose |
 |---|---|
-| `HistoryPage` | Main page: summary stats, session list with expandable rows, filtering by provider/model. |
+| `HistoryPage` | Main page: summary stats, session list with expandable rows, per-session JSON export, and clear-history controls. |
 | `HistorySummary` | Aggregated high-level stats (total sessions, requests, errors). |
 | `HistoryTopStats` | Top provider and top model cards derived from session data. |
 | `HistoryHeader` | Page controls: clear history button, help tooltip. |
 | `ClearHistoryModal` | Confirmation modal for clearing the entire archive. |
-| `SessionsTable` | Expandable table of archived sessions. Each row expands to show request log details. |
+| `SessionsTable` | Expandable table of archived sessions. Each row expands to show request log details and includes export/delete actions. |
 | `SessionDetails` | Expanded row content: request log entries and metadata for a session. |
 | `SessionMetadataCards` | Shows session metadata: launch hint, provider, model, duration. |
 | `RequestLogTable` | Table of individual API requests within a session (model, provider, latency, status). |
@@ -262,7 +262,7 @@ Displays archived Claude Code sessions with detailed breakdowns.
 
 | Hook | Purpose |
 |---|---|
-| `useHistory` | Polls `GET /api/sessions` and `GET /api/stats` every 5 seconds. Manages sessions, provider stats, totals, expanded keys, clear/delete operations. |
+| `useHistory` | Polls `GET /api/sessions` and `GET /api/stats` every 5 seconds. Manages sessions, provider stats, totals, expanded keys, clear/delete/export operations. |
 | `useHistoryPage` | Orchestrator hook that filters and sorts sessions, derives top provider/model info, manages the clear modal. |
 
 ### Services
@@ -270,6 +270,7 @@ Displays archived Claude Code sessions with detailed breakdowns.
 | Service | Endpoints Used |
 |---|---|
 | `historyService` | `GET /api/sessions`, `GET /api/stats`, `DELETE /api/sessions` (clear archive), `DELETE /api/sessions/:id` (delete single session) |
+| `sessionExport` | Exports a single `SessionRecord` as formatted JSON. In Tauri it invokes `save_session_json`; in browser/dev fallback it downloads a Blob. |
 
 ### Domain
 
@@ -286,7 +287,8 @@ Displays archived Claude Code sessions with detailed breakdowns.
 2. Sessions are stored in `archive` (sorted newest-first) with per-session `requestLog`, `modelStats`, and `providerStats`.
 3. `SessionsTable` renders sessions as expandable Ant Design table rows.
 4. Expanding a row renders `SessionDetails`, which shows `RequestLogTable` from the session's `requestLog` entries.
-5. Global aggregate stats come from the `/api/stats` endpoint.
+5. Exporting a row serializes that session to `session-{id}.json`. Desktop builds save it through Tauri to the user's Downloads directory; browser/dev builds use a normal Blob download.
+6. Global aggregate stats come from the `/api/stats` endpoint.
 
 ---
 
@@ -307,7 +309,7 @@ Real-time server log viewer using Server-Sent Events.
 
 | Hook | Purpose |
 |---|---|
-| `useServerLogs` | Subscribes to SSE at `/api/logs`. Maintains last 5000 lines. Provides `filteredLogs` (by level + search), `stats` (counts per level), and all toolbar state (paused, search, levelFilter, wrapLines, showLineNumbers). Includes `downloadLogs()` to export as `.log` file. |
+| `useServerLogs` | Subscribes to SSE at `/api/logs`. Maintains last 5000 lines. Provides `filteredLogs` (by level + search), `stats` (counts per level), and all toolbar state (paused, search, levelFilter, wrapLines, showLineNumbers). Includes `downloadLogs()` to export as `.log`; desktop builds invoke `save_server_logs`, while browser/dev builds use a Blob download. |
 | `useLogViewerScroll` | Manages auto-scroll behavior. Tracks whether the user is at bottom, scrolls to bottom on new lines when unpaused and at bottom. |
 
 ### Domain

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -187,5 +187,9 @@ Useful files:
 | `current-session.json` | Active session checkpoint. |
 | `sessions.jsonl` | Archived sessions. |
 
+The desktop app can also export the current Server Logs buffer as a `.log` file
+and individual History sessions as `session-{id}.json` in Downloads.
+
 Do not share `secrets.enc.json`, `secret.key`, `config.json`, session files, or
 daemon logs publicly unless you have reviewed them for secrets and private code.
+This includes exported `.log` and `session-{id}.json` files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-provider-gateway",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-provider-gateway",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "workspaces": [
         "packages/daemon",
@@ -5127,7 +5127,7 @@
     },
     "packages/daemon": {
       "name": "@claude-code-provider-gateway/daemon",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "dependencies": {
         "@hono/node-server": "^1.14.3",
         "hono": "^4.7.10",
@@ -5142,14 +5142,14 @@
     },
     "packages/desktop": {
       "name": "@claude-code-provider-gateway/desktop",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }
     },
     "packages/panel": {
       "name": "@claude-code-provider-gateway/panel",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "dependencies": {
         "@ant-design/icons": "^5.0.0",
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-provider-gateway",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Claude Code Gateway — proxy Anthropic-compatible para múltiplos providers de LLM",
   "private": true,
   "scripts": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-code-provider-gateway/daemon",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -59,7 +59,7 @@ On Linux this produces `.deb`, `.rpm`, and `.AppImage` bundles. On macOS it prod
 packages/desktop/src-tauri/src/
 ├── main.rs              # Windows subsystem config, entry point
 ├── lib.rs               # Tauri builder setup, plugin registration, autostart
-├── commands.rs          # Tauri IPC commands: start_daemon, stop_daemon, daemon_status, open_url
+├── commands.rs          # Tauri IPC commands: daemon lifecycle, safe URL opening, desktop file exports
 ├── daemon_supervisor.rs # Daemon sidecar process lifecycle (spawn, kill, status)
 ├── tray.rs              # System tray/menu bar lifecycle: show, hide, quit
 ├── config.rs            # Environment variable reading (external daemon flag, secret key)
@@ -67,7 +67,7 @@ packages/desktop/src-tauri/src/
 └── external_url.rs      # Secure external URL validation and opening (allowlist-based)
 ```
 
-The Tauri app registers four IPC commands callable from the panel frontend:
+The Tauri app registers IPC commands callable from the panel frontend:
 
 | Command | Description |
 |---|---|
@@ -75,6 +75,8 @@ The Tauri app registers four IPC commands callable from the panel frontend:
 | `stop_daemon` | Kills the running daemon sidecar. |
 | `daemon_status` | Returns `{ running: boolean, pid: number \| null }`. |
 | `open_url` | Opens an external URL in the system browser. Only `https://` URLs with hosts on the allowlist are permitted. |
+| `save_server_logs` | Saves the Server Logs buffer as a `.log` file in the user's Downloads directory. |
+| `save_session_json` | Saves one History session as `session-{id}.json` in the user's Downloads directory. |
 
 The panel frontend is loaded from `../../daemon/dist/static` (built panel output). At dev time, Tauri opens `http://localhost:5173` (Vite dev server).
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-code-provider-gateway/desktop",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "claude-code-provider-gateway-desktop"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "hex",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-provider-gateway-desktop"
-version = "0.1.3"
+version = "0.2.0"
 description = "Claude Code Provider Gateway — desktop shell"
 edition = "2021"
 rust-version = "1.77"

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ keyring = { version = "3", features = ["apple-native", "windows-native", "linux-
 rand = "0.8"
 hex = "0.4"
 anyhow = "1"
-tokio = { version = "1", features = ["sync", "time"] }
+tokio = { version = "1", features = ["fs", "sync", "time"] }
 log = "0.4"
 url = "2"
 

--- a/packages/desktop/src-tauri/src/commands.rs
+++ b/packages/desktop/src-tauri/src/commands.rs
@@ -3,7 +3,7 @@ use crate::daemon_supervisor::{self, DaemonStatus};
 use crate::external_url;
 use crate::master_key;
 use serde::Serialize;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 #[derive(Debug, Serialize)]
 pub struct CommandError {
@@ -44,6 +44,19 @@ impl From<external_url::ExternalUrlError> for CommandError {
 
 pub type CommandResult<T> = Result<T, CommandError>;
 
+#[derive(Debug, Serialize)]
+pub struct SaveServerLogsResult {
+    path: String,
+    bytes: usize,
+    lines: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SaveSessionJsonResult {
+    path: String,
+    bytes: usize,
+}
+
 #[tauri::command]
 pub async fn start_daemon(app: AppHandle) -> CommandResult<u32> {
     if config::uses_external_daemon() {
@@ -77,4 +90,62 @@ pub async fn daemon_status(app: AppHandle) -> DaemonStatus {
 #[tauri::command]
 pub async fn open_url(app: AppHandle, url: String) -> CommandResult<()> {
     external_url::open(&app, &url).await.map_err(Into::into)
+}
+
+#[tauri::command]
+pub async fn save_server_logs(
+    app: AppHandle,
+    file_name: String,
+    lines: Vec<String>,
+) -> CommandResult<SaveServerLogsResult> {
+    let mut path = app.path().download_dir().map_err(CommandError::internal)?;
+    let safe_name = sanitize_file_name(&file_name, "server-logs.log", ".log");
+    let contents = lines.join("\n");
+    let bytes = contents.len();
+    let line_count = lines.len();
+
+    path.push(safe_name);
+    std::fs::write(&path, contents).map_err(CommandError::internal)?;
+
+    Ok(SaveServerLogsResult {
+        path: path.to_string_lossy().into_owned(),
+        bytes,
+        lines: line_count,
+    })
+}
+
+#[tauri::command]
+pub async fn save_session_json(
+    app: AppHandle,
+    file_name: String,
+    contents: String,
+) -> CommandResult<SaveSessionJsonResult> {
+    let mut path = app.path().download_dir().map_err(CommandError::internal)?;
+    let safe_name = sanitize_file_name(&file_name, "session.json", ".json");
+    let bytes = contents.len();
+
+    path.push(safe_name);
+    std::fs::write(&path, contents).map_err(CommandError::internal)?;
+
+    Ok(SaveSessionJsonResult {
+        path: path.to_string_lossy().into_owned(),
+        bytes,
+    })
+}
+
+fn sanitize_file_name(file_name: &str, fallback: &str, extension: &str) -> String {
+    let sanitized: String = file_name
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => ch,
+            _ => '-',
+        })
+        .collect();
+
+    let trimmed = sanitized.trim_matches(['-', '.']).to_string();
+    if trimmed.is_empty() || !trimmed.ends_with(extension) {
+        fallback.into()
+    } else {
+        trimmed
+    }
 }

--- a/packages/desktop/src-tauri/src/commands.rs
+++ b/packages/desktop/src-tauri/src/commands.rs
@@ -105,7 +105,9 @@ pub async fn save_server_logs(
     let line_count = lines.len();
 
     path.push(safe_name);
-    std::fs::write(&path, contents).map_err(CommandError::internal)?;
+    tokio::fs::write(&path, contents)
+        .await
+        .map_err(CommandError::internal)?;
 
     Ok(SaveServerLogsResult {
         path: path.to_string_lossy().into_owned(),
@@ -125,7 +127,9 @@ pub async fn save_session_json(
     let bytes = contents.len();
 
     path.push(safe_name);
-    std::fs::write(&path, contents).map_err(CommandError::internal)?;
+    tokio::fs::write(&path, contents)
+        .await
+        .map_err(CommandError::internal)?;
 
     Ok(SaveSessionJsonResult {
         path: path.to_string_lossy().into_owned(),

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -39,6 +39,8 @@ pub fn run() {
             commands::stop_daemon,
             commands::daemon_status,
             commands::open_url,
+            commands::save_server_logs,
+            commands::save_session_json,
         ])
         .build(tauri::generate_context!())
         .expect("failed to build Tauri app")

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -35,9 +35,7 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "externalBin": [
-      "binaries/claude-code-provider-gateway-daemon"
-    ]
+    "externalBin": ["binaries/claude-code-provider-gateway-daemon"]
   },
   "plugins": {}
 }

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Claude Code Provider Gateway",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "identifier": "com.ccprovidergtw.desktop",
   "build": {
     "beforeDevCommand": "npm run prepare-sidecar -w @claude-code-provider-gateway/desktop && npm run dev -w @claude-code-provider-gateway/panel",
@@ -35,7 +35,9 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "externalBin": ["binaries/claude-code-provider-gateway-daemon"]
+    "externalBin": [
+      "binaries/claude-code-provider-gateway-daemon"
+    ]
   },
   "plugins": {}
 }

--- a/packages/panel/README.md
+++ b/packages/panel/README.md
@@ -49,8 +49,8 @@ The panel exposes the following pages:
 | **Providers** | `/providers` | Add custom OpenAI/Anthropic-compatible providers, configure, test, reorder, and favorite LLM providers. Supports search and status filtering. |
 | **Model Chain** | `/model-chain` | Create custom fallback chains from active provider models. Chains try models in priority order on failure. |
 | **Routing** | `/routing` | Map Claude model tiers (Opus, Sonnet, Haiku) to specific providers and models. |
-| **History** | `/history` | Browse completed session history with request details, token counts, latency, and response previews. |
-| **Server Logs** | `/logs` | View the daemon's structured log output with filtering and severity indicators. |
+| **History** | `/history` | Browse completed session history with request details, token counts, latency, response previews, and per-session JSON export. |
+| **Server Logs** | `/logs` | View the daemon's structured log output with filtering, severity indicators, and `.log` export. |
 | **Settings** | `/settings` | Configure token savers (RTK compression, Caveman mode), outbound proxy, port settings, and other preferences. |
 
 ## API Layer

--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-code-provider-gateway/panel",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/panel/src/features/history/components/page/HistoryPage.tsx
+++ b/packages/panel/src/features/history/components/page/HistoryPage.tsx
@@ -1,4 +1,6 @@
-import { Card, Col, Empty, Flex, Row, Skeleton, Typography, theme } from "antd";
+import { App, Card, Col, Empty, Flex, Row, Skeleton, Typography, theme } from "antd";
+import { useCallback } from "react";
+import type { Session } from "../../domain/types.js";
 import { useHistoryPage } from "../../hooks/useHistoryPage.js";
 import { ProvidersTable } from "../tables/ProvidersTable.js";
 import { SessionsTable } from "../tables/SessionsTable.js";
@@ -57,8 +59,24 @@ function HistorySkeletonSummary() {
 }
 
 export default function HistoryPage() {
+  const { message } = App.useApp();
   const { token } = theme.useToken();
   const page = useHistoryPage();
+  const handleExportSession = useCallback(
+    async (session: Session) => {
+      try {
+        const result = await page.exportSession(session);
+        if (result.target === "desktop") {
+          message.success(`Session JSON saved to ${result.path}`);
+        } else {
+          message.success(`Downloaded ${result.fileName}`);
+        }
+      } catch (err) {
+        message.error(err instanceof Error ? err.message : "Failed to export session JSON");
+      }
+    },
+    [message, page],
+  );
 
   return (
     <Flex vertical gap={token.paddingLG}>
@@ -101,7 +119,9 @@ export default function HistoryPage() {
             expandedKeys={page.expandedKeys}
             onToggleExpanded={page.toggleExpanded}
             onDeleteSession={page.deleteSession}
+            onExportSession={handleExportSession}
             deletingId={page.deletingId}
+            exportingId={page.exportingId}
           />
         </>
       )}

--- a/packages/panel/src/features/history/components/tables/SessionsTable.tsx
+++ b/packages/panel/src/features/history/components/tables/SessionsTable.tsx
@@ -11,7 +11,9 @@ interface SessionsTableProps {
   expandedKeys: string[];
   onToggleExpanded: (id: string, expanded: boolean) => void;
   onDeleteSession: (id: string) => void;
+  onExportSession: (session: Session) => void;
   deletingId: string | null;
+  exportingId: string | null;
 }
 
 export function SessionsTable({
@@ -19,10 +21,17 @@ export function SessionsTable({
   expandedKeys,
   onToggleExpanded,
   onDeleteSession,
+  onExportSession,
   deletingId,
+  exportingId,
 }: SessionsTableProps) {
   const { token } = theme.useToken();
-  const columns = useSessionColumns({ onDelete: onDeleteSession, deletingId });
+  const columns = useSessionColumns({
+    onDelete: onDeleteSession,
+    onExport: onExportSession,
+    deletingId,
+    exportingId,
+  });
 
   return (
     <Card styles={{ body: { padding: 0 } }}>

--- a/packages/panel/src/features/history/components/tables/sessionColumns.tsx
+++ b/packages/panel/src/features/history/components/tables/sessionColumns.tsx
@@ -2,6 +2,7 @@ import {
   CheckCircleOutlined,
   CloseCircleOutlined,
   DeleteOutlined,
+  DownloadOutlined,
   SyncOutlined,
 } from "@ant-design/icons";
 import type { TableColumnsType } from "antd";
@@ -15,12 +16,16 @@ const { Text } = Typography;
 
 interface SessionColumnsOptions {
   onDelete: (id: string) => void;
+  onExport: (session: Session) => void;
   deletingId: string | null;
+  exportingId: string | null;
 }
 
 export function useSessionColumns({
   onDelete,
+  onExport,
   deletingId,
+  exportingId,
 }: SessionColumnsOptions): TableColumnsType<Session> {
   const { token } = theme.useToken();
 
@@ -82,9 +87,18 @@ export function useSessionColumns({
     },
     {
       key: "actions",
-      width: 56,
+      width: 88,
       render: (_, session) => (
-        <div style={{ display: "flex", justifyContent: "center", paddingInlineEnd: 8 }}>
+        <div style={{ display: "flex", justifyContent: "center", gap: 4, paddingInlineEnd: 8 }}>
+          <Button
+            type="text"
+            size="small"
+            icon={<DownloadOutlined />}
+            loading={exportingId === session.id}
+            aria-label={`Export session ${session.id} as JSON`}
+            title="Export as JSON"
+            onClick={() => onExport(session)}
+          />
           <Popconfirm
             title="Delete this session?"
             okText="Delete"
@@ -101,7 +115,7 @@ export function useSessionColumns({
               icon={<DeleteOutlined />}
               loading={deletingId === session.id}
               aria-label={`Delete session ${session.id}`}
-              title={`Delete session ${session.id}`}
+              title="Delete Session"
             />
           </Popconfirm>
         </div>

--- a/packages/panel/src/features/history/components/tables/sessionColumns.tsx
+++ b/packages/panel/src/features/history/components/tables/sessionColumns.tsx
@@ -95,6 +95,9 @@ export function useSessionColumns({
             size="small"
             icon={<DownloadOutlined />}
             loading={exportingId === session.id}
+            disabled={
+              deletingId === session.id || (exportingId !== null && exportingId !== session.id)
+            }
             aria-label={`Export session ${session.id} as JSON`}
             title="Export as JSON"
             onClick={() => onExport(session)}
@@ -114,6 +117,7 @@ export function useSessionColumns({
               danger
               icon={<DeleteOutlined />}
               loading={deletingId === session.id}
+              disabled={exportingId === session.id}
               aria-label={`Delete session ${session.id}`}
               title="Delete Session"
             />

--- a/packages/panel/src/features/history/hooks/useHistory.ts
+++ b/packages/panel/src/features/history/hooks/useHistory.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { usePolling } from "../../../shared/hooks/usePolling.js";
 import type { GatewayProviderStat, Session, SessionsResponse } from "../domain/types.js";
 import { historyService } from "../services/historyService.js";
+import { exportSessionJson } from "../services/sessionExport.js";
 
 export const HISTORY_POLL_INTERVAL_MS = 5000;
 
@@ -11,6 +12,7 @@ export function useHistory() {
   const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
   const [clearing, setClearing] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [exportingId, setExportingId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   const refresh = useCallback(() => {
@@ -71,6 +73,15 @@ export function useHistory() {
     }
   }, []);
 
+  const exportSession = useCallback(async (session: Session) => {
+    setExportingId(session.id);
+    try {
+      return await exportSessionJson(session);
+    } finally {
+      setExportingId(null);
+    }
+  }, []);
+
   const toggleExpanded = useCallback((id: string, expanded: boolean) => {
     setExpandedKeys((prev) => (expanded ? [...prev, id] : prev.filter((k) => k !== id)));
   }, []);
@@ -84,8 +95,10 @@ export function useHistory() {
     refresh,
     clearArchive,
     deleteSession,
+    exportSession,
     clearing,
     deletingId,
+    exportingId,
     canClear: (data?.archive.length ?? 0) > 0,
     pollIntervalMs: HISTORY_POLL_INTERVAL_MS,
     isLoading,

--- a/packages/panel/src/features/history/hooks/useHistory.ts
+++ b/packages/panel/src/features/history/hooks/useHistory.ts
@@ -74,11 +74,12 @@ export function useHistory() {
   }, []);
 
   const exportSession = useCallback(async (session: Session) => {
-    setExportingId(session.id);
+    const myId = session.id;
+    setExportingId(myId);
     try {
       return await exportSessionJson(session);
     } finally {
-      setExportingId(null);
+      setExportingId((prev) => (prev === myId ? null : prev));
     }
   }, []);
 

--- a/packages/panel/src/features/history/services/sessionExport.ts
+++ b/packages/panel/src/features/history/services/sessionExport.ts
@@ -1,0 +1,43 @@
+import type { Session } from "../domain/types.js";
+
+interface SaveSessionJsonResult {
+  path: string;
+  bytes: number;
+}
+
+export type ExportSessionResult =
+  | { target: "desktop"; path: string; bytes: number }
+  | { target: "browser"; fileName: string; bytes: number };
+
+declare global {
+  interface Window {
+    __TAURI_INTERNALS__?: unknown;
+  }
+}
+
+export async function exportSessionJson(session: Session): Promise<ExportSessionResult> {
+  const fileName = `session-${session.id}.json`;
+  const contents = `${JSON.stringify(session, null, 2)}\n`;
+  const bytes = new TextEncoder().encode(contents).length;
+
+  if (typeof window !== "undefined" && window.__TAURI_INTERNALS__ != null) {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const result = await invoke<SaveSessionJsonResult>("save_session_json", {
+      fileName,
+      contents,
+    });
+    return { target: "desktop", ...result };
+  }
+
+  const blob = new Blob([contents], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fileName;
+  document.body.append(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+
+  return { target: "browser", fileName, bytes };
+}

--- a/packages/panel/src/features/logs/components/page/ServerLogsPage.tsx
+++ b/packages/panel/src/features/logs/components/page/ServerLogsPage.tsx
@@ -1,4 +1,5 @@
-import { Badge, Card, Flex, Typography, theme } from "antd";
+import { App, Badge, Card, Flex, Typography, theme } from "antd";
+import { useCallback } from "react";
 import { PageHeader } from "../../../../shared/components/PageHeader.js";
 import { useServerLogs } from "../../hooks/useServerLogs.js";
 import { LogsSummary } from "../summary/LogsSummary.js";
@@ -8,6 +9,7 @@ import { LogViewer } from "../terminal/LogViewer.js";
 const { Text } = Typography;
 
 export default function ServerLogsPage() {
+  const { message } = App.useApp();
   const { token } = theme.useToken();
   const {
     logs,
@@ -24,10 +26,24 @@ export default function ServerLogsPage() {
     toggleWrap,
     showLineNumbers,
     toggleLineNumbers,
+    downloadingLogs,
     downloadLogs,
   } = useServerLogs();
 
   const pageHeight = `calc(100vh - 56px - ${token.paddingLG * 2}px)`;
+  const handleDownload = useCallback(async () => {
+    try {
+      const result = await downloadLogs();
+      if (!result) return;
+      if (result.target === "desktop") {
+        message.success(`Logs saved to ${result.path}`);
+      } else {
+        message.success(`Downloaded ${result.fileName}`);
+      }
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : "Failed to save logs");
+    }
+  }, [downloadLogs, message]);
 
   return (
     <Flex vertical gap={token.paddingLG} style={{ height: pageHeight }}>
@@ -74,13 +90,14 @@ export default function ServerLogsPage() {
           wrapLines={wrapLines}
           showLineNumbers={showLineNumbers}
           hasLogs={logs.length > 0}
+          downloading={downloadingLogs}
           onSearchChange={setSearch}
           onLevelFilterChange={setLevelFilter}
           onTogglePaused={togglePaused}
           onToggleWrap={toggleWrap}
           onToggleLineNumbers={toggleLineNumbers}
           onClear={clear}
-          onDownload={downloadLogs}
+          onDownload={handleDownload}
         />
         <LogViewer
           logs={filteredLogs}

--- a/packages/panel/src/features/logs/components/page/ServerLogsPage.tsx
+++ b/packages/panel/src/features/logs/components/page/ServerLogsPage.tsx
@@ -34,7 +34,10 @@ export default function ServerLogsPage() {
   const handleDownload = useCallback(async () => {
     try {
       const result = await downloadLogs();
-      if (!result) return;
+      if (!result) {
+        message.info("No logs were downloaded");
+        return;
+      }
       if (result.target === "desktop") {
         message.success(`Logs saved to ${result.path}`);
       } else {

--- a/packages/panel/src/features/logs/components/terminal/LogsToolbar.tsx
+++ b/packages/panel/src/features/logs/components/terminal/LogsToolbar.tsx
@@ -25,13 +25,14 @@ interface LogsToolbarProps {
   wrapLines: boolean;
   showLineNumbers: boolean;
   hasLogs: boolean;
+  downloading: boolean;
   onSearchChange: (value: string) => void;
   onLevelFilterChange: (value: LogLevel) => void;
   onTogglePaused: () => void;
   onToggleWrap: () => void;
   onToggleLineNumbers: () => void;
   onClear: () => void;
-  onDownload: () => void;
+  onDownload: () => void | Promise<void>;
 }
 
 export function LogsToolbar({
@@ -42,6 +43,7 @@ export function LogsToolbar({
   wrapLines,
   showLineNumbers,
   hasLogs,
+  downloading,
   onSearchChange,
   onLevelFilterChange,
   onTogglePaused,
@@ -135,7 +137,12 @@ export function LogsToolbar({
         </Space.Compact>
 
         <Tooltip title="Download full log buffer as .log file">
-          <Button icon={<DownloadOutlined />} onClick={onDownload} disabled={!hasLogs}>
+          <Button
+            icon={<DownloadOutlined />}
+            onClick={onDownload}
+            disabled={!hasLogs}
+            loading={downloading}
+          >
             Download
           </Button>
         </Tooltip>

--- a/packages/panel/src/features/logs/hooks/useServerLogs.ts
+++ b/packages/panel/src/features/logs/hooks/useServerLogs.ts
@@ -9,6 +9,22 @@ interface LogEvent {
 
 export type LogLevel = "all" | "error" | "warn" | "info" | "debug";
 
+interface SaveServerLogsResult {
+  path: string;
+  bytes: number;
+  lines: number;
+}
+
+type DownloadLogsResult =
+  | { target: "desktop"; path: string; bytes: number; lines: number }
+  | { target: "browser"; fileName: string; lines: number };
+
+declare global {
+  interface Window {
+    __TAURI_INTERNALS__?: unknown;
+  }
+}
+
 export function detectLogLevel(line: string): "error" | "warn" | "info" | "debug" {
   if (/\[ERROR\]/i.test(line)) return "error";
   if (/\[WARN\]/i.test(line)) return "warn";
@@ -23,6 +39,7 @@ export function useServerLogs() {
   const [levelFilter, setLevelFilter] = useState<LogLevel>("all");
   const [wrapLines, setWrapLines] = useState(false);
   const [showLineNumbers, setShowLineNumbers] = useState(true);
+  const [downloadingLogs, setDownloadingLogs] = useState(false);
 
   useSSE<LogEvent>(
     "/api/logs",
@@ -62,14 +79,34 @@ export function useServerLogs() {
     return result;
   }, [logs, levelFilter, search]);
 
-  const downloadLogs = useCallback(() => {
+  const downloadLogs = useCallback(async (): Promise<DownloadLogsResult | null> => {
+    if (logs.length === 0) return null;
+
+    const fileName = `server-logs-${new Date().toISOString().replace(/[:.]/g, "-")}.log`;
+    if (typeof window !== "undefined" && window.__TAURI_INTERNALS__ != null) {
+      setDownloadingLogs(true);
+      try {
+        const { invoke } = await import("@tauri-apps/api/core");
+        const result = await invoke<SaveServerLogsResult>("save_server_logs", {
+          fileName,
+          lines: logs,
+        });
+        return { target: "desktop", ...result };
+      } finally {
+        setDownloadingLogs(false);
+      }
+    }
+
     const blob = new Blob([logs.join("\n")], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `server-logs-${new Date().toISOString().replace(/[:.]/g, "-")}.log`;
+    a.download = fileName;
+    document.body.append(a);
     a.click();
+    a.remove();
     URL.revokeObjectURL(url);
+    return { target: "browser", fileName, lines: logs.length };
   }, [logs]);
 
   return {
@@ -87,6 +124,7 @@ export function useServerLogs() {
     toggleWrap,
     showLineNumbers,
     toggleLineNumbers,
+    downloadingLogs,
     downloadLogs,
   };
 }


### PR DESCRIPTION
## Summary

Adds desktop-aware export support for observability/debugging data:

- Server Logs can now be saved as a `.log` file from the desktop app.
- History sessions can now be exported individually as formatted JSON.
- Browser/dev mode keeps a Blob download fallback.
- Documentation was updated to describe the new export behavior and privacy considerations.

## Changes

### Desktop / Tauri

- Added `save_server_logs` command.
  - Saves the current Server Logs buffer to the user's Downloads directory.
  - Produces `.log` files with sanitized filenames.

- Added `save_session_json` command.
  - Saves one History session as formatted JSON.
  - Produces `session-{id}.json` in the user's Downloads directory.

- Registered both commands in the Tauri invoke handler.

### Panel

- Updated `/logs` download behavior.
  - In Tauri, calls `save_server_logs`.
  - In browser/dev mode, falls back to Blob download.
  - Adds loading state and success/error feedback.

- Updated `/history` session table.
  - Adds per-session export action.
  - Exports the full `SessionRecord` as JSON.
  - In Tauri, calls `save_session_json`.
  - In browser/dev mode, falls back to Blob download.
  - Adds loading state and success/error feedback.

- Simplified action button tooltips:
  - `Export as JSON`
  - `Delete Session`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session export: users can now export individual history sessions as JSON files to their Downloads folder (desktop) or browser download.
  * Added server logs export: users can now export the current server logs buffer as a `.log` file to Downloads (desktop).

* **Documentation**
  * Updated architecture, feature, and troubleshooting guides to reflect new export capabilities and provide security guidance for exported files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danielalves96/claude-code-provider-gateway/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->